### PR TITLE
템플릿 상세 조회 API 구현

### DIFF
--- a/backend/src/main/java/codezap/snippet/repository/SnippetRepository.java
+++ b/backend/src/main/java/codezap/snippet/repository/SnippetRepository.java
@@ -1,8 +1,12 @@
 package codezap.snippet.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import codezap.snippet.domain.Snippet;
+import codezap.template.domain.Template;
 
 public interface SnippetRepository extends JpaRepository<Snippet, Long> {
+    List<Snippet> findAllByTemplate(Template template);
 }

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -35,6 +35,6 @@ public class TemplateController implements SpringDocTemplateController {
 
     @GetMapping("/{id}")
     public ResponseEntity<FindTemplateByIdResponse> getTemplateById(@PathVariable Long id) {
-        throw new NotImplementedException();
+        return ResponseEntity.ok(templateService.findById(id));
     }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindAllSnippetByTemplateResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllSnippetByTemplateResponse.java
@@ -1,9 +1,19 @@
 package codezap.template.dto.response;
 
+import codezap.snippet.domain.Snippet;
+
 public record FindAllSnippetByTemplateResponse(
         Long id,
         String filename,
         String content,
         int ordinal
 ) {
+    public static FindAllSnippetByTemplateResponse from(Snippet snippet) {
+        return new FindAllSnippetByTemplateResponse(
+                snippet.getId(),
+                snippet.getFilename(),
+                snippet.getContent(),
+                snippet.getOrdinal()
+        );
+    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindTemplateByIdResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindTemplateByIdResponse.java
@@ -3,12 +3,33 @@ package codezap.template.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import codezap.snippet.domain.Snippet;
+import codezap.template.domain.Template;
+
 public record FindTemplateByIdResponse(
         Long id,
         String title,
         FindMemberBySummaryResponse member,
-        Long representative_snippet_ordinal,
+        Integer representative_snippet_ordinal,
         List<FindAllSnippetByTemplateResponse> snippets,
         LocalDateTime modified_at
 ) {
+    public static FindTemplateByIdResponse from(Template template, List<Snippet> snippets) {
+        return new FindTemplateByIdResponse(
+                template.getId(),
+                template.getTitle(),
+                FindMemberBySummaryResponse.from(template.getMember()),
+                1,
+                mapToFindAllSnippetByTemplateResponse(snippets),
+                template.getModifiedAt()
+        );
+    }
+
+    private static List<FindAllSnippetByTemplateResponse> mapToFindAllSnippetByTemplateResponse(
+            List<Snippet> snippets
+    ) {
+        return snippets.stream()
+                .map(FindAllSnippetByTemplateResponse::from)
+                .toList();
+    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindTemplateBySummaryResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindTemplateBySummaryResponse.java
@@ -3,7 +3,6 @@ package codezap.template.dto.response;
 import java.time.LocalDateTime;
 
 import codezap.representative_snippet.domain.RepresentativeSnippet;
-import codezap.template.domain.Template;
 
 public record FindTemplateBySummaryResponse(
         Long id,

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -1,8 +1,15 @@
 package codezap.template.repository;
 
+import java.util.NoSuchElementException;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import codezap.template.domain.Template;
 
 public interface TemplateRepository extends JpaRepository<Template, Long> {
+
+    default Template getById(Long id) {
+        return findById(id).orElseThrow(
+                () -> new NoSuchElementException("식별자 " + id + "에 해당하는 템플릿이 존재하지 않습니다."));
+    }
 }

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -1,20 +1,41 @@
 package codezap.template.service;
 
+import java.util.List;
+
 import org.springframework.stereotype.Service;
 
 import codezap.representative_snippet.repository.RepresentativeSnippetRepository;
+import codezap.snippet.domain.Snippet;
+import codezap.snippet.repository.SnippetRepository;
+import codezap.template.domain.Template;
 import codezap.template.dto.response.FindAllTemplatesResponse;
+import codezap.template.dto.response.FindTemplateByIdResponse;
+import codezap.template.repository.TemplateRepository;
 
 @Service
 public class TemplateService {
 
     private final RepresentativeSnippetRepository representativeSnippetRepository;
+    private final TemplateRepository templateRepository;
+    private final SnippetRepository snippetRepository;
 
-    public TemplateService(RepresentativeSnippetRepository representativeSnippetRepository) {
+    public TemplateService(RepresentativeSnippetRepository representativeSnippetRepository,
+            TemplateRepository templateRepository,
+            SnippetRepository snippetRepository
+    ) {
         this.representativeSnippetRepository = representativeSnippetRepository;
+        this.templateRepository = templateRepository;
+        this.snippetRepository = snippetRepository;
     }
 
     public FindAllTemplatesResponse findAll() {
         return FindAllTemplatesResponse.from(representativeSnippetRepository.findAll());
     }
+
+    public FindTemplateByIdResponse findById(Long id) {
+        Template template = templateRepository.getById(id);
+        List<Snippet> snippets = snippetRepository.findAllByTemplate(template);
+        return FindTemplateByIdResponse.from(template, snippets);
+    }
+
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #37

## 📍주요 변경 사항
1. Id 값에 따른 템플릿 상세 조회 기능 구현

## 🎸기타
1. TemplateRepository의 getById 메서드 이름에 대한 추후 논의가 필요합니다.
2. FindTemplateByIdResponse의 대표 스니펫 순서가 1로 고정되어 있습니다.
  + 추후 대표 스니펫 설정 기능 추가 시 변경이 필요합니다.


