### PR TITLE
Input 컴포넌트 사이즈 추가

### DIFF
--- a/frontend/src/components/Input/Input.stories.tsx
+++ b/frontend/src/components/Input/Input.stories.tsx
@@ -17,7 +17,7 @@ const meta: Meta<typeof Input> = {
     size: {
       control: {
         type: 'radio',
-        options: ['small', 'medium'],
+        options: ['small', 'medium', 'large'],
       },
     },
     isValid: {

--- a/frontend/src/components/Input/Input.style.ts
+++ b/frontend/src/components/Input/Input.style.ts
@@ -8,7 +8,7 @@ const sizes = {
     gap: 0.5rem;
 
     height: 2rem;
-    padding: 0.625rem 0.75rem;
+    padding: 0 0.75rem;
 
     font-size: 0.75rem;
     line-height: 100%;
@@ -16,10 +16,21 @@ const sizes = {
     border-radius: 8px;
   `,
   medium: css`
+    gap: 0.875rem;
+
+    height: 2.5rem;
+    padding: 0 0.875rem;
+
+    font-size: 0.875rem;
+    line-height: 100%;
+
+    border-radius: 10px;
+  `,
+  large: css`
     gap: 0.75rem;
 
     height: 3rem;
-    padding: 1rem;
+    padding: 0 1rem;
 
     font-size: 1rem;
     line-height: 100%;

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -11,12 +11,12 @@ import {
 import * as S from './Input.style';
 
 export interface BaseProps extends HTMLAttributes<HTMLDivElement> {
-  size?: 'small' | 'medium';
+  size?: 'small' | 'medium' | 'large';
   variant?: 'filled' | 'outlined' | 'text';
   isValid?: boolean;
 }
 export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
-  inputSize?: 'small' | 'medium';
+  inputSize?: 'small' | 'medium' | 'large';
 }
 
 export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #247 

## 📍주요 변경 사항
### 1. Input 컴포넌트에 `small`과 `medium` 사이의 사이즈를 추가함
- 기존의 `medium` 사이즈를 `large` 사이즈로 변경
