### PR TITLE
템플릿 목록 조회 API 구현

### DIFF
--- a/backend/src/main/java/codezap/global/domain/BaseTimeEntity.java
+++ b/backend/src/main/java/codezap/global/domain/BaseTimeEntity.java
@@ -10,8 +10,11 @@ import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedDate;
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
+import lombok.Getter;
+
 @EntityListeners(AuditingEntityListener.class)
 @MappedSuperclass
+@Getter
 public class BaseTimeEntity {
 
     @CreatedDate

--- a/backend/src/main/java/codezap/representative_snippet/domain/RepresentativeSnippet.java
+++ b/backend/src/main/java/codezap/representative_snippet/domain/RepresentativeSnippet.java
@@ -1,0 +1,28 @@
+package codezap.representative_snippet.domain;
+
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+
+import codezap.global.domain.BaseTimeEntity;
+import codezap.snippet.domain.Snippet;
+import codezap.template.domain.Template;
+import lombok.Getter;
+
+@Entity
+@Table(name = "representative_snippet")
+@Getter
+public class RepresentativeSnippet extends BaseTimeEntity {
+
+    @Id
+    @OneToOne
+    @JoinColumn(name = "template_id")
+    private Template template;
+
+    @ManyToOne
+    @JoinColumn(name = "snippet_id", nullable = false)
+    private Snippet snippet;
+}

--- a/backend/src/main/java/codezap/representative_snippet/repository/RepresentativeSnippetRepository.java
+++ b/backend/src/main/java/codezap/representative_snippet/repository/RepresentativeSnippetRepository.java
@@ -1,0 +1,8 @@
+package codezap.representative_snippet.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import codezap.representative_snippet.domain.RepresentativeSnippet;
+
+public interface RepresentativeSnippetRepository extends JpaRepository<RepresentativeSnippet, Long> {
+}

--- a/backend/src/main/java/codezap/snippet/domain/Snippet.java
+++ b/backend/src/main/java/codezap/snippet/domain/Snippet.java
@@ -1,5 +1,8 @@
 package codezap.snippet.domain;
 
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,12 +17,10 @@ import codezap.extension.domain.Extension;
 import codezap.global.domain.BaseTimeEntity;
 import codezap.template.domain.Template;
 import lombok.Getter;
-import lombok.Setter;
 
 @Entity
 @Table(name = "snippet")
 @Getter
-@Setter
 public class Snippet extends BaseTimeEntity {
 
     @Id
@@ -42,4 +43,10 @@ public class Snippet extends BaseTimeEntity {
 
     @Column(nullable = false)
     private Integer ordinal;
+
+    public String getSummaryContent() {
+        return Arrays.stream(content.split("<br>"))
+                .limit(10)
+                .collect(Collectors.joining("<br>"));
+    }
 }

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -1,4 +1,4 @@
-package codezap.member.controller;
+package codezap.template.controller;
 
 import org.apache.commons.lang3.NotImplementedException;
 import org.springframework.http.ResponseEntity;
@@ -9,15 +9,19 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-import codezap.template.controller.SpringDocTemplateController;
 import codezap.template.dto.request.CreateTemplateResponse;
 import codezap.template.dto.response.CreateTemplateRequest;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateByIdResponse;
+import codezap.template.service.TemplateService;
 
 @RestController
 @RequestMapping("/templates")
 public class TemplateController implements SpringDocTemplateController {
+
+    private final TemplateService templateService;
+
+    public TemplateController(TemplateService templateService) {this.templateService = templateService;}
 
     @PostMapping("")
     public ResponseEntity<CreateTemplateResponse> create(@RequestBody CreateTemplateRequest createTemplateRequest) {
@@ -26,7 +30,7 @@ public class TemplateController implements SpringDocTemplateController {
 
     @GetMapping("")
     public ResponseEntity<FindAllTemplatesResponse> getTemplates() {
-        throw new NotImplementedException();
+        return ResponseEntity.ok(templateService.findAll());
     }
 
     @GetMapping("/{id}")

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -2,7 +2,15 @@ package codezap.template.dto.response;
 
 import java.util.List;
 
+import codezap.representative_snippet.domain.RepresentativeSnippet;
+
 public record FindAllTemplatesResponse(
         List<FindTemplateBySummaryResponse> templates
 ) {
+    public static FindAllTemplatesResponse from(List<RepresentativeSnippet> representativeSnippets) {
+        List<FindTemplateBySummaryResponse> templatesBySummaryResponse = representativeSnippets.stream()
+                .map(FindTemplateBySummaryResponse::from)
+                .toList();
+        return new FindAllTemplatesResponse(templatesBySummaryResponse);
+    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindMemberBySummaryResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindMemberBySummaryResponse.java
@@ -1,7 +1,15 @@
 package codezap.template.dto.response;
 
+import codezap.member.domain.Member;
+
 public record FindMemberBySummaryResponse(
         Long id,
         String nickname
 ) {
+    public static FindMemberBySummaryResponse from(Member member) {
+        return new FindMemberBySummaryResponse(
+                member.getId(),
+                member.getNickname()
+        );
+    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindRepresentativeSnippetResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindRepresentativeSnippetResponse.java
@@ -1,7 +1,15 @@
 package codezap.template.dto.response;
 
+import codezap.snippet.domain.Snippet;
+
 public record FindRepresentativeSnippetResponse(
         String filename,
         String content_summary
 ) {
+    public static FindRepresentativeSnippetResponse from(Snippet snippet) {
+        return new FindRepresentativeSnippetResponse(
+                snippet.getFilename(),
+                snippet.getSummaryContent()
+        );
+    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindTemplateBySummaryResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindTemplateBySummaryResponse.java
@@ -2,6 +2,9 @@ package codezap.template.dto.response;
 
 import java.time.LocalDateTime;
 
+import codezap.representative_snippet.domain.RepresentativeSnippet;
+import codezap.template.domain.Template;
+
 public record FindTemplateBySummaryResponse(
         Long id,
         String title,
@@ -9,4 +12,13 @@ public record FindTemplateBySummaryResponse(
         FindRepresentativeSnippetResponse representative_snippet,
         LocalDateTime modified_at
 ) {
+    public static FindTemplateBySummaryResponse from(RepresentativeSnippet representativeSnippet) {
+        return new FindTemplateBySummaryResponse(
+                representativeSnippet.getTemplate().getId(),
+                representativeSnippet.getTemplate().getTitle(),
+                FindMemberBySummaryResponse.from(representativeSnippet.getTemplate().getMember()),
+                FindRepresentativeSnippetResponse.from(representativeSnippet.getSnippet()),
+                representativeSnippet.getModifiedAt()
+        );
+    }
 }

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -1,0 +1,20 @@
+package codezap.template.service;
+
+import org.springframework.stereotype.Service;
+
+import codezap.representative_snippet.repository.RepresentativeSnippetRepository;
+import codezap.template.dto.response.FindAllTemplatesResponse;
+
+@Service
+public class TemplateService {
+
+    private final RepresentativeSnippetRepository representativeSnippetRepository;
+
+    public TemplateService(RepresentativeSnippetRepository representativeSnippetRepository) {
+        this.representativeSnippetRepository = representativeSnippetRepository;
+    }
+
+    public FindAllTemplatesResponse findAll() {
+        return FindAllTemplatesResponse.from(representativeSnippetRepository.findAll());
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #21

## 📍주요 변경 사항
1. RepresentativeSnippet 엔티티 생성
2. 템플릿 목록 조회 기능 구현 (대표 스니펫 한개의 최대 10줄의 코드와 최종 수정 시간)

