### PR TITLE
CI 워크플로에서 태스크를 build에서 test로 변경

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -1,4 +1,4 @@
-name: Build and deploy
+name: Backend CD
 
 on:
   push:

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -18,8 +18,7 @@ jobs:
         with:
           host port: 23306
           mysql database: code_zap
-          mysql user: root
-          mysql password: woowacourse
+          mysql root password: woowacourse
       - name: Setup JDK 17
         uses: actions/setup-java@v4
         with:

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -14,9 +14,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
       - name: Start MySQL
-        uses: samin/mysql-action@v1
+        uses: mirromutth/mysql-action@v1.1
         with:
           host port: 23306
+          container port: 3306
+          mysql version: lts
           mysql database: code_zap
           mysql root password: woowacourse
       - name: Setup JDK 17

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -1,0 +1,30 @@
+name: Backend CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    env:
+      build-directory: ./backend
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
+      - name: Start MySQL
+        uses: samin/mysql-action@v1
+        with:
+          host port: 23306
+          mysql database: code_zap
+          mysql user: root
+          mysql password: woowacourse
+      - name: Build with Gradle Wrapper
+        run: ./gradlew build
+        working-directory: ${{ env.build-directory }}

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -25,6 +25,6 @@ jobs:
           mysql database: code_zap
           mysql user: root
           mysql password: woowacourse
-      - name: Build with Gradle Wrapper
-        run: ./gradlew build
+      - name: Test with Gradle Wrapper
+        run: ./gradlew test
         working-directory: ${{ env.build-directory }}

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -13,11 +13,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
-      - name: Setup JDK 17
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
       - name: Start MySQL
         uses: samin/mysql-action@v1
         with:
@@ -25,6 +20,11 @@ jobs:
           mysql database: code_zap
           mysql user: root
           mysql password: woowacourse
+      - name: Setup JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
       - name: Test with Gradle Wrapper
         run: ./gradlew test
         working-directory: ${{ env.build-directory }}

--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -8,6 +8,8 @@ spring:
     password: woowacourse
     driver-class-name: com.mysql.cj.jdbc.Driver
   jpa:
+    database: mysql
+    database-platform: org.hibernate.dialect.MySQLDialect
     hibernate:
       ddl-auto: create
     properties:


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #82 

## 📍주요 변경 사항
1. ci 워크플로에서 실행되는 gradle build 태스크를 test 로 변경
2. 백엔드만 사용하는 ci, cd 파일이므로 backend_ci, backend_cd 로 이름 변경