### PR TITLE
목록 조회

### DIFF
--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -1,5 +1,7 @@
 package codezap.template.controller;
 
+import java.util.List;
+
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
@@ -39,13 +41,20 @@ public interface SpringDocTemplateController {
     })
     ResponseEntity<Void> create(CreateTemplateRequest createTemplateRequest);
 
-    @Operation(summary = "템플릿 목록 조회", description = "작성된 모든 템플릿을 조회합니다.")
+    @Operation(summary = "템플릿 목록 조회", description = """
+            조건에 맞는 모든 템플릿을 조회합니다.
+            필터링 조건은 작성자 Id, 카테고리 Id, 태그 목록을 사용할 수 있습니다.
+            조회 조건으로 페이지 인덱스, 한 페이지에 들어갈 최대 템플릿의 개수를 변경할 수 있습니다.
+            페이지 인덱스는 1, 템플릿 개수는 20개가 기본 값입니다.
+            """)
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공",
             content = {@Content(schema = @Schema(implementation = ExploreTemplatesResponse.class))})
     ResponseEntity<FindAllTemplatesResponse> getTemplates(
-            Long memberId,
+            //Long memberId,
             Integer pageNumber,
-            Integer pageSize
+            Integer pageSize,
+            Long categoryId,
+            List<String> tagNames
     );
 
     @Operation(summary = "템플릿 단건 조회", description = "해당하는 식별자의 템플릿을 조회합니다.")

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -7,6 +7,7 @@ import codezap.global.swagger.error.ApiErrorResponse;
 import codezap.global.swagger.error.ErrorCase;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.dto.response.ExploreTemplatesResponse;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -39,13 +40,17 @@ public interface SpringDocTemplateController {
     ResponseEntity<Void> create(CreateTemplateRequest createTemplateRequest);
 
     @Operation(summary = "템플릿 목록 조회", description = "작성된 모든 템플릿을 조회합니다.")
-    @ApiResponse(responseCode = "200", description = "조회 성공",
-            content = {@Content(schema = @Schema(implementation = FindAllTemplatesResponse.class))})
-    ResponseEntity<FindAllTemplatesResponse> getTemplates();
+    @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공",
+            content = {@Content(schema = @Schema(implementation = ExploreTemplatesResponse.class))})
+    ResponseEntity<FindAllTemplatesResponse> getTemplates(
+            Long memberId,
+            Integer pageNumber,
+            Integer pageSize
+    );
 
     @Operation(summary = "템플릿 단건 조회", description = "해당하는 식별자의 템플릿을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공",
-            content = {@Content(schema = @Schema(implementation = FindAllTemplatesResponse.class))})
+            content = {@Content(schema = @Schema(implementation = ExploreTemplatesResponse.class))})
     @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
     })

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 import codezap.global.validation.ValidationSequence;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.dto.response.ExploreTemplatesResponse;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import codezap.template.service.TemplateService;
@@ -39,7 +40,15 @@ public class TemplateController implements SpringDocTemplateController {
     }
 
     @GetMapping
-    public ResponseEntity<FindAllTemplatesResponse> getTemplates() {
+    public ResponseEntity<FindAllTemplatesResponse> getTemplates(
+            Long memberId,
+            Integer pageNumber,
+            Integer pageSize) {
+        return null;
+    }
+
+    @GetMapping("/explore")
+    public ResponseEntity<ExploreTemplatesResponse> explore() {
         return ResponseEntity.ok(templateService.findAll());
     }
 

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -1,6 +1,7 @@
 package codezap.template.controller;
 
 import java.net.URI;
+import java.util.List;
 
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -10,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codezap.global.validation.ValidationSequence;
@@ -41,9 +43,12 @@ public class TemplateController implements SpringDocTemplateController {
 
     @GetMapping
     public ResponseEntity<FindAllTemplatesResponse> getTemplates(
-            Long memberId,
-            Integer pageNumber,
-            Integer pageSize) {
+            //@RequestParam Long memberId,
+            @RequestParam(required = false, defaultValue = "1") Integer pageNumber,
+            @RequestParam(required = false, defaultValue = "20") Integer pageSize,
+            @RequestParam(required = false, defaultValue = "1") Long categoryId,
+            @RequestParam(required = false) List<String> tagNames
+    ) {
         return null;
     }
 

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -3,6 +3,7 @@ package codezap.template.controller;
 import java.net.URI;
 import java.util.List;
 
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -49,7 +50,7 @@ public class TemplateController implements SpringDocTemplateController {
             @RequestParam(required = false, defaultValue = "1") Long categoryId,
             @RequestParam(required = false) List<String> tagNames
     ) {
-        return null;
+        return ResponseEntity.ok(templateService.findAllBy(PageRequest.of(pageNumber - 1, pageSize), categoryId, tagNames));
     }
 
     @GetMapping("/explore")

--- a/backend/src/main/java/codezap/template/dto/response/ExploreTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/ExploreTemplatesResponse.java
@@ -1,0 +1,39 @@
+package codezap.template.dto.response;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import codezap.template.domain.ThumbnailSnippet;
+import io.swagger.v3.oas.annotations.media.Schema;
+
+public record ExploreTemplatesResponse(
+        @Schema(description = "템플릿 목록")
+        List<ItemResponse> templates
+) {
+    public static ExploreTemplatesResponse from(List<ThumbnailSnippet> thumbnailSnippets) {
+        List<ItemResponse> templatesBySummaryResponse = thumbnailSnippets.stream()
+                .map(ItemResponse::from)
+                .toList();
+        return new ExploreTemplatesResponse(templatesBySummaryResponse);
+    }
+
+    public record ItemResponse(
+            @Schema(description = "템플릿 식별자", example = "0")
+            Long id,
+            @Schema(description = "템플릿 이름", example = "스프링 로그인 구현")
+            String title,
+            @Schema(description = "목록 조회 시 보여질 대표 스니펫 정보")
+            FindThumbnailSnippetResponse thumbnailSnippet,
+            @Schema(description = "템플릿 수정 시간", example = "2024-11-11 12:00", type = "string")
+            LocalDateTime modifiedAt
+    ) {
+        public static ItemResponse from(ThumbnailSnippet thumbnailSnippet) {
+            return new ItemResponse(
+                    thumbnailSnippet.getTemplate().getId(),
+                    thumbnailSnippet.getTemplate().getTitle(),
+                    FindThumbnailSnippetResponse.from(thumbnailSnippet.getSnippet()),
+                    thumbnailSnippet.getModifiedAt()
+            );
+        }
+    }
+}

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -21,9 +21,9 @@ public record FindAllTemplatesResponse(
             Long id,
             @Schema(description = "템플릿 이름", example = "스프링 로그인 구현")
             String title,
-            //todo 문서화
+            @Schema(description = "템플릿 설명", example = "Jwt 토큰을 이용하여 로그인 기능을 구현합니다.")
             String description,
-            //todo 문서화
+            @Schema(description = "태그 리스트")
             List<FindTagResponse> tags,
             @Schema(description = "템플릿 수정 시간", example = "2024-11-11 12:00", type = "string")
             LocalDateTime modifiedAt

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -1,39 +1,5 @@
 package codezap.template.dto.response;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
-import codezap.template.domain.ThumbnailSnippet;
-import io.swagger.v3.oas.annotations.media.Schema;
-
 public record FindAllTemplatesResponse(
-        @Schema(description = "템플릿 목록")
-        List<ItemResponse> templates
 ) {
-    public static FindAllTemplatesResponse from(List<ThumbnailSnippet> thumbnailSnippets) {
-        List<ItemResponse> templatesBySummaryResponse = thumbnailSnippets.stream()
-                .map(ItemResponse::from)
-                .toList();
-        return new FindAllTemplatesResponse(templatesBySummaryResponse);
-    }
-
-    public record ItemResponse(
-            @Schema(description = "템플릿 식별자", example = "0")
-            Long id,
-            @Schema(description = "템플릿 이름", example = "스프링 로그인 구현")
-            String title,
-            @Schema(description = "목록 조회 시 보여질 대표 스니펫 정보")
-            FindThumbnailSnippetResponse thumbnailSnippet,
-            @Schema(description = "템플릿 수정 시간", example = "2024-11-11 12:00", type = "string")
-            LocalDateTime modifiedAt
-    ) {
-        public static ItemResponse from(ThumbnailSnippet thumbnailSnippet) {
-            return new ItemResponse(
-                    thumbnailSnippet.getTemplate().getId(),
-                    thumbnailSnippet.getTemplate().getTitle(),
-                    FindThumbnailSnippetResponse.from(thumbnailSnippet.getSnippet()),
-                    thumbnailSnippet.getModifiedAt()
-            );
-        }
-    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -10,6 +10,8 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record FindAllTemplatesResponse(
         @Schema(description = "전체 페이지 개수", example = "1")
         int totalPage,
+        @Schema(description = "총 템플릿 개수", example = "134")
+        long totalElement,
         @Schema(description = "템플릿 목록")
         List<ItemResponse> templates
 ) {
@@ -27,15 +29,15 @@ public record FindAllTemplatesResponse(
             LocalDateTime modifiedAt
     ) {
         public static ItemResponse of(Template template, List<Tag> templateTags) {
-        return new ItemResponse(
-                template.getId(),
-                template.getTitle(),
-                template.getDescription(),
-                templateTags.stream()
-                        .map(tag -> new FindTagResponse(tag.getId(), tag.getName()))
-                        .toList(),
-                template.getModifiedAt()
-        );
-    }
+            return new ItemResponse(
+                    template.getId(),
+                    template.getTitle(),
+                    template.getDescription(),
+                    templateTags.stream()
+                            .map(tag -> new FindTagResponse(tag.getId(), tag.getName()))
+                            .toList(),
+                    template.getModifiedAt()
+            );
+        }
     }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -1,5 +1,28 @@
 package codezap.template.dto.response;
 
+import java.time.LocalDateTime;
+import java.util.List;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+
 public record FindAllTemplatesResponse(
+        @Schema(description = "전체 페이지 개수", example = "1")
+        int totalPage,
+        @Schema(description = "템플릿 목록")
+        List<ItemResponse> templates
 ) {
+
+    public record ItemResponse(
+            @Schema(description = "템플릿 식별자", example = "0")
+            Long id,
+            @Schema(description = "템플릿 이름", example = "스프링 로그인 구현")
+            String title,
+            //todo 문서화
+            String description,
+            //todo 문서화
+            List<FindTagResponse> tags,
+            @Schema(description = "템플릿 수정 시간", example = "2024-11-11 12:00", type = "string")
+            LocalDateTime modifiedAt
+    ) {
+    }
 }

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -3,6 +3,8 @@ package codezap.template.dto.response;
 import java.time.LocalDateTime;
 import java.util.List;
 
+import codezap.template.domain.Tag;
+import codezap.template.domain.Template;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FindAllTemplatesResponse(
@@ -24,5 +26,16 @@ public record FindAllTemplatesResponse(
             @Schema(description = "템플릿 수정 시간", example = "2024-11-11 12:00", type = "string")
             LocalDateTime modifiedAt
     ) {
+        public static ItemResponse of(Template template, List<Tag> templateTags) {
+        return new ItemResponse(
+                template.getId(),
+                template.getTitle(),
+                template.getDescription(),
+                templateTags.stream()
+                        .map(tag -> new FindTagResponse(tag.getId(), tag.getName()))
+                        .toList(),
+                template.getModifiedAt()
+        );
+    }
     }
 }

--- a/backend/src/main/java/codezap/template/repository/TagRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TagRepository.java
@@ -1,13 +1,24 @@
 package codezap.template.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
 
+import codezap.global.exception.CodeZapException;
 import codezap.template.domain.Tag;
 
 public interface TagRepository extends JpaRepository<Tag, Long> {
+
+    default Tag fetchById(Long id) {
+        return findById(id).orElseThrow(
+                () -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 태그가 존재하지 않습니다."));
+    }
+
     boolean existsByName(String name);
 
     Optional<Tag> findByName(String name);
+
+    List<Tag> findByNameIn(List<String> tagNames);
 }

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -28,4 +28,10 @@ public interface TemplateRepository extends JpaRepository<Template, Long> {
 
     Page<Template> findByIdInAndCategoryId(PageRequest pageRequest, List<Long> templateIds, Long categoryId);
 
+    long countByCategoryId(Long categoryId);
+
+    long countByIdInAndCategoryId(List<Long> templateIds, Long categoryId);
+
+    long countByIdIn(List<Long> templateIds);
+
 }

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -1,5 +1,10 @@
 package codezap.template.repository;
 
+import java.util.List;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 
@@ -14,4 +19,13 @@ public interface TemplateRepository extends JpaRepository<Template, Long> {
     }
 
     boolean existsByCategoryId(Long categoryId);
+
+    Page<Template> findBy(Pageable pageable);
+
+    Page<Template> findByCategoryId(Pageable pageable, Long categoryId);
+
+    Page<Template> findByIdIn(PageRequest pageRequest, List<Long> templateIds);
+
+    Page<Template> findByIdInAndCategoryId(PageRequest pageRequest, List<Long> templateIds, Long categoryId);
+
 }

--- a/backend/src/main/java/codezap/template/repository/TemplateTagRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateTagRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import codezap.template.domain.Tag;
 import codezap.template.domain.Template;
 import codezap.template.domain.TemplateTag;
 
@@ -12,4 +13,6 @@ public interface TemplateTagRepository extends JpaRepository<TemplateTag, Long> 
     List<TemplateTag> findAllByTemplate(Template template);
 
     void deleteAllByTemplateId(Long id);
+
+    List<TemplateTag> findByTagIn(List<Tag> tags);
 }

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -113,7 +113,6 @@ public class TemplateService {
         return FindTemplateResponse.of(template, snippets, tags);
     }
 
-
     public FindAllTemplatesResponse findAllBy(
             //long memberId,
             PageRequest pageRequest,
@@ -124,20 +123,24 @@ public class TemplateService {
             List<Long> templateIds = filterTemplatesBy(tagNames);
             Page<Template> templatePage =
                     templateRepository.findByIdInAndCategoryId(pageRequest, templateIds, categoryId);
-            return makeTemplatesResponseBy(templatePage);
+            long totalTemplatesCount = templateRepository.countByIdInAndCategoryId(templateIds, categoryId);
+            return makeTemplatesResponseBy(totalTemplatesCount, templatePage);
 
         }
         if (categoryId != null && tagNames == null) {
             Page<Template> templatePage = templateRepository.findByCategoryId(pageRequest, categoryId);
-            return makeTemplatesResponseBy(templatePage);
+            long totalTemplatesCount = templateRepository.countByCategoryId(categoryId);
+            return makeTemplatesResponseBy(totalTemplatesCount, templatePage);
         }
         if (categoryId == null && tagNames != null) {
             List<Long> templateIds = filterTemplatesBy(tagNames);
             Page<Template> templatePage = templateRepository.findByIdIn(pageRequest, templateIds);
-            return makeTemplatesResponseBy(templatePage);
+            long totalTemplatesCount = templateRepository.countByIdIn(templateIds);
+            return makeTemplatesResponseBy(totalTemplatesCount, templatePage);
         }
         Page<Template> templatePage = templateRepository.findBy(pageRequest);
-        return makeTemplatesResponseBy(templatePage);
+        long totalTemplatesCount = templateRepository.count();
+        return makeTemplatesResponseBy(totalTemplatesCount, templatePage);
     }
 
     private List<Long> filterTemplatesBy(List<String> tagNames) {
@@ -149,11 +152,11 @@ public class TemplateService {
                 .toList();
     }
 
-    private FindAllTemplatesResponse makeTemplatesResponseBy(Page<Template> page) {
+    private FindAllTemplatesResponse makeTemplatesResponseBy(long totalTemplatesCount, Page<Template> page) {
         List<ItemResponse> itemResponses = page.stream()
                 .map(template -> ItemResponse.of(template, getTemplateTags(template)))
                 .toList();
-        return new FindAllTemplatesResponse(page.getTotalPages(), itemResponses);
+        return new FindAllTemplatesResponse(page.getTotalPages(), totalTemplatesCount, itemResponses);
     }
 
     private List<Tag> getTemplateTags(Template template) {

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -19,6 +19,7 @@ import codezap.template.dto.request.CreateSnippetRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateSnippetRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.dto.response.ExploreTemplatesResponse;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import codezap.template.repository.SnippetRepository;
@@ -95,8 +96,8 @@ public class TemplateService {
         );
     }
 
-    public FindAllTemplatesResponse findAll() {
-        return FindAllTemplatesResponse.from(thumbnailSnippetRepository.findAll());
+    public ExploreTemplatesResponse findAll() {
+        return ExploreTemplatesResponse.from(thumbnailSnippetRepository.findAll());
     }
 
     public FindTemplateResponse findById(Long id) {

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -188,7 +188,7 @@ class TemplateControllerTest {
     }
 
     @Test
-    @DisplayName("템플릿 전체 조회 성공")
+    @DisplayName("템플릿 전체 탐색 성공")
     void findAllTemplatesSuccess() {
         // given
         categoryService.create(new CreateCategoryRequest("category"));
@@ -199,7 +199,7 @@ class TemplateControllerTest {
 
         // when & then
         RestAssured.given().log().all()
-                .get("/templates")
+                .get("/templates/explore")
                 .then().log().all()
                 .statusCode(200)
                 .body("templates.size()", is(2));

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -147,8 +147,10 @@ class TemplateServiceTest {
 
             assertAll(
                     () -> assertThat(allBy.templates().size()).isEqualTo(20),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20)
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20),
+                    () -> assertThat(allBy.totalElement()).isEqualTo(30)
             );
+
         }
 
         @Test
@@ -158,7 +160,8 @@ class TemplateServiceTest {
 
             assertAll(
                     () -> assertThat(allBy.templates().size()).isEqualTo(10),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() > 20)
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() > 20),
+                    () -> assertThat(allBy.totalElement()).isEqualTo(30)
             );
         }
 
@@ -170,7 +173,8 @@ class TemplateServiceTest {
 
             assertAll(
                     () -> assertThat(allBy.templates().size()).isEqualTo(15),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 1)
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 1),
+                    () -> assertThat(allBy.totalElement()).isEqualTo(15)
             );
         }
 
@@ -182,7 +186,8 @@ class TemplateServiceTest {
 
             assertAll(
                     () -> assertThat(allBy.templates().size()).isEqualTo(15),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16)
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16),
+                    () -> assertThat(allBy.totalElement()).isEqualTo(15)
             );
         }
 
@@ -194,7 +199,8 @@ class TemplateServiceTest {
 
             assertAll(
                     () -> assertThat(allBy.templates().size()).isEqualTo(20),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 21)
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 21),
+                    () -> assertThat(allBy.totalElement()).isEqualTo(30)
             );
         }
 
@@ -207,7 +213,8 @@ class TemplateServiceTest {
             assertAll(
                     () -> assertThat(allBy.templates().size()).isEqualTo(8),
                     () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 1)
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 1),
+                    () -> assertThat(allBy.totalElement()).isEqualTo(8)
             );
         }
     }

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -26,6 +26,7 @@ import codezap.template.dto.request.CreateSnippetRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateSnippetRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.dto.response.ExploreTemplatesResponse;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import codezap.template.repository.SnippetRepository;
@@ -96,7 +97,7 @@ class TemplateServiceTest {
         saveTemplate(makeTemplateRequest("title2"));
 
         // when
-        FindAllTemplatesResponse allTemplates = templateService.findAll();
+        ExploreTemplatesResponse allTemplates = templateService.findAll();
 
         // then
         assertThat(allTemplates.templates()).hasSize(2);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #201

## 📍주요 변경 사항
1. 카테고리, 태그를 필터링 조건으로 목록을 조회합니다.

## 🎸기타
1. 동적 쿼리를 사용하기 위해 추후 QueryDsl, 또는 그 이외의 라이브러리를 학습해 리팩토링 할 예정입니다.
2. 유저 도메인이 추가되면 유저 정보를 필터링 조건에 추가할 예정입니다.