### PR TITLE
커스텀한 에러 응답 어노테이션 중복 정의 안되는 이슈 해결

### DIFF
--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponse.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponse.java
@@ -2,6 +2,7 @@ package codezap.global.swagger.error;
 
 import static java.lang.annotation.ElementType.METHOD;
 
+import java.lang.annotation.Repeatable;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
@@ -18,6 +19,7 @@ import org.springframework.http.HttpStatus;
 
 @Target(value = METHOD)
 @Retention(RetentionPolicy.RUNTIME)
+@Repeatable(ApiErrorResponses.class)
 public @interface ApiErrorResponse {
 
     String type() default "about:blank";

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponses.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponses.java
@@ -1,0 +1,12 @@
+package codezap.global.swagger.error;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target(ElementType.METHOD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface ApiErrorResponses {
+    ApiErrorResponse[] value();
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #265 

## 📍주요 변경 사항
1. 한 메서드에서 `@ApiErrorResponse`가 중복적으로 사용되지 못했는데 `@Repeatable`을 사용하여 중복 가능하게 변경

