### PR TITLE
로거 순환 참조로 MethodExecutionTimeAspect 적용되지 않는 문제

### DIFF
--- a/backend/src/main/java/codezap/global/logger/MethodExecutionTimeAspect.java
+++ b/backend/src/main/java/codezap/global/logger/MethodExecutionTimeAspect.java
@@ -13,8 +13,8 @@ import lombok.extern.slf4j.Slf4j;
 public class MethodExecutionTimeAspect {
 
     @Around("execution(* codezap..*(..)) && " +
-            "!execution(* codezap.global.logger.MethodExecutionTimeAspect(..))" +
-            "!execution(* codezap.global.exception.*.*(..))")
+            "!within(codezap.global.logger.*) && " +
+            "!within(codezap.global.exception.*)")
     public Object logExecutionTime(ProceedingJoinPoint joinPoint) throws Throwable {
         if (!log.isInfoEnabled()) {
             return joinPoint.proceed();


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #282

## 📍주요 변경 사항
1. MethodExecutionTimeAspect의 포인트컷 표현식 변경

## 🎸기타
1. 로거 순환 참조의 문제인 것 같습니다. 포인트컷 표현식 수정했습니다.
+ 두 표현식 차이 공부 필요함