### PR TITLE
롬복을 최신 버전을 사용하도록 변경

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -24,7 +24,7 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.5.0'
 
-    compileOnly 'org.projectlombok:lombok:0.11.0'
+    compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
 
     runtimeOnly 'com.mysql:mysql-connector-j:9.0.0'


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #202 

## 📍주요 변경 사항
1. 롬복 최신 버전을 사용하도록 `build.gradle` 변경

## 🎸기타

참고자료 : [SOF - How are some gradle dependencies working with no version supplied](https://stackoverflow.com/questions/41676534/how-are-some-gradle-dependencies-working-with-no-version-supplied)