### PR TITLE
각종 슬랙 알람을 위한 워크플로 작성

### DIFF
--- a/.github/workflows/ci_cd_fail_notification.yml
+++ b/.github/workflows/ci_cd_fail_notification.yml
@@ -1,0 +1,44 @@
+name: Notify on Workflow Failure
+
+on:
+  workflow_run:
+    workflows: ["Backend CI", "Backend CD", "Frontend CD", "Frontend CI"]
+    types:
+      - completed
+
+jobs:
+  notify:
+    if: ${{ github.event.workflow_run.conclusion == 'failure' }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send Slack notification
+        env:
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CICD_FAIL_WEBHOOK_URL }}
+          SLACK_IDS: ${{ secrets.SLACK_IDS }}
+        run: |
+          WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
+          WORKFLOW_URL="${{ github.event.workflow_run.html_url }}"
+          ASSIGNEE="${{ github.event.workflow_run.actor.login }}"
+          mentions=""
+
+          parse_slack_ids() {
+              echo "$SLACK_IDS" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
+          }
+          
+          slack_id=$(parse_slack_ids | grep "^$ASSIGNEE:" | cut -d':' -f2)
+
+          if [ -n "$slack_id" ]; then
+              MENTION="<@$slack_id>"
+          else
+              MENTION="$ASSIGNEE"
+          fi
+
+          if [ ! -z "$MENTION" ]; then
+            message="$MENTION 님, 실행된 $WORKFLOW_NAME 워크플로가 실패했습니다. <$WORKFLOW_URL|확인하러 가기>."
+            curl -X POST -H 'Content-type: application/json' \
+              --data "{\"text\":\"$message\"}" \
+              "$SLACK_WEBHOOK_URL"
+            echo "Sent message: $message"
+          else
+            echo "No MENTIONER to notify"
+          fi

--- a/.github/workflows/ci_cd_fail_notification.yml
+++ b/.github/workflows/ci_cd_fail_notification.yml
@@ -11,11 +11,15 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: self-hosted
     steps:
-      - name: CI 또는 CD 실패 시 Slack 알람 보내기
-        env:
-          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CICD_FAIL_WEBHOOK_URL }}
-          SLACK_IDS: ${{ secrets.SLACK_IDS }}
-        run: |
+    - name: 변수 추출
+      run: |
+        SLACK_WEBHOOK_URL=$(cat ../slack_noti/SLACK_CICD_FAIL_WEBHOOK_URL)
+        SLACK_IDS=$(cat ../slack_noti/SLACK_IDS)
+        echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> $GITHUB_ENV
+        echo "SLACK_IDS=$SLACK_IDS" >> $GITHUB_ENV
+
+    - name: CI 또는 CD 실패 시 Slack 알람 보내기
+      run: |
           WORKFLOW_NAME="${{ github.event.workflow_run.name }}"
           WORKFLOW_URL="${{ github.event.workflow_run.html_url }}"
           ASSIGNEE="${{ github.event.workflow_run.actor.login }}"

--- a/.github/workflows/ci_cd_fail_notification.yml
+++ b/.github/workflows/ci_cd_fail_notification.yml
@@ -11,7 +11,7 @@ jobs:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
     runs-on: self-hosted
     steps:
-      - name: Send Slack notification
+      - name: CI 또는 CD 실패 시 Slack 알람 보내기
         env:
           SLACK_WEBHOOK_URL: ${{ secrets.SLACK_CICD_FAIL_WEBHOOK_URL }}
           SLACK_IDS: ${{ secrets.SLACK_IDS }}

--- a/.github/workflows/ci_cd_fail_notification.yml
+++ b/.github/workflows/ci_cd_fail_notification.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   notify:
     if: ${{ github.event.workflow_run.conclusion == 'failure' }}
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
       - name: Send Slack notification
         env:

--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -1,0 +1,49 @@
+name: PR Slack Notification
+on:
+  pull_request:
+    types: [opened, reopened]
+jobs:
+  notify_reviewers:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+        
+    - name: Slack 알람 보내기
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}
+        SLACK_IDS: ${{ secrets.SLACK_IDS }}
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        REVIEWERS='${{ toJson(github.event.pull_request.requested_reviewers.*.login) }}'
+        echo "REVIEWERS: $REVIEWERS"
+        
+        parse_slack_ids() {
+            echo "$SLACK_IDS" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
+        }
+        
+        reviewers=$(echo "$REVIEWERS" | jq -r '.[]')
+        mentions=""
+        
+        for reviewer in $reviewers; do
+            slack_id=$(parse_slack_ids | grep "^$reviewer:" | cut -d':' -f2)
+            
+            if [ -n "$slack_id" ]; then
+                mentions="$mentions <@$slack_id>"
+            else
+                mentions="$mentions $reviewer"
+            fi
+        done
+        
+        echo "Mentions: $mentions"
+        
+        if [ ! -z "$mentions" ]; then
+          message="$mentions 님, 새로운 PR이 생성되었습니다: <$PR_URL|$PR_TITLE>"
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"$message\"}" \
+            "$SLACK_WEBHOOK_URL"
+          echo "Sent message: $message"
+        else
+          echo "No reviewers to notify"
+        fi

--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: self-hosted
     steps:
         
-    - name: Slack 알람 보내기
+    - name: PR 생성 시 reviewer들에게 Slack 알람 보내기
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}
         SLACK_IDS: ${{ secrets.SLACK_IDS }}

--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -6,11 +6,14 @@ jobs:
   notify_reviewers:
     runs-on: self-hosted
     steps:
+    - name: 변수 추출
+      run: |
+        SLACK_WEBHOOK_URL=$(cat ../slack_noti/SLACK_PR_CREATE_WEBHOOK_URL)
+        SLACK_IDS=$(cat ../slack_noti/SLACK_IDS)
+        echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> $GITHUB_ENV
+        echo "SLACK_IDS=$SLACK_IDS" >> $GITHUB_ENV
         
     - name: PR 생성 시 reviewer들에게 Slack 알람 보내기
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_CREATE_WEBHOOK_URL }}
-        SLACK_IDS: ${{ secrets.SLACK_IDS }}
       run: |
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -4,10 +4,8 @@ on:
     types: [opened, reopened]
 jobs:
   notify_reviewers:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
         
     - name: Slack 알람 보내기
       env:
@@ -47,3 +45,4 @@ jobs:
         else
           echo "No reviewers to notify"
         fi
+

--- a/.github/workflows/review_notification.yml
+++ b/.github/workflows/review_notification.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: self-hosted
     steps:
 
-    - name: Send Slack notification
+    - name: PR에 리뷰 등록 시 담당자에게 Slack 알람
       env:
         SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_REVIEW_WEBHOOK_URL }}
         SLACK_IDS: ${{ secrets.SLACK_IDS }}

--- a/.github/workflows/review_notification.yml
+++ b/.github/workflows/review_notification.yml
@@ -7,11 +7,14 @@ jobs:
   notify_pr_author:
     runs-on: self-hosted
     steps:
+    - name: 변수 추출
+      run: |
+        SLACK_WEBHOOK_URL=$(cat ../slack_noti/SLACK_PR_REVIEW_WEBHOOK_URL)
+        SLACK_IDS=$(cat ../slack_noti/SLACK_IDS)
+        echo "SLACK_WEBHOOK_URL=$SLACK_WEBHOOK_URL" >> $GITHUB_ENV
+        echo "SLACK_IDS=$SLACK_IDS" >> $GITHUB_ENV
 
     - name: PR에 리뷰 등록 시 담당자에게 Slack 알람
-      env:
-        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_REVIEW_WEBHOOK_URL }}
-        SLACK_IDS: ${{ secrets.SLACK_IDS }}
       run: |
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"

--- a/.github/workflows/review_notification.yml
+++ b/.github/workflows/review_notification.yml
@@ -5,10 +5,8 @@ on:
 
 jobs:
   notify_pr_author:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     steps:
-    - name: Checkout code
-      uses: actions/checkout@v2
 
     - name: Send Slack notification
       env:

--- a/.github/workflows/review_notification.yml
+++ b/.github/workflows/review_notification.yml
@@ -1,0 +1,62 @@
+name: PR Review Notification
+on:
+  pull_request_review:
+    types: [submitted]
+
+jobs:
+  notify_pr_author:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v2
+
+    - name: Send Slack notification
+      env:
+        SLACK_WEBHOOK_URL: ${{ secrets.SLACK_PR_REVIEW_WEBHOOK_URL }}
+        SLACK_IDS: ${{ secrets.SLACK_IDS }}
+      run: |
+        PR_TITLE="${{ github.event.pull_request.title }}"
+        PR_URL="${{ github.event.pull_request.html_url }}"
+        PR_AUTHOR="${{ github.event.pull_request.user.login }}"
+        REVIEW_STATE="${{ github.event.review.state }}"
+        REVIEWER="${{ github.event.review.user.login }}"
+
+        parse_slack_ids() {
+            echo "$SLACK_IDS" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
+        }
+
+        author_slack_id=$(parse_slack_ids | grep "^$PR_AUTHOR:" | cut -d':' -f2)
+        reviewer_slack_id=$(parse_slack_ids | grep "^$REVIEWER:" | cut -d':' -f2)
+
+        if [ -n "$author_slack_id" ]; then
+            author_mention="<@$author_slack_id>"
+        else
+            author_mention="$PR_AUTHOR"
+        fi
+
+        if [ -n "$reviewer_slack_id" ]; then
+            reviewer_mention="<@$reviewer_slack_id>"
+        else
+            reviewer_mention="$REVIEWER"
+        fi
+
+        case "$REVIEW_STATE" in
+          "changes_requested")
+            message="$author_mention님, $reviewer_mention님이 PR에 변경을 요청했습니다: <$PR_URL|$PR_TITLE>"
+            ;;
+          "commented")
+            message="$author_mention님, $reviewer_mention님이 PR에 코멘트를 남겼습니다: <$PR_URL|$PR_TITLE>"
+            ;;
+          "approved")
+            message="$author_mention님, 축하합니다! $reviewer_mention님이 PR을 승인했습니다: <$PR_URL|$PR_TITLE>"
+            ;;
+        esac
+
+        if [ ! -z "$message" ]; then
+          curl -X POST -H 'Content-type: application/json' \
+            --data "{\"text\":\"$message\"}" \
+            "$SLACK_WEBHOOK_URL"
+          echo "Sent message: $message"
+        else
+          echo "No notification sent"
+        fi


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #173

## 📍주요 변경 사항
1. ci, cd 실패 시 워크플로 작동 시킨 사람에게 슬랙 알람
2. pr 생성 시 리뷰어에게 알람
3. 리뷰 등록 시 assignee에게 알람

## 🎸기타
1. 우리 팀이 문서화를 잘해서 디스커션이나 위키 작성 시에도 알람이 가게 할까 생각을 해보았는데, 알람이 너무 많아지는 건가 싶어 고민중입니다.
