### PR TITLE
실패 케이스 문서화에 사용할 스웨거 커스텀 기능 구현

### DIFF
--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponse.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponse.java
@@ -1,0 +1,31 @@
+package codezap.global.swagger.error;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.http.HttpStatus;
+
+/**
+ * HTTP API 에러 응답을 문서화하기 위한 어노테이션입니다.
+ * RFC 7807 "Problem Details for HTTP APIs" 규격을 따르는 {@link ProblemDetailSchema}를 생성하는 데 사용됩니다.
+ *
+ * @see ProblemDetailSchema
+ * @see ErrorCase
+ */
+
+@Target(value = METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorResponse {
+
+    String type() default "about:blank";
+
+    HttpStatus status();
+
+    String instance();
+
+    ErrorCase[] failCases();
+}
+

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponse.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponse.java
@@ -26,6 +26,6 @@ public @interface ApiErrorResponse {
 
     String instance();
 
-    ErrorCase[] failCases();
+    ErrorCase[] errorCases();
 }
 

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -32,7 +32,7 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
     }
 
     private MediaType makeMediaType(ApiErrorResponse apiErrorResponse) {
-        ErrorCase[] errorCases = apiErrorResponse.failCases();
+        ErrorCase[] errorCases = apiErrorResponse.errorCases();
 
         MediaType mediaType = new MediaType();
         Arrays.stream(errorCases).forEach(

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -30,8 +30,18 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
     }
 
     private ApiResponse makeFailResponse(ApiErrorResponse apiErrorResponse) {
-        ApiResponse apiResponse = new ApiResponse().description(apiErrorResponse.status().name());
+        ApiResponse apiResponse = new ApiResponse().description(getDescriptionByStatus(apiErrorResponse.status()));
         return apiResponse.content(new Content().addMediaType("application/json", makeMediaType(apiErrorResponse)));
+    }
+
+    private String getDescriptionByStatus(HttpStatusCode httpStatusCode) {
+        if (httpStatusCode.is4xxClientError()) {
+            return "클라이언트 오류";
+        }
+        if (httpStatusCode.is5xxServerError()) {
+            return "서버 오류";
+        }
+        return "문서화에 오류가 발생했습니다. 서버팀에게 문의해주세요 😭";
     }
 
     private MediaType makeMediaType(ApiErrorResponse apiErrorResponse) {

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -1,8 +1,10 @@
 package codezap.global.swagger.error;
 
 import java.util.Arrays;
+import java.util.Objects;
 
 import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 
@@ -19,9 +21,10 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
     @Override
     public Operation customize(Operation operation, HandlerMethod handlerMethod) {
         if (handlerMethod.hasMethodAnnotation(ApiErrorResponse.class)) {
-            ApiErrorResponse apiErrorResponse = handlerMethod.getMethodAnnotation(ApiErrorResponse.class);
+            ApiErrorResponse apiErrorResponse = Objects.requireNonNull(handlerMethod.getMethodAnnotation(ApiErrorResponse.class));
             ApiResponses responses = operation.getResponses();
-            responses.addApiResponse(apiErrorResponse.status().name(), makeFailResponse(apiErrorResponse));
+            String statusCode = String.valueOf(apiErrorResponse.status().value());
+            responses.addApiResponse(statusCode, makeFailResponse(apiErrorResponse));
         }
         return operation;
     }

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -1,0 +1,47 @@
+package codezap.global.swagger.error;
+
+import java.util.Arrays;
+
+import org.springdoc.core.customizers.OperationCustomizer;
+import org.springframework.stereotype.Component;
+import org.springframework.web.method.HandlerMethod;
+
+import io.swagger.v3.oas.models.Operation;
+import io.swagger.v3.oas.models.examples.Example;
+import io.swagger.v3.oas.models.media.Content;
+import io.swagger.v3.oas.models.media.MediaType;
+import io.swagger.v3.oas.models.responses.ApiResponse;
+import io.swagger.v3.oas.models.responses.ApiResponses;
+
+@Component
+public class ApiErrorResponsesCustomizer implements OperationCustomizer {
+
+    @Override
+    public Operation customize(Operation operation, HandlerMethod handlerMethod) {
+        if (handlerMethod.hasMethodAnnotation(ApiErrorResponse.class)) {
+            ApiErrorResponse apiErrorResponse = handlerMethod.getMethodAnnotation(ApiErrorResponse.class);
+            ApiResponses responses = operation.getResponses();
+            responses.addApiResponse(apiErrorResponse.status().name(), makeFailResponse(apiErrorResponse));
+        }
+        return operation;
+    }
+
+    private ApiResponse makeFailResponse(ApiErrorResponse apiErrorResponse) {
+        ApiResponse apiResponse = new ApiResponse().description(apiErrorResponse.status().name());
+        return apiResponse.content(new Content().addMediaType("application/json", makeMediaType(apiErrorResponse)));
+    }
+
+    private MediaType makeMediaType(ApiErrorResponse apiErrorResponse) {
+        ErrorCase[] errorCases = apiErrorResponse.failCases();
+
+        MediaType mediaType = new MediaType();
+        Arrays.stream(errorCases).forEach(
+                errorCase -> mediaType.addExamples(errorCase.description(), makeExample(apiErrorResponse, errorCase)));
+        return mediaType;
+    }
+
+    private Example makeExample(ApiErrorResponse apiErrorResponse, ErrorCase failResponse) {
+        Example example = new Example().summary(failResponse.description());
+        return example.value(ProblemDetailSchema.of(apiErrorResponse, failResponse.exampleMessage()));
+    }
+}

--- a/backend/src/main/java/codezap/global/swagger/error/ErrorCase.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ErrorCase.java
@@ -1,0 +1,24 @@
+package codezap.global.swagger.error;
+
+import static java.lang.annotation.ElementType.METHOD;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * API 에러 응답의 개별 케이스를 문서화하기 위한 어노테이션입니다.
+ * {@link ApiErrorResponse} 어노테이션 내에서 사용되어 다양한 에러 시나리오를 설명합니다.
+ *
+ * @see ApiErrorResponse
+ */
+
+@Target(value = METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ErrorCase {
+
+    String description();
+
+    String exampleMessage();
+}
+

--- a/backend/src/main/java/codezap/global/swagger/error/ProblemDetailSchema.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ProblemDetailSchema.java
@@ -1,0 +1,30 @@
+package codezap.global.swagger.error;
+
+/**
+ * ApiErrorResponse 어노테이션과 상세 설명을 바탕으로 ProblemDetailSchema 객체를 생성합니다.
+ * 이 메서드는 RFC 7807 "Problem Details for HTTP APIs" 규격을 준수하는 오류 응답 스키마를 생성합니다.
+ *
+ * <br>
+ * <br>
+ * 객체를 생성하지 않을 경우, 개별 예외 케이스의 응답 예시를 문서화할 수 없습니다.
+ *
+ * @param detail 문제에 대한 상세 설명 (예외 메시지를 작성하시면 좋을 것 같습니다.)
+ */
+
+public record ProblemDetailSchema(
+        String type,
+        String title,
+        int status,
+        String detail,
+        String instance
+) {
+    public static ProblemDetailSchema of(ApiErrorResponse apiErrorResponse, String detail) {
+        return new ProblemDetailSchema(
+                apiErrorResponse.type(),
+                apiErrorResponse.status().name(),
+                apiErrorResponse.status().value(),
+                detail,
+                apiErrorResponse.instance()
+        );
+    }
+}

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -1,8 +1,10 @@
 package codezap.template.controller;
 
-import org.springframework.http.ProblemDetail;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
+import codezap.global.swagger.error.ApiErrorResponse;
+import codezap.global.swagger.error.ErrorCase;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.FindAllTemplatesResponse;
@@ -10,7 +12,6 @@ import codezap.template.dto.response.FindTemplateByIdResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.ExampleObject;
 import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -28,18 +29,13 @@ public interface SpringDocTemplateController {
             """)
     @ApiResponse(responseCode = "201", description = "회원 예약 생성 성공", headers = {
             @Header(name = "생성된 템플릿의 API 경로", example = "/templates/1")})
-    @ApiResponse(responseCode = "400", content = @Content(schema = @Schema(implementation = ProblemDetail.class),
-            examples = {
-                    @ExampleObject(summary = "모든 필드 중 null인 값이 있는 경우",
-                            name = "메시지 예시: 템플릿 이름 null 입니다."),
-                    @ExampleObject(summary = "제목 또는 스니펫 파일명이 255자를 초과한 경우",
-                            name = "메시지 예시: 제목은 최대 255자까지 입력 가능합니다."),
-                    @ExampleObject(summary = "썸네일 스니펫의 순서가 1이 아닌 경우",
-                            name = "메시지 예시: 썸네일 스니펫의 순서가 잘못되었습니다."),
-                    @ExampleObject(summary = "스니펫 순서가 잘못된 경우 (ex. 1 -> 3 -> 2 순으로 스니펫 목록이 온 경우)",
-                            name = "메시지 예시: 스니펫 순서가 잘못되었습니다."),
-                    @ExampleObject(summary = "스니펫 내용 65,535 byte를 초과한 경우",
-                            name = "메시지 예시: 파일 내용은 최대 65,535 byte까지 입력 가능합니다.")}))
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", failCases = {
+            @ErrorCase(description = "모든 필드 중 null인 값이 있는 경우", exampleMessage = "템플릿 이름 null 입니다."),
+            @ErrorCase(description = "제목 또는 스니펫 파일명이 255자를 초과한 경우", exampleMessage = "제목은 최대 255자까지 입력 가능합니다."),
+            @ErrorCase(description = "썸네일 스니펫의 순서가 1이 아닌 경우", exampleMessage = "썸네일 스니펫의 순서가 잘못되었습니다."),
+            @ErrorCase(description = "스니펫 순서가 잘못된 경우", exampleMessage = "스니펫 순서가 잘못되었습니다."),
+            @ErrorCase(description = "스니펫 내용 65,535 byte를 초과한 경우", exampleMessage = "파일 내용은 최대 65,535 byte까지 입력 가능합니다.")
+    })
     ResponseEntity<Void> create(CreateTemplateRequest createTemplateRequest);
 
     @Operation(summary = "템플릿 목록 조회", description = "작성된 모든 템플릿을 조회합니다.")
@@ -50,14 +46,16 @@ public interface SpringDocTemplateController {
     @Operation(summary = "템플릿 단건 조회", description = "해당하는 식별자의 템플릿을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공",
             content = {@Content(schema = @Schema(implementation = FindAllTemplatesResponse.class))})
-    @ApiResponse(responseCode = "400", description = "해당하는 id 값인 템플릿이 없는 경우",
-            content = {@Content(schema = @Schema(implementation = ProblemDetail.class))})
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", failCases = {
+            @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
+    })
     ResponseEntity<FindTemplateByIdResponse> getTemplateById(Long id);
 
     @Operation(summary = "템플릿 수정", description = "해당하는 식별자의 템플릿을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 수정 성공")
-    @ApiResponse(responseCode = "400", description = "해당하는 id 값인 템플릿이 없는 경우",
-            content = {@Content(schema = @Schema(implementation = ProblemDetail.class))})
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", failCases = {
+            @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
+    })
     ResponseEntity<Void> updateTemplate(Long id, UpdateTemplateRequest updateTemplateRequest);
 
     @Operation(summary = "템플릿 삭제", description = "해당하는 식별자의 템플릿을 삭제합니다.")

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -29,7 +29,7 @@ public interface SpringDocTemplateController {
             """)
     @ApiResponse(responseCode = "201", description = "회원 예약 생성 성공", headers = {
             @Header(name = "생성된 템플릿의 API 경로", example = "/templates/1")})
-    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", failCases = {
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "모든 필드 중 null인 값이 있는 경우", exampleMessage = "템플릿 이름 null 입니다."),
             @ErrorCase(description = "제목 또는 스니펫 파일명이 255자를 초과한 경우", exampleMessage = "제목은 최대 255자까지 입력 가능합니다."),
             @ErrorCase(description = "썸네일 스니펫의 순서가 1이 아닌 경우", exampleMessage = "썸네일 스니펫의 순서가 잘못되었습니다."),
@@ -46,14 +46,14 @@ public interface SpringDocTemplateController {
     @Operation(summary = "템플릿 단건 조회", description = "해당하는 식별자의 템플릿을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공",
             content = {@Content(schema = @Schema(implementation = FindAllTemplatesResponse.class))})
-    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", failCases = {
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
     })
     ResponseEntity<FindTemplateByIdResponse> getTemplateById(Long id);
 
     @Operation(summary = "템플릿 수정", description = "해당하는 식별자의 템플릿을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 수정 성공")
-    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", failCases = {
+    @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
     })
     ResponseEntity<Void> updateTemplate(Long id, UpdateTemplateRequest updateTemplateRequest);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #128 

## 📍주요 변경 사항
1. 에러 응답을 문서화하기 위한 커스텀 어노테이션 구현 <br> - OperationCustomizer를 통한 실패 응답 추가 자동화
2. SpringDocTemplateController의 Api응답 작성 부분 리팩토링

## 🎸기타
1. 기존 @ApiReponse를 사용하게 되면 개별 예외 케이스에 대한 응답 예시가 문서화되지 않습니다(이슈 참고 바람) 
따라서 **새로 생성된 커스텀 어노테이션을 사용하여 문서화**해주세요.
