### PR TITLE
프론트엔드 CI 설정 (github actions)

### DIFF
--- a/.github/workflows/frontend_ci.yml
+++ b/.github/workflows/frontend_ci.yml
@@ -1,0 +1,27 @@
+name: Frontend CI
+
+on:
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build-with-test:
+    runs-on: ubuntu-latest
+    env:
+      frontend-directory: ./frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Install Dependencies
+        run: npm install
+        working-directory: ${{ env.frontend-directory }}
+
+      - name: Run Tests
+        run: npm test
+        working-directory: ${{ env.frontend-directory }}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #90 

## 📍주요 변경 사항
1. CI 파일 업로드
- frontend 폴더에서 npm install 후 npm test

## 🎸기타
1. node 버전을 20으로 맞추었습니다. github actions에서 다음과 같은 warning을 줍니다. 
```
The following actions uses Node.js version which is deprecated and will be forced to run on node20: actions/setup-node@v3. For more info: https://github.blog/changelog/2024-03-07-github-actions-all-actions-will-run-on-node20-instead-of-node16-by-default/
```