### PR TITLE
CI/CD build 실행 self-hosted-runner에서 하도록 변경

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -7,38 +7,34 @@ on:
       - main
 
 jobs:
+  find-branch:
+    runs-on: self-hosted
+    steps:
+      - name: 브랜치명을 통해 개발 환경 알아내기
+        run: |
+          cd ${{ secrets.SCRIPT_DIRECTORY }}
+          bash find-env-by-branch.sh
+          
   build:
-    runs-on: ubuntu-latest
+    needs: find-branch
+    runs-on: self-hosted
     steps:
       - name: 체크아웃
         uses: actions/checkout@v4
-
-      - name: JDK 17 설정
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
-
+        
       - name: gradle 캐싱
-        uses: actions/cache@v3
-        with:
-          path: |
-            ~/.gradle/caches
-            ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
-          restore-keys: |
-            ${{ runner.os }}-gradle-
+        uses: gradle/actions/setup-gradle@v3
             
       - name: bootJar로 jar 파일 생성
-        run: ./gradlew bootJar
+        run: |
+          ./gradlew bootJar
+          mv build/libs/*.jar ${{ secrets.WORK_DIRECTORY }}/${{ env.ENVIRONMENT }}
         working-directory: ./backend
-
-      - name: jar 파일 Artifact로 업로드
-        uses: actions/upload-artifact@v4
-        with:
-          name: code-zap-jar
-          path: backend/build/libs/*.jar
-
+      
+      - name: 클린업
+        if: always()
+        run: rm -rf ../2024-code-zap/*
+        
   deploy:
     needs: build
     runs-on: self-hosted
@@ -48,12 +44,6 @@ jobs:
           cd ${{ secrets.SCRIPT_DIRECTORY }}
           bash find-env-by-branch.sh
           
-      - name: Artifact 다운로드
-        uses: actions/download-artifact@v4
-        with:
-          name: code-zap-jar
-          path: ${{ secrets.WORK_DIRECTORY }}/${{ env.ENVIRONMENT }}
-
       - name: 실행 프로세스 확인
         run: |
           cd ${{ secrets.SCRIPT_DIRECTORY }}
@@ -61,8 +51,6 @@ jobs:
         
       - name: 배포 스크립트 실행
         run: |
-          cd ${{ secrets.WORK_DIRECTORY }}
-          unzip -o code-zap-jar.zip
           cd ${{ secrets.SCRIPT_DIRECTORY }}
           RUNNER_TRACKING_ID="" && bash start.sh ${{ env.ENVIRONMENT }}
                     
@@ -70,3 +58,4 @@ jobs:
         run: |
           cd ${{ secrets.SCRIPT_DIRECTORY }}
           bash verify-deploy.sh
+          

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -1,4 +1,4 @@
-name: 백엔드 CD
+name: Backend CD
 
 on:
   push:

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -1,4 +1,4 @@
-name: 백엔드 CI
+name: Backend CI
 
 on:
   pull_request:

--- a/.github/workflows/backend_ci.yml
+++ b/.github/workflows/backend_ci.yml
@@ -6,10 +6,11 @@ on:
       - dev/be
       - develop
       - main
-      
+
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
+
     steps:
       - name: 체크아웃
         uses: actions/checkout@v4
@@ -23,13 +24,11 @@ jobs:
                 path: /h2-console
             datasource:
               url: jdbc:h2:mem:database" > backend/src/main/resources/application.yml
-
-      - name: JDK 17 설정
-        uses: actions/setup-java@v4
-        with:
-          java-version: 17
-          distribution: temurin
           
       - name: 테스트 코드 실행
         run: ./gradlew test
         working-directory: ./backend
+
+      - name: 클린업
+        if: always()
+        run: rm -rf ../2024-code-zap/*


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #268 

## 📍주요 변경 사항
- CI를 self-hosted-runner에서 실행하도록 변경
- CD의 build 실행도 self-hosted-runner에서 실행하도록 변경
  - self-hosted-runner에서 jar 파일 생성 후 사용 (아키텍처 이용 안함)
- 캐싱 방법 다른 aciton 사용으로 변경
## 🎸기타
정확한 문제 파악을 하지 못했다. (어떤 제한이 있는지? 얼마까지만 허용하는지?)
추후 찾아볼 예정. 아는 사람은 알려주세요.
