### PR TITLE
템플릿, 카테고리 CRUD에 멤버 정보 추가

### DIFF
--- a/backend/src/main/java/codezap/category/controller/CategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/CategoryController.java
@@ -18,6 +18,8 @@ import codezap.category.dto.request.UpdateCategoryRequest;
 import codezap.category.dto.response.FindAllCategoriesResponse;
 import codezap.category.service.CategoryService;
 import codezap.global.validation.ValidationSequence;
+import codezap.member.configuration.BasicAuthentication;
+import codezap.member.dto.MemberDto;
 
 @RestController
 @RequestMapping("/categories")
@@ -31,9 +33,10 @@ public class CategoryController implements SpringDocCategoryController {
 
     @PostMapping
     public ResponseEntity<Void> createCategory(
-            @Validated(ValidationSequence.class) @RequestBody CreateCategoryRequest createCategoryRequest
+            @Validated(ValidationSequence.class) @RequestBody CreateCategoryRequest createCategoryRequest,
+            @BasicAuthentication MemberDto memberDto
     ) {
-        Long createdCategoryId = categoryService.create(createCategoryRequest);
+        Long createdCategoryId = categoryService.create(createCategoryRequest, memberDto);
         return ResponseEntity.created(URI.create("/categories/" + createdCategoryId))
                 .build();
     }
@@ -55,6 +58,7 @@ public class CategoryController implements SpringDocCategoryController {
     @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
         categoryService.deleteById(id);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.noContent()
+                .build();
     }
 }

--- a/backend/src/main/java/codezap/category/controller/CategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/CategoryController.java
@@ -42,8 +42,8 @@ public class CategoryController implements SpringDocCategoryController {
     }
 
     @GetMapping
-    public ResponseEntity<FindAllCategoriesResponse> getCategories() {
-        return ResponseEntity.ok(categoryService.findAll());
+    public ResponseEntity<FindAllCategoriesResponse> getCategories(@BasicAuthentication MemberDto memberDto) {
+        return ResponseEntity.ok(categoryService.findAllByMember(memberDto));
     }
 
     @PutMapping("/{id}")

--- a/backend/src/main/java/codezap/category/controller/CategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/CategoryController.java
@@ -57,8 +57,8 @@ public class CategoryController implements SpringDocCategoryController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteCategory(@PathVariable Long id) {
-        categoryService.deleteById(id);
+    public ResponseEntity<Void> deleteCategory(@PathVariable Long id, @BasicAuthentication MemberDto memberDto) {
+        categoryService.deleteById(id, memberDto);
         return ResponseEntity.noContent()
                 .build();
     }

--- a/backend/src/main/java/codezap/category/controller/CategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/CategoryController.java
@@ -49,9 +49,10 @@ public class CategoryController implements SpringDocCategoryController {
     @PutMapping("/{id}")
     public ResponseEntity<Void> updateCategory(
             @PathVariable Long id,
-            @Validated(ValidationSequence.class) @RequestBody UpdateCategoryRequest updateCategoryRequest
+            @Validated(ValidationSequence.class) @RequestBody UpdateCategoryRequest updateCategoryRequest,
+            @BasicAuthentication MemberDto memberDto
     ) {
-        categoryService.update(id, updateCategoryRequest);
+        categoryService.update(id, updateCategoryRequest, memberDto);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
@@ -53,5 +53,5 @@ public interface SpringDocCategoryController {
             @ErrorCase(description = "삭제하려는 카테고리에 템플릿이 존재하는 경우",
                     exampleMessage = "템플릿이 존재하는 카테고리는 삭제할 수 없습니다."),
     })
-    ResponseEntity<Void> deleteCategory(Long id);
+    ResponseEntity<Void> deleteCategory(Long id, MemberDto memberDto);
 }

--- a/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
@@ -45,7 +45,7 @@ public interface SpringDocCategoryController {
             @ErrorCase(description = "동일한 이름의 카테고리가 존재하는 경우",
                     exampleMessage = "이름이 Spring 인 카테고리가 이미 존재합니다.")
     })
-    ResponseEntity<Void> updateCategory(Long id, UpdateCategoryRequest updateCategoryRequest);
+    ResponseEntity<Void> updateCategory(Long id, UpdateCategoryRequest updateCategoryRequest, MemberDto memberDto);
 
     @Operation(summary = "카테고리 삭제", description = "해당하는 식별자의 카테고리를 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "카테고리 삭제 성공")

--- a/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
@@ -8,6 +8,7 @@ import codezap.category.dto.request.UpdateCategoryRequest;
 import codezap.category.dto.response.FindAllCategoriesResponse;
 import codezap.global.swagger.error.ApiErrorResponse;
 import codezap.global.swagger.error.ErrorCase;
+import codezap.member.dto.MemberDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.headers.Header;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -29,7 +30,7 @@ public interface SpringDocCategoryController {
             @ErrorCase(description = "카테고리 이름이 255자를 초과한 경우", exampleMessage = "카테고리 이름은 최대 255자까지 입력 가능합니다."),
             @ErrorCase(description = "동일한 이름의 카테고리가 존재하는 경우", exampleMessage = "이름이 Spring 인 카테고리가 이미 존재합니다.")
     })
-    ResponseEntity<Void> createCategory(CreateCategoryRequest createCategoryRequest);
+    ResponseEntity<Void> createCategory(CreateCategoryRequest createCategoryRequest, MemberDto memberDto);
 
     @Operation(summary = "카테고리 목록 조회", description = "생성된 모든 카테고리를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",

--- a/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
+++ b/backend/src/main/java/codezap/category/controller/SpringDocCategoryController.java
@@ -35,7 +35,7 @@ public interface SpringDocCategoryController {
     @Operation(summary = "카테고리 목록 조회", description = "생성된 모든 카테고리를 조회합니다.")
     @ApiResponse(responseCode = "200", description = "조회 성공",
             content = {@Content(schema = @Schema(implementation = FindAllCategoriesResponse.class))})
-    ResponseEntity<FindAllCategoriesResponse> getCategories();
+    ResponseEntity<FindAllCategoriesResponse> getCategories(MemberDto memberDto);
 
     @Operation(summary = "카테고리 수정", description = "해당하는 식별자의 카테고리를 수정합니다.")
     @ApiResponse(responseCode = "200", description = "카테고리 수정 성공")

--- a/backend/src/main/java/codezap/category/domain/Category.java
+++ b/backend/src/main/java/codezap/category/domain/Category.java
@@ -7,6 +7,8 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 
 import codezap.global.auditing.BaseTimeEntity;
 import codezap.member.domain.Member;
@@ -19,6 +21,14 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
+@Table(
+        uniqueConstraints={
+                @UniqueConstraint(
+                        name="name_with_member",
+                        columnNames={"member_id", "name"}
+                )
+        }
+)
 public class Category extends BaseTimeEntity {
 
     private static final String DEFAULT_CATEGORY_NAME = "카테고리 없음";
@@ -30,7 +40,7 @@ public class Category extends BaseTimeEntity {
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Member member;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false)
     private String name;
 
     @Column(nullable = false)

--- a/backend/src/main/java/codezap/category/domain/Category.java
+++ b/backend/src/main/java/codezap/category/domain/Category.java
@@ -11,11 +11,13 @@ import jakarta.persistence.ManyToOne;
 import codezap.global.auditing.BaseTimeEntity;
 import codezap.member.domain.Member;
 import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 @Getter
 public class Category extends BaseTimeEntity {
     @Id
@@ -28,9 +30,16 @@ public class Category extends BaseTimeEntity {
     @Column(nullable = false, unique = true)
     private String name;
 
+    @Column(nullable = false)
+    private Boolean isDefault;
+
     public Category(String name, Member member) {
         this.name = name;
         this.member = member;
+    }
+
+    public static Category createDefaultCategory(Member member) {
+        return new Category(null, member, "카테고리 없음", true);
     }
 
     public void updateName(String name) {

--- a/backend/src/main/java/codezap/category/domain/Category.java
+++ b/backend/src/main/java/codezap/category/domain/Category.java
@@ -36,6 +36,7 @@ public class Category extends BaseTimeEntity {
     public Category(String name, Member member) {
         this.name = name;
         this.member = member;
+        this.isDefault = false;
     }
 
     public static Category createDefaultCategory(Member member) {

--- a/backend/src/main/java/codezap/category/domain/Category.java
+++ b/backend/src/main/java/codezap/category/domain/Category.java
@@ -20,6 +20,9 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class Category extends BaseTimeEntity {
+
+    private static final String DEFAULT_CATEGORY_NAME = "카테고리 없음";
+
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
@@ -40,7 +43,7 @@ public class Category extends BaseTimeEntity {
     }
 
     public static Category createDefaultCategory(Member member) {
-        return new Category(null, member, "카테고리 없음", true);
+        return new Category(null, member, DEFAULT_CATEGORY_NAME, true);
     }
 
     public void updateName(String name) {

--- a/backend/src/main/java/codezap/category/domain/Category.java
+++ b/backend/src/main/java/codezap/category/domain/Category.java
@@ -2,11 +2,14 @@ package codezap.category.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.ManyToOne;
 
 import codezap.global.auditing.BaseTimeEntity;
+import codezap.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -19,11 +22,15 @@ public class Category extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Member member;
+
     @Column(nullable = false, unique = true)
     private String name;
 
-    public Category(String name) {
+    public Category(String name, Member member) {
         this.name = name;
+        this.member = member;
     }
 
     public void updateName(String name) {

--- a/backend/src/main/java/codezap/category/repository/CategoryJpaRepository.java
+++ b/backend/src/main/java/codezap/category/repository/CategoryJpaRepository.java
@@ -1,0 +1,23 @@
+package codezap.category.repository;
+
+import java.util.List;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
+
+import codezap.category.domain.Category;
+import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+
+@SuppressWarnings("unused")
+public interface CategoryJpaRepository extends CategoryRepository, JpaRepository<Category, Long> {
+
+    default Category fetchById(Long id) {
+        return findById(id).orElseThrow(
+                () -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다."));
+    }
+
+    List<Category> findAllByMember(Member member);
+
+    boolean existsByNameAndMember(String categoryName, Member member);
+}

--- a/backend/src/main/java/codezap/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/codezap/category/repository/CategoryRepository.java
@@ -2,21 +2,20 @@ package codezap.category.repository;
 
 import java.util.List;
 
-import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.http.HttpStatus;
-
 import codezap.category.domain.Category;
-import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 
-public interface CategoryRepository extends JpaRepository<Category, Long> {
+public interface CategoryRepository {
 
-    default Category fetchById(Long id) {
-        return findById(id).orElseThrow(
-                () -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다."));
-    }
+    Category fetchById(Long id);
 
     List<Category> findAllByMember(Member member);
 
+    List<Category> findAll();
+
     boolean existsByNameAndMember(String categoryName, Member member);
+
+    Category save(Category category);
+
+    void deleteById(Long id);
 }

--- a/backend/src/main/java/codezap/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/codezap/category/repository/CategoryRepository.java
@@ -1,10 +1,13 @@
 package codezap.category.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.http.HttpStatus;
 
 import codezap.category.domain.Category;
 import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
 
 public interface CategoryRepository extends JpaRepository<Category, Long> {
 
@@ -13,5 +16,7 @@ public interface CategoryRepository extends JpaRepository<Category, Long> {
                 () -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다."));
     }
 
-    boolean existsByName(String name);
+    List<Category> findAllByMember(Member member);
+
+    boolean existsByNameAndMember(String categoryName, Member member);
 }

--- a/backend/src/main/java/codezap/category/service/CategoryService.java
+++ b/backend/src/main/java/codezap/category/service/CategoryService.java
@@ -10,6 +10,9 @@ import codezap.category.dto.request.UpdateCategoryRequest;
 import codezap.category.dto.response.FindAllCategoriesResponse;
 import codezap.category.repository.CategoryRepository;
 import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+import codezap.member.dto.MemberDto;
+import codezap.member.repository.MemberJpaRepository;
 import codezap.template.repository.TemplateRepository;
 
 @Service
@@ -18,17 +21,22 @@ public class CategoryService {
     private static final long DEFAULT_CATEGORY = 1L;
     private final CategoryRepository categoryRepository;
     private final TemplateRepository templateRepository;
+    private final MemberJpaRepository memberJpaRepository;
 
-    public CategoryService(CategoryRepository categoryRepository, TemplateRepository templateRepository) {
+    public CategoryService(CategoryRepository categoryRepository, TemplateRepository templateRepository,
+            MemberJpaRepository memberJpaRepository
+    ) {
         this.categoryRepository = categoryRepository;
         this.templateRepository = templateRepository;
+        this.memberJpaRepository = memberJpaRepository;
     }
 
     @Transactional
-    public Long create(CreateCategoryRequest createCategoryRequest) {
+    public Long create(CreateCategoryRequest createCategoryRequest, MemberDto memberDto) {
         String categoryName = createCategoryRequest.name();
         validateDuplicatedCategory(categoryName);
-        Category category = new Category(categoryName);
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        Category category = new Category(categoryName, member);
         return categoryRepository.save(category).getId();
     }
 

--- a/backend/src/main/java/codezap/category/service/CategoryService.java
+++ b/backend/src/main/java/codezap/category/service/CategoryService.java
@@ -50,15 +50,23 @@ public class CategoryService {
     }
 
     @Transactional
-    public void update(Long id, UpdateCategoryRequest updateCategoryRequest) {
-        validateDuplicatedCategory(updateCategoryRequest.name(), null);
+    public void update(Long id, UpdateCategoryRequest updateCategoryRequest, MemberDto memberDto) {
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        validateDuplicatedCategory(updateCategoryRequest.name(), member);
         Category category = categoryRepository.fetchById(id);
+        validateAuthorizeMember(category, member);
         category.updateName(updateCategoryRequest.name());
     }
 
     private void validateDuplicatedCategory(String categoryName, Member member) {
         if (categoryRepository.existsByNameAndMember(categoryName, member)) {
             throw new CodeZapException(HttpStatus.CONFLICT, "이름이 " + categoryName + "인 카테고리가 이미 존재합니다.");
+        }
+    }
+
+    private void validateAuthorizeMember(Category category, Member member) {
+        if (category.getMember().equals(member)) {
+            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리를 수정할 권한이 없는 유저입니다.");
         }
     }
 

--- a/backend/src/main/java/codezap/category/service/CategoryService.java
+++ b/backend/src/main/java/codezap/category/service/CategoryService.java
@@ -80,7 +80,7 @@ public class CategoryService {
 
     private void validateAuthorizeMember(Category category, Member member) {
         if (!category.getMember().equals(member)) {
-            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리를 수정할 권한이 없는 유저입니다.");
+            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리를 수정 또는 삭제할 권한이 없는 유저입니다.");
         }
     }
 }

--- a/backend/src/main/java/codezap/category/service/CategoryService.java
+++ b/backend/src/main/java/codezap/category/service/CategoryService.java
@@ -64,19 +64,23 @@ public class CategoryService {
         }
     }
 
-    private void validateAuthorizeMember(Category category, Member member) {
-        if (category.getMember().equals(member)) {
-            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리를 수정할 권한이 없는 유저입니다.");
-        }
-    }
+    public void deleteById(Long id, MemberDto memberDto) {
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        Category category = categoryRepository.fetchById(id);
+        validateAuthorizeMember(category, member);
 
-    public void deleteById(Long id) {
         if (templateRepository.existsByCategoryId(id)) {
             throw new CodeZapException(HttpStatus.BAD_REQUEST, "템플릿이 존재하는 카테고리는 삭제할 수 없습니다.");
         }
-        if (id == DEFAULT_CATEGORY) {
+        if (category.getIsDefault()) {
             throw new CodeZapException(HttpStatus.BAD_REQUEST, "기본 카테고리는 삭제할 수 없습니다.");
         }
         categoryRepository.deleteById(id);
+    }
+
+    private void validateAuthorizeMember(Category category, Member member) {
+        if (!category.getMember().equals(member)) {
+            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리를 수정할 권한이 없는 유저입니다.");
+        }
     }
 }

--- a/backend/src/main/java/codezap/category/service/CategoryService.java
+++ b/backend/src/main/java/codezap/category/service/CategoryService.java
@@ -8,25 +8,26 @@ import codezap.category.domain.Category;
 import codezap.category.dto.request.CreateCategoryRequest;
 import codezap.category.dto.request.UpdateCategoryRequest;
 import codezap.category.dto.response.FindAllCategoriesResponse;
+import codezap.category.repository.CategoryJpaRepository;
 import codezap.category.repository.CategoryRepository;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.dto.MemberDto;
 import codezap.member.repository.MemberJpaRepository;
+import codezap.member.repository.MemberRepository;
 import codezap.template.repository.TemplateRepository;
 
 @Service
 public class CategoryService {
 
-    public static final int DEFAULT_CATEGORY = 1;
-    private final CategoryRepository categoryRepository;
+    private final CategoryRepository categoryJpaRepository;
     private final TemplateRepository templateRepository;
-    private final MemberJpaRepository memberJpaRepository;
+    private final MemberRepository memberJpaRepository;
 
-    public CategoryService(CategoryRepository categoryRepository, TemplateRepository templateRepository,
+    public CategoryService(CategoryJpaRepository categoryJpaRepository, TemplateRepository templateRepository,
             MemberJpaRepository memberJpaRepository
     ) {
-        this.categoryRepository = categoryRepository;
+        this.categoryJpaRepository = categoryJpaRepository;
         this.templateRepository = templateRepository;
         this.memberJpaRepository = memberJpaRepository;
     }
@@ -37,36 +38,36 @@ public class CategoryService {
         Member member = memberJpaRepository.fetchById(memberDto.id());
         validateDuplicatedCategory(categoryName, member);
         Category category = new Category(categoryName, member);
-        return categoryRepository.save(category).getId();
+        return categoryJpaRepository.save(category).getId();
     }
 
     public FindAllCategoriesResponse findAllByMember(MemberDto memberDto) {
         Member member = memberJpaRepository.fetchById(memberDto.id());
-        return FindAllCategoriesResponse.from(categoryRepository.findAllByMember(member));
+        return FindAllCategoriesResponse.from(categoryJpaRepository.findAllByMember(member));
     }
 
     public FindAllCategoriesResponse findAll() {
-        return FindAllCategoriesResponse.from(categoryRepository.findAll());
+        return FindAllCategoriesResponse.from(categoryJpaRepository.findAll());
     }
 
     @Transactional
     public void update(Long id, UpdateCategoryRequest updateCategoryRequest, MemberDto memberDto) {
         Member member = memberJpaRepository.fetchById(memberDto.id());
         validateDuplicatedCategory(updateCategoryRequest.name(), member);
-        Category category = categoryRepository.fetchById(id);
+        Category category = categoryJpaRepository.fetchById(id);
         validateAuthorizeMember(category, member);
         category.updateName(updateCategoryRequest.name());
     }
 
     private void validateDuplicatedCategory(String categoryName, Member member) {
-        if (categoryRepository.existsByNameAndMember(categoryName, member)) {
+        if (categoryJpaRepository.existsByNameAndMember(categoryName, member)) {
             throw new CodeZapException(HttpStatus.CONFLICT, "이름이 " + categoryName + "인 카테고리가 이미 존재합니다.");
         }
     }
 
     public void deleteById(Long id, MemberDto memberDto) {
         Member member = memberJpaRepository.fetchById(memberDto.id());
-        Category category = categoryRepository.fetchById(id);
+        Category category = categoryJpaRepository.fetchById(id);
         validateAuthorizeMember(category, member);
 
         if (templateRepository.existsByCategoryId(id)) {
@@ -75,12 +76,12 @@ public class CategoryService {
         if (category.getIsDefault()) {
             throw new CodeZapException(HttpStatus.BAD_REQUEST, "기본 카테고리는 삭제할 수 없습니다.");
         }
-        categoryRepository.deleteById(id);
+        categoryJpaRepository.deleteById(id);
     }
 
     private void validateAuthorizeMember(Category category, Member member) {
         if (!category.getMember().equals(member)) {
-            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리를 수정 또는 삭제할 권한이 없는 유저입니다.");
+            throw new CodeZapException(HttpStatus.UNAUTHORIZED, "해당 카테고리를 수정 또는 삭제할 권한이 없는 유저입니다.");
         }
     }
 }

--- a/backend/src/main/java/codezap/member/repository/MemberJpaRepository.java
+++ b/backend/src/main/java/codezap/member/repository/MemberJpaRepository.java
@@ -3,11 +3,18 @@ package codezap.member.repository;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.http.HttpStatus;
 
+import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 
 @SuppressWarnings("unused")
 public interface MemberJpaRepository extends MemberRepository, JpaRepository<Member, Long> {
+
+    default Member fetchById(Long id) {
+        return findById(id).orElseThrow(
+                () -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 멤버가 존재하지 않습니다."));
+    }
 
     boolean existsByEmail(String email);
 

--- a/backend/src/main/java/codezap/member/repository/MemberRepository.java
+++ b/backend/src/main/java/codezap/member/repository/MemberRepository.java
@@ -6,6 +6,8 @@ import codezap.member.domain.Member;
 
 public interface MemberRepository {
 
+    Member fetchById(Long id);
+
     boolean existsByEmail(String email);
 
     boolean existsByUsername(String username);

--- a/backend/src/main/java/codezap/member/service/MemberService.java
+++ b/backend/src/main/java/codezap/member/service/MemberService.java
@@ -5,6 +5,8 @@ import jakarta.servlet.http.Cookie;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.dto.LoginRequest;
@@ -19,11 +21,13 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final AuthService authService;
+    private final CategoryRepository categoryRepository;
 
     public Member signup(SignupRequest request) {
         assertUniqueEmail(request.email());
         assertUniqueUsername(request.username());
         Member member = new Member(request.email(), request.password(), request.username());
+        categoryRepository.save(Category.createDefaultCategory(member));
         return memberRepository.save(member);
     }
 

--- a/backend/src/main/java/codezap/member/service/MemberService.java
+++ b/backend/src/main/java/codezap/member/service/MemberService.java
@@ -21,13 +21,13 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final AuthService authService;
-    private final CategoryRepository categoryRepository;
+    private final CategoryRepository categoryJpaRepository;
 
     public Member signup(SignupRequest request) {
         assertUniqueEmail(request.email());
         assertUniqueUsername(request.username());
         Member member = new Member(request.email(), request.password(), request.username());
-        categoryRepository.save(Category.createDefaultCategory(member));
+        categoryJpaRepository.save(Category.createDefaultCategory(member));
         return memberRepository.save(member);
     }
 

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -71,7 +71,7 @@ public interface SpringDocTemplateController {
     @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
     })
-    ResponseEntity<Void> updateTemplate(Long id, UpdateTemplateRequest updateTemplateRequest);
+    ResponseEntity<Void> updateTemplate(Long id, UpdateTemplateRequest updateTemplateRequest, MemberDto memberDto);
 
     @Operation(summary = "템플릿 삭제", description = "해당하는 식별자의 템플릿을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "템플릿 삭제 성공")

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -7,6 +7,7 @@ import org.springframework.http.ResponseEntity;
 
 import codezap.global.swagger.error.ApiErrorResponse;
 import codezap.global.swagger.error.ErrorCase;
+import codezap.member.dto.MemberDto;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.ExploreTemplatesResponse;
@@ -39,7 +40,7 @@ public interface SpringDocTemplateController {
             @ErrorCase(description = "스니펫 순서가 잘못된 경우", exampleMessage = "스니펫 순서가 잘못되었습니다."),
             @ErrorCase(description = "스니펫 내용 65,535 byte를 초과한 경우", exampleMessage = "파일 내용은 최대 65,535 byte까지 입력 가능합니다.")
     })
-    ResponseEntity<Void> create(CreateTemplateRequest createTemplateRequest);
+    ResponseEntity<Void> create(CreateTemplateRequest createTemplateRequest, MemberDto memberDto);
 
     @Operation(summary = "템플릿 목록 조회", description = """
             조건에 맞는 모든 템플릿을 조회합니다.

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -75,5 +75,5 @@ public interface SpringDocTemplateController {
 
     @Operation(summary = "템플릿 삭제", description = "해당하는 식별자의 템플릿을 삭제합니다.")
     @ApiResponse(responseCode = "204", description = "템플릿 삭제 성공")
-    ResponseEntity<Void> deleteTemplate(Long id);
+    ResponseEntity<Void> deleteTemplate(Long id, MemberDto memberDto);
 }

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -64,7 +64,7 @@ public interface SpringDocTemplateController {
     @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "해당하는 id 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
     })
-    ResponseEntity<FindTemplateResponse> getTemplateById(Long id);
+    ResponseEntity<FindTemplateResponse> getTemplateById(Long id, MemberDto memberDto);
 
     @Operation(summary = "템플릿 수정", description = "해당하는 식별자의 템플릿을 수정합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 수정 성공")

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -16,6 +16,8 @@ import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import codezap.global.validation.ValidationSequence;
+import codezap.member.configuration.BasicAuthentication;
+import codezap.member.dto.MemberDto;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.ExploreTemplatesResponse;
@@ -35,9 +37,10 @@ public class TemplateController implements SpringDocTemplateController {
 
     @PostMapping
     public ResponseEntity<Void> create(
-            @Validated(ValidationSequence.class) @RequestBody CreateTemplateRequest createTemplateRequest
+            @Validated(ValidationSequence.class) @RequestBody CreateTemplateRequest createTemplateRequest,
+            @BasicAuthentication MemberDto memberDto
     ) {
-        Long createdTemplateId = templateService.createTemplate(createTemplateRequest);
+        Long createdTemplateId = templateService.createTemplate(createTemplateRequest, memberDto);
         return ResponseEntity.created(URI.create("/templates/" + createdTemplateId))
                 .build();
     }

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -62,8 +62,8 @@ public class TemplateController implements SpringDocTemplateController {
     }
 
     @GetMapping("/{id}")
-    public ResponseEntity<FindTemplateResponse> getTemplateById(@PathVariable Long id) {
-        return ResponseEntity.ok(templateService.findById(id));
+    public ResponseEntity<FindTemplateResponse> getTemplateById(@PathVariable Long id, @BasicAuthentication MemberDto memberDto) {
+        return ResponseEntity.ok(templateService.findByIdAndMember(id, memberDto));
     }
 
     @PostMapping("/{id}")

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -69,9 +69,10 @@ public class TemplateController implements SpringDocTemplateController {
     @PostMapping("/{id}")
     public ResponseEntity<Void> updateTemplate(
             @PathVariable Long id,
-            @Validated(ValidationSequence.class) @RequestBody UpdateTemplateRequest updateTemplateRequest
+            @Validated(ValidationSequence.class) @RequestBody UpdateTemplateRequest updateTemplateRequest,
+            @BasicAuthentication MemberDto memberDto
     ) {
-        templateService.update(id, updateTemplateRequest);
+        templateService.update(id, updateTemplateRequest, memberDto);
         return ResponseEntity.ok().build();
     }
 

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -77,8 +77,8 @@ public class TemplateController implements SpringDocTemplateController {
     }
 
     @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteTemplate(@PathVariable Long id) {
-        templateService.deleteById(id);
+    public ResponseEntity<Void> deleteTemplate(@PathVariable Long id, @BasicAuthentication MemberDto memberDto) {
+        templateService.deleteById(id, memberDto);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -2,6 +2,7 @@ package codezap.template.domain;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
@@ -9,6 +10,7 @@ import jakarta.persistence.ManyToOne;
 
 import codezap.category.domain.Category;
 import codezap.global.auditing.BaseTimeEntity;
+import codezap.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -22,6 +24,9 @@ public class Template extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    private Member member;
+
     @Column(nullable = false)
     private String title;
 
@@ -31,7 +36,8 @@ public class Template extends BaseTimeEntity {
     @ManyToOne(optional = false)
     private Category category;
 
-    public Template(String title, String description, Category category) {
+    public Template(Member member, String title, String description, Category category) {
+        this.member = member;
         this.title = title;
         this.description = description;
         this.category = category;

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -12,6 +12,9 @@ import org.springframework.transaction.annotation.Transactional;
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
 import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+import codezap.member.dto.MemberDto;
+import codezap.member.repository.MemberJpaRepository;
 import codezap.template.domain.Snippet;
 import codezap.template.domain.Tag;
 import codezap.template.domain.Template;
@@ -43,11 +46,13 @@ public class TemplateService {
     private final CategoryRepository categoryRepository;
     private final TagRepository tagRepository;
     private final TemplateTagRepository templateTagRepository;
+    private final MemberJpaRepository memberJpaRepository;
 
     public TemplateService(ThumbnailSnippetRepository thumbnailSnippetRepository,
             TemplateRepository templateRepository, SnippetRepository snippetRepository,
             CategoryRepository categoryRepository, TagRepository tagRepository,
-            TemplateTagRepository templateTagRepository
+            TemplateTagRepository templateTagRepository,
+            MemberJpaRepository memberJpaRepository
     ) {
         this.thumbnailSnippetRepository = thumbnailSnippetRepository;
         this.templateRepository = templateRepository;
@@ -55,13 +60,15 @@ public class TemplateService {
         this.categoryRepository = categoryRepository;
         this.tagRepository = tagRepository;
         this.templateTagRepository = templateTagRepository;
+        this.memberJpaRepository = memberJpaRepository;
     }
 
     @Transactional
-    public Long createTemplate(CreateTemplateRequest createTemplateRequest) {
+    public Long createTemplate(CreateTemplateRequest createTemplateRequest, MemberDto memberDto) {
+        Member member = memberJpaRepository.fetchById(memberDto.id());
         Category category = categoryRepository.fetchById(createTemplateRequest.categoryId());
         Template template = templateRepository.save(
-                new Template(createTemplateRequest.title(), createTemplateRequest.description(), category)
+                new Template(member, createTemplateRequest.title(), createTemplateRequest.description(), category)
         );
         createTags(createTemplateRequest, template);
         snippetRepository.saveAll(

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -124,7 +124,7 @@ public class TemplateService {
 
     private void validateAuthorizeMember(Template template, Member member) {
         if (!template.getMember().equals(member)) {
-            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 템플릿을 열람할 권한이 없는 유저입니다.");
+            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 템플릿에 대한 권한이 없는 유저입니다.");
         }
     }
 
@@ -181,9 +181,12 @@ public class TemplateService {
     }
 
     @Transactional
-    public void update(Long templateId, UpdateTemplateRequest updateTemplateRequest) {
+    public void update(Long templateId, UpdateTemplateRequest updateTemplateRequest, MemberDto memberDto) {
+        Member member = memberJpaRepository.fetchById(memberDto.id());
         Category category = categoryRepository.fetchById(updateTemplateRequest.categoryId());
         Template template = templateRepository.fetchById(templateId);
+        validateAuthorizeMember(template, member);
+
         template.updateTemplate(updateTemplateRequest.title(), updateTemplateRequest.description(), category);
         updateSnippets(updateTemplateRequest, template);
         updateTags(updateTemplateRequest, template);

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -10,7 +10,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
+import codezap.category.repository.CategoryJpaRepository;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.dto.MemberDto;
@@ -42,21 +42,21 @@ public class TemplateService {
     private final ThumbnailSnippetRepository thumbnailSnippetRepository;
     private final TemplateRepository templateRepository;
     private final SnippetRepository snippetRepository;
-    private final CategoryRepository categoryRepository;
+    private final CategoryJpaRepository categoryJpaRepository;
     private final TagRepository tagRepository;
     private final TemplateTagRepository templateTagRepository;
     private final MemberJpaRepository memberJpaRepository;
 
     public TemplateService(ThumbnailSnippetRepository thumbnailSnippetRepository,
             TemplateRepository templateRepository, SnippetRepository snippetRepository,
-            CategoryRepository categoryRepository, TagRepository tagRepository,
+            CategoryJpaRepository categoryJpaRepository, TagRepository tagRepository,
             TemplateTagRepository templateTagRepository,
             MemberJpaRepository memberJpaRepository
     ) {
         this.thumbnailSnippetRepository = thumbnailSnippetRepository;
         this.templateRepository = templateRepository;
         this.snippetRepository = snippetRepository;
-        this.categoryRepository = categoryRepository;
+        this.categoryJpaRepository = categoryJpaRepository;
         this.tagRepository = tagRepository;
         this.templateTagRepository = templateTagRepository;
         this.memberJpaRepository = memberJpaRepository;
@@ -65,7 +65,7 @@ public class TemplateService {
     @Transactional
     public Long createTemplate(CreateTemplateRequest createTemplateRequest, MemberDto memberDto) {
         Member member = memberJpaRepository.fetchById(memberDto.id());
-        Category category = categoryRepository.fetchById(createTemplateRequest.categoryId());
+        Category category = categoryJpaRepository.fetchById(createTemplateRequest.categoryId());
         validateCategoryAuthorizeMember(category, member);
         Template template = templateRepository.save(
                 new Template(member, createTemplateRequest.title(), createTemplateRequest.description(), category)
@@ -85,7 +85,7 @@ public class TemplateService {
 
     private void validateCategoryAuthorizeMember(Category category, Member member) {
         if (!category.getMember().equals(member)) {
-            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 카테고리에 대한 권한이 없는 유저입니다.");
+            throw new CodeZapException(HttpStatus.UNAUTHORIZED, "해당 카테고리에 대한 권한이 없는 유저입니다.");
         }
     }
 
@@ -131,7 +131,7 @@ public class TemplateService {
 
     private void validateTemplateAuthorizeMember(Template template, Member member) {
         if (!template.getMember().equals(member)) {
-            throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당 템플릿에 대한 권한이 없는 유저입니다.");
+            throw new CodeZapException(HttpStatus.UNAUTHORIZED, "해당 템플릿에 대한 권한이 없는 유저입니다.");
         }
     }
 
@@ -190,7 +190,7 @@ public class TemplateService {
     @Transactional
     public void update(Long templateId, UpdateTemplateRequest updateTemplateRequest, MemberDto memberDto) {
         Member member = memberJpaRepository.fetchById(memberDto.id());
-        Category category = categoryRepository.fetchById(updateTemplateRequest.categoryId());
+        Category category = categoryJpaRepository.fetchById(updateTemplateRequest.categoryId());
         validateCategoryAuthorizeMember(category, member);
         Template template = templateRepository.fetchById(templateId);
         validateTemplateAuthorizeMember(template, member);
@@ -281,10 +281,10 @@ public class TemplateService {
     }
 
     private CodeZapException throwNotFoundTag() {
-        throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당하는 태그가 존재하지 않습니다.");
+        throw new CodeZapException(HttpStatus.NOT_FOUND, "해당하는 태그가 존재하지 않습니다.");
     }
 
     private CodeZapException throwNotFoundThumbnailSnippet() {
-        throw new CodeZapException(HttpStatus.BAD_REQUEST, "해당하는 썸네일 스니펫이 존재하지 않습니다.");
+        throw new CodeZapException(HttpStatus.NOT_FOUND, "해당하는 썸네일 스니펫이 존재하지 않습니다.");
     }
 }

--- a/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
@@ -1,204 +1,226 @@
-//package codezap.category.controller;
-//
-//import static org.hamcrest.Matchers.is;
-//
-//import java.util.List;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-//import org.springframework.boot.test.web.server.LocalServerPort;
-//import org.springframework.test.context.jdbc.Sql;
-//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-//
-//import codezap.category.dto.request.CreateCategoryRequest;
-//import codezap.category.dto.request.UpdateCategoryRequest;
-//import codezap.category.service.CategoryService;
-//import codezap.template.dto.request.CreateSnippetRequest;
-//import codezap.template.dto.request.CreateTemplateRequest;
-//import codezap.template.service.TemplateService;
-//import io.restassured.RestAssured;
-//import io.restassured.http.ContentType;
-//
-//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-//class CategoryControllerTest {
-//
-//    private static final int MAX_LENGTH = 255;
-//
-//    @LocalServerPort
-//    int port;
-//
-//    @Autowired
-//    private CategoryService categoryService;
-//    @Autowired
-//    private TemplateService templateService;
-//
-//    @BeforeEach
-//    void setting() {
-//        RestAssured.port = port;
-//    }
-//
-//    @Nested
-//    @DisplayName("카테고리 생성 테스트")
-//    class createCategoryTest {
-//        @Test
-//        @DisplayName("카테고리 생성 성공")
-//        void createCategorySuccess() {
-//            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH));
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(createCategoryRequest)
-//                    .when().post("/categories")
-//                    .then().log().all()
-//                    .header("Location", "/categories/1")
-//                    .statusCode(201);
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 생성 실패: 카테고리 이름 길이 초과")
-//        void createCategoryFailWithLongName() {
-//            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH + 1));
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(createCategoryRequest)
-//                    .when().post("/categories")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
-//        }
-//    }
-//
-//    @Test
-//    @DisplayName("카테고리 전체 조회 성공")
-//    void findAllCategoriesSuccess() {
-//        CreateCategoryRequest createCategoryRequest1 = new CreateCategoryRequest("category1");
-//        CreateCategoryRequest createCategoryRequest2 = new CreateCategoryRequest("category2");
-//        categoryService.create(createCategoryRequest1);
-//        categoryService.create(createCategoryRequest2);
-//
-//        RestAssured.given().log().all()
-//                .contentType(ContentType.JSON)
-//                .when().get("/categories")
-//                .then().log().all()
-//                .statusCode(200)
-//                .body("categories.size()", is(2));
-//    }
-//
-//    @Nested
-//    @DisplayName("카테고리 수정 테스트")
-//    class updateCategoryTest {
-//
-//        Long savedCategoryId;
-//
-//        @BeforeEach
-//        void saveCategory() {
-//            savedCategoryId = categoryService.create(new CreateCategoryRequest("category1"));
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 수정 성공")
-//        void updateCategorySuccess() {
-//            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH));
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateCategoryRequest)
-//                    .when().put("/categories/" + savedCategoryId)
-//                    .then().log().all()
-//                    .statusCode(200);
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 수정 실패: 카테고리 이름 길이 초과")
-//        void updateCategoryFailWithLongName() {
-//            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH + 1));
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateCategoryRequest)
-//                    .when().put("/categories/" + savedCategoryId)
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 수정 실패: 중복된 이름의 카테고리 존재")
-//        void updateCategoryFailWithDuplicatedName() {
-//            // given
-//            String duplicatedName = "duplicatedName";
-//            categoryService.create(new CreateCategoryRequest(duplicatedName));
-//
-//            UpdateCategoryRequest createCategoryRequest = new UpdateCategoryRequest(duplicatedName);
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(createCategoryRequest)
-//                    .when().put("/categories/" + savedCategoryId)
-//                    .then().log().all()
-//                    .statusCode(409)
-//                    .body("detail", is("이름이 " + duplicatedName + "인 카테고리가 이미 존재합니다."));
-//        }
-//    }
-//
-//
-//    @Nested
-//    @DisplayName("카테고리 삭제 테스트")
-//    class deleteCategoryTest {
-//
-//        Long savedCategoryId;
-//
-//        @BeforeEach
-//        void saveCategory() {
-//            categoryService.create(new CreateCategoryRequest("category1"));
-//            savedCategoryId = categoryService.create(new CreateCategoryRequest("category2"));
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 삭제 성공")
-//        void deleteCategorySuccess() {
-//            RestAssured.given().log().all()
-//                    .when().delete("/categories/" + savedCategoryId)
-//                    .then().log().all()
-//                    .statusCode(204);
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 수정 성공: 존재하지 않는 카테고리의 삭제 요청")
-//        void updateCategoryFailWithDuplicatedName() {
-//            RestAssured.given().log().all()
-//                    .when().delete("/categories/" + savedCategoryId + 1)
-//                    .then().log().all()
-//                    .statusCode(204);
-//        }
-//
-//        @Test
-//        @DisplayName("카테고리 삭제 실패: 템플릿이 존재하는 카테고리는 삭제 불가능")
-//        void updateCategoryFailWithLongName() {
-//            // given
-//            templateService.createTemplate(new CreateTemplateRequest(
-//                    "title",
-//                    "description",
-//                    List.of(new CreateSnippetRequest("filename", "content", 1)),
-//                    savedCategoryId,
-//                    List.of("tag1", "tag2")
-//            ));
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .when().delete("/categories/" + savedCategoryId)
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("템플릿이 존재하는 카테고리는 삭제할 수 없습니다."));
-//        }
-//    }
-//}
+package codezap.category.controller;
+
+import static org.hamcrest.Matchers.is;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+import codezap.category.dto.request.CreateCategoryRequest;
+import codezap.category.dto.request.UpdateCategoryRequest;
+import codezap.category.service.CategoryService;
+import codezap.fixture.MemberDtoFixture;
+import codezap.member.dto.MemberDto;
+import codezap.template.dto.request.CreateSnippetRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
+import codezap.template.service.TemplateService;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+class CategoryControllerTest {
+
+    private static final int MAX_LENGTH = 255;
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @Autowired
+    private TemplateService templateService;
+
+    String cookie;
+
+    @BeforeEach
+    void setting() {
+        RestAssured.port = port;
+        cookie = HttpHeaders.encodeBasicAuth("test1@email.com", "password1234", StandardCharsets.UTF_8);
+    }
+
+    @Nested
+    @DisplayName("카테고리 생성 테스트")
+    class createCategoryTest {
+        @Test
+        @DisplayName("카테고리 생성 성공")
+        void createCategorySuccess() {
+            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH));
+
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(createCategoryRequest)
+                    .when().post("/categories")
+                    .then().log().all()
+                    .header("Location", "/categories/3")
+                    .statusCode(201);
+        }
+
+        @Test
+        @DisplayName("카테고리 생성 실패: 카테고리 이름 길이 초과")
+        void createCategoryFailWithLongName() {
+            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH + 1));
+
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(createCategoryRequest)
+                    .when().post("/categories")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
+        }
+    }
+
+    @Test
+    @DisplayName("카테고리 전체 조회 성공")
+    void findAllCategoriesSuccess() {
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("category1");
+        categoryService.create(createCategoryRequest, memberDto);
+
+        RestAssured.given().log().all()
+                .cookie("Authorization", cookie)
+                .contentType(ContentType.JSON)
+                .when().get("/categories")
+                .then().log().all()
+                .statusCode(200)
+                .body("categories.size()", is(2));
+    }
+
+    @Nested
+    @DisplayName("카테고리 수정 테스트")
+    class updateCategoryTest {
+
+        Long savedCategoryId;
+
+        @BeforeEach
+        void saveCategory() {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            savedCategoryId = categoryService.create(new CreateCategoryRequest("category1"), memberDto);
+        }
+
+        @Test
+        @DisplayName("카테고리 수정 성공")
+        void updateCategorySuccess() {
+            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH));
+
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateCategoryRequest)
+                    .when().put("/categories/" + savedCategoryId)
+                    .then().log().all()
+                    .statusCode(200);
+        }
+
+        @Test
+        @DisplayName("카테고리 수정 실패: 카테고리 이름 길이 초과")
+        void updateCategoryFailWithLongName() {
+            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH + 1));
+
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateCategoryRequest)
+                    .when().put("/categories/" + savedCategoryId)
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("카테고리 수정 실패: 중복된 이름의 카테고리 존재")
+        void updateCategoryFailWithDuplicatedName() {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            String duplicatedName = "duplicatedName";
+            categoryService.create(new CreateCategoryRequest(duplicatedName), memberDto);
+
+            UpdateCategoryRequest createCategoryRequest = new UpdateCategoryRequest(duplicatedName);
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(createCategoryRequest)
+                    .when().put("/categories/" + savedCategoryId)
+                    .then().log().all()
+                    .statusCode(409)
+                    .body("detail", is("이름이 " + duplicatedName + "인 카테고리가 이미 존재합니다."));
+        }
+    }
+
+
+    @Nested
+    @DisplayName("카테고리 삭제 테스트")
+    class deleteCategoryTest {
+
+        Long savedCategoryId;
+
+        @BeforeEach
+        void saveCategory() {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(new CreateCategoryRequest("category1"), memberDto);
+            savedCategoryId = categoryService.create(new CreateCategoryRequest("category2"), memberDto);
+        }
+
+        @Test
+        @DisplayName("카테고리 삭제 성공")
+        void deleteCategorySuccess() {
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .when().delete("/categories/" + savedCategoryId)
+                    .then().log().all()
+                    .statusCode(204);
+        }
+
+        @Test
+        @DisplayName("카테고리 삭제 성공: 존재하지 않는 카테고리의 삭제 요청")
+        void updateCategoryFailWithDuplicatedName() {
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .when().delete("/categories/" + savedCategoryId)
+                    .then().log().all()
+                    .statusCode(204);
+        }
+
+        @Test
+        @DisplayName("카테고리 삭제 실패: 템플릿이 존재하는 카테고리는 삭제 불가능")
+        void updateCategoryFailWithLongName() {
+            // given
+            templateService.createTemplate(
+                    new CreateTemplateRequest(
+                            "title",
+                            "description",
+                            List.of(new CreateSnippetRequest("filename", "content", 1)),
+                            savedCategoryId,
+                            List.of("tag1", "tag2")
+                    ),
+                    MemberDtoFixture.getFirstMemberDto()
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .when().delete("/categories/" + savedCategoryId)
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("템플릿이 존재하는 카테고리는 삭제할 수 없습니다."));
+        }
+    }
+}

--- a/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
@@ -1,204 +1,204 @@
-package codezap.category.controller;
-
-import static org.hamcrest.Matchers.is;
-
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-
-import codezap.category.dto.request.CreateCategoryRequest;
-import codezap.category.dto.request.UpdateCategoryRequest;
-import codezap.category.service.CategoryService;
-import codezap.template.dto.request.CreateSnippetRequest;
-import codezap.template.dto.request.CreateTemplateRequest;
-import codezap.template.service.TemplateService;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-class CategoryControllerTest {
-
-    private static final int MAX_LENGTH = 255;
-
-    @LocalServerPort
-    int port;
-
-    @Autowired
-    private CategoryService categoryService;
-    @Autowired
-    private TemplateService templateService;
-
-    @BeforeEach
-    void setting() {
-        RestAssured.port = port;
-    }
-
-    @Nested
-    @DisplayName("카테고리 생성 테스트")
-    class createCategoryTest {
-        @Test
-        @DisplayName("카테고리 생성 성공")
-        void createCategorySuccess() {
-            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH));
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(createCategoryRequest)
-                    .when().post("/categories")
-                    .then().log().all()
-                    .header("Location", "/categories/1")
-                    .statusCode(201);
-        }
-
-        @Test
-        @DisplayName("카테고리 생성 실패: 카테고리 이름 길이 초과")
-        void createCategoryFailWithLongName() {
-            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH + 1));
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(createCategoryRequest)
-                    .when().post("/categories")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
-        }
-    }
-
-    @Test
-    @DisplayName("카테고리 전체 조회 성공")
-    void findAllCategoriesSuccess() {
-        CreateCategoryRequest createCategoryRequest1 = new CreateCategoryRequest("category1");
-        CreateCategoryRequest createCategoryRequest2 = new CreateCategoryRequest("category2");
-        categoryService.create(createCategoryRequest1);
-        categoryService.create(createCategoryRequest2);
-
-        RestAssured.given().log().all()
-                .contentType(ContentType.JSON)
-                .when().get("/categories")
-                .then().log().all()
-                .statusCode(200)
-                .body("categories.size()", is(2));
-    }
-
-    @Nested
-    @DisplayName("카테고리 수정 테스트")
-    class updateCategoryTest {
-
-        Long savedCategoryId;
-
-        @BeforeEach
-        void saveCategory() {
-            savedCategoryId = categoryService.create(new CreateCategoryRequest("category1"));
-        }
-
-        @Test
-        @DisplayName("카테고리 수정 성공")
-        void updateCategorySuccess() {
-            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH));
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateCategoryRequest)
-                    .when().put("/categories/" + savedCategoryId)
-                    .then().log().all()
-                    .statusCode(200);
-        }
-
-        @Test
-        @DisplayName("카테고리 수정 실패: 카테고리 이름 길이 초과")
-        void updateCategoryFailWithLongName() {
-            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH + 1));
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateCategoryRequest)
-                    .when().put("/categories/" + savedCategoryId)
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @Test
-        @DisplayName("카테고리 수정 실패: 중복된 이름의 카테고리 존재")
-        void updateCategoryFailWithDuplicatedName() {
-            // given
-            String duplicatedName = "duplicatedName";
-            categoryService.create(new CreateCategoryRequest(duplicatedName));
-
-            UpdateCategoryRequest createCategoryRequest = new UpdateCategoryRequest(duplicatedName);
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(createCategoryRequest)
-                    .when().put("/categories/" + savedCategoryId)
-                    .then().log().all()
-                    .statusCode(409)
-                    .body("detail", is("이름이 " + duplicatedName + "인 카테고리가 이미 존재합니다."));
-        }
-    }
-
-
-    @Nested
-    @DisplayName("카테고리 삭제 테스트")
-    class deleteCategoryTest {
-
-        Long savedCategoryId;
-
-        @BeforeEach
-        void saveCategory() {
-            categoryService.create(new CreateCategoryRequest("category1"));
-            savedCategoryId = categoryService.create(new CreateCategoryRequest("category2"));
-        }
-
-        @Test
-        @DisplayName("카테고리 삭제 성공")
-        void deleteCategorySuccess() {
-            RestAssured.given().log().all()
-                    .when().delete("/categories/" + savedCategoryId)
-                    .then().log().all()
-                    .statusCode(204);
-        }
-
-        @Test
-        @DisplayName("카테고리 수정 성공: 존재하지 않는 카테고리의 삭제 요청")
-        void updateCategoryFailWithDuplicatedName() {
-            RestAssured.given().log().all()
-                    .when().delete("/categories/" + savedCategoryId + 1)
-                    .then().log().all()
-                    .statusCode(204);
-        }
-
-        @Test
-        @DisplayName("카테고리 삭제 실패: 템플릿이 존재하는 카테고리는 삭제 불가능")
-        void updateCategoryFailWithLongName() {
-            // given
-            templateService.createTemplate(new CreateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(new CreateSnippetRequest("filename", "content", 1)),
-                    savedCategoryId,
-                    List.of("tag1", "tag2")
-            ));
-
-            // when & then
-            RestAssured.given().log().all()
-                    .when().delete("/categories/" + savedCategoryId)
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("템플릿이 존재하는 카테고리는 삭제할 수 없습니다."));
-        }
-    }
-}
+//package codezap.category.controller;
+//
+//import static org.hamcrest.Matchers.is;
+//
+//import java.util.List;
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+//import org.springframework.boot.test.web.server.LocalServerPort;
+//import org.springframework.test.context.jdbc.Sql;
+//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+//
+//import codezap.category.dto.request.CreateCategoryRequest;
+//import codezap.category.dto.request.UpdateCategoryRequest;
+//import codezap.category.service.CategoryService;
+//import codezap.template.dto.request.CreateSnippetRequest;
+//import codezap.template.dto.request.CreateTemplateRequest;
+//import codezap.template.service.TemplateService;
+//import io.restassured.RestAssured;
+//import io.restassured.http.ContentType;
+//
+//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+//class CategoryControllerTest {
+//
+//    private static final int MAX_LENGTH = 255;
+//
+//    @LocalServerPort
+//    int port;
+//
+//    @Autowired
+//    private CategoryService categoryService;
+//    @Autowired
+//    private TemplateService templateService;
+//
+//    @BeforeEach
+//    void setting() {
+//        RestAssured.port = port;
+//    }
+//
+//    @Nested
+//    @DisplayName("카테고리 생성 테스트")
+//    class createCategoryTest {
+//        @Test
+//        @DisplayName("카테고리 생성 성공")
+//        void createCategorySuccess() {
+//            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH));
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(createCategoryRequest)
+//                    .when().post("/categories")
+//                    .then().log().all()
+//                    .header("Location", "/categories/1")
+//                    .statusCode(201);
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 생성 실패: 카테고리 이름 길이 초과")
+//        void createCategoryFailWithLongName() {
+//            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH + 1));
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(createCategoryRequest)
+//                    .when().post("/categories")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
+//        }
+//    }
+//
+//    @Test
+//    @DisplayName("카테고리 전체 조회 성공")
+//    void findAllCategoriesSuccess() {
+//        CreateCategoryRequest createCategoryRequest1 = new CreateCategoryRequest("category1");
+//        CreateCategoryRequest createCategoryRequest2 = new CreateCategoryRequest("category2");
+//        categoryService.create(createCategoryRequest1);
+//        categoryService.create(createCategoryRequest2);
+//
+//        RestAssured.given().log().all()
+//                .contentType(ContentType.JSON)
+//                .when().get("/categories")
+//                .then().log().all()
+//                .statusCode(200)
+//                .body("categories.size()", is(2));
+//    }
+//
+//    @Nested
+//    @DisplayName("카테고리 수정 테스트")
+//    class updateCategoryTest {
+//
+//        Long savedCategoryId;
+//
+//        @BeforeEach
+//        void saveCategory() {
+//            savedCategoryId = categoryService.create(new CreateCategoryRequest("category1"));
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 수정 성공")
+//        void updateCategorySuccess() {
+//            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH));
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateCategoryRequest)
+//                    .when().put("/categories/" + savedCategoryId)
+//                    .then().log().all()
+//                    .statusCode(200);
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 수정 실패: 카테고리 이름 길이 초과")
+//        void updateCategoryFailWithLongName() {
+//            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH + 1));
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateCategoryRequest)
+//                    .when().put("/categories/" + savedCategoryId)
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("카테고리 이름은 최대 255자까지 입력 가능합니다."));
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 수정 실패: 중복된 이름의 카테고리 존재")
+//        void updateCategoryFailWithDuplicatedName() {
+//            // given
+//            String duplicatedName = "duplicatedName";
+//            categoryService.create(new CreateCategoryRequest(duplicatedName));
+//
+//            UpdateCategoryRequest createCategoryRequest = new UpdateCategoryRequest(duplicatedName);
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(createCategoryRequest)
+//                    .when().put("/categories/" + savedCategoryId)
+//                    .then().log().all()
+//                    .statusCode(409)
+//                    .body("detail", is("이름이 " + duplicatedName + "인 카테고리가 이미 존재합니다."));
+//        }
+//    }
+//
+//
+//    @Nested
+//    @DisplayName("카테고리 삭제 테스트")
+//    class deleteCategoryTest {
+//
+//        Long savedCategoryId;
+//
+//        @BeforeEach
+//        void saveCategory() {
+//            categoryService.create(new CreateCategoryRequest("category1"));
+//            savedCategoryId = categoryService.create(new CreateCategoryRequest("category2"));
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 삭제 성공")
+//        void deleteCategorySuccess() {
+//            RestAssured.given().log().all()
+//                    .when().delete("/categories/" + savedCategoryId)
+//                    .then().log().all()
+//                    .statusCode(204);
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 수정 성공: 존재하지 않는 카테고리의 삭제 요청")
+//        void updateCategoryFailWithDuplicatedName() {
+//            RestAssured.given().log().all()
+//                    .when().delete("/categories/" + savedCategoryId + 1)
+//                    .then().log().all()
+//                    .statusCode(204);
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 삭제 실패: 템플릿이 존재하는 카테고리는 삭제 불가능")
+//        void updateCategoryFailWithLongName() {
+//            // given
+//            templateService.createTemplate(new CreateTemplateRequest(
+//                    "title",
+//                    "description",
+//                    List.of(new CreateSnippetRequest("filename", "content", 1)),
+//                    savedCategoryId,
+//                    List.of("tag1", "tag2")
+//            ));
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .when().delete("/categories/" + savedCategoryId)
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("템플릿이 존재하는 카테고리는 삭제할 수 없습니다."));
+//        }
+//    }
+//}

--- a/backend/src/test/java/codezap/category/repository/FakeCategoryRepository.java
+++ b/backend/src/test/java/codezap/category/repository/FakeCategoryRepository.java
@@ -1,0 +1,80 @@
+package codezap.category.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+
+import org.springframework.http.HttpStatus;
+
+import codezap.category.domain.Category;
+import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+
+public class FakeCategoryRepository implements CategoryRepository {
+
+    private final AtomicLong idCounter = new AtomicLong(1);
+
+    private final List<Category> categories;
+
+    public FakeCategoryRepository() {
+        this.categories = new ArrayList<>();
+    }
+
+    @Override
+    public Category fetchById(Long id) {
+        return categories.stream()
+                .filter(category -> Objects.equals(category.getId(), id))
+                .findFirst()
+                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다."));
+    }
+
+    @Override
+    public List<Category> findAllByMember(Member member) {
+        return categories.stream()
+                .filter(category -> Objects.equals(category.getMember(), member))
+                .toList();
+    }
+
+    @Override
+    public List<Category> findAll() {
+        return categories;
+    }
+
+    @Override
+    public boolean existsByNameAndMember(String categoryName, Member member) {
+        return categories.stream()
+                .anyMatch(category ->
+                        Objects.equals(category.getName(), categoryName) && Objects.equals(category.getMember(), member)
+                );
+    }
+
+    @Override
+    public Category save(Category entity) {
+        var saved = new Category(
+                getOrGenerateId(entity),
+                entity.getMember(),
+                entity.getName(),
+                entity.getIsDefault()
+        );
+        categories.removeIf(category -> Objects.equals(category.getId(), entity.getId()));
+        categories.add(saved);
+        return saved;
+    }
+
+    private long getOrGenerateId(Category entity) {
+        if (existsById(entity.getId())) {
+            return entity.getId();
+        }
+        return idCounter.getAndIncrement();
+    }
+
+    private boolean existsById(Long id) {
+        return categories.stream().anyMatch(category -> Objects.equals(category.getId(), id));
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        categories.removeIf(category -> Objects.equals(category.getId(), id));
+    }
+}

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -1,106 +1,106 @@
-package codezap.category.service;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-
-import codezap.category.domain.Category;
-import codezap.category.dto.request.CreateCategoryRequest;
-import codezap.category.dto.request.UpdateCategoryRequest;
-import codezap.category.dto.response.FindAllCategoriesResponse;
-import codezap.category.repository.CategoryRepository;
-import codezap.global.exception.CodeZapException;
-import io.restassured.RestAssured;
-
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-class CategoryServiceTest {
-
-    @LocalServerPort
-    int port;
-
-    @Autowired
-    private CategoryService categoryService;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @BeforeEach
-    void setting() {
-        RestAssured.port = port;
-    }
-
-    @Nested
-    @DisplayName("카테고리 생성 테스트")
-    class createCategoryTest {
-        @Test
-        @DisplayName("카테고리 생성 성공")
-        void createCategorySuccess() {
-            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("category1");
-
-            Long categoryId = categoryService.create(createCategoryRequest);
-
-            assertThat(categoryId).isEqualTo(1L);
-        }
-
-        @Test
-        @DisplayName("카테고리 생성 실패: 중복된 이름의 카테고리 이름 생성")
-        void createCategoryFailWithDuplicateName() {
-            categoryRepository.save(new Category("category"));
-            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("category");
-
-            assertThatThrownBy(() -> categoryService.create(createCategoryRequest))
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("이름이 " + createCategoryRequest.name() + "인 카테고리가 이미 존재합니다.");
-        }
-    }
-
-    @Test
-    @DisplayName("카테고리 전체 조회 테스트")
-    void findAllCategoriesSuccess() {
-        categoryRepository.save(new Category("category1"));
-        categoryRepository.save(new Category("category2"));
-
-        FindAllCategoriesResponse findAllCategoriesResponse = categoryService.findAll();
-
-        assertThat(findAllCategoriesResponse.categories()).hasSize(2);
-    }
-
-    @Test
-    @DisplayName("카테고리 수정 성공")
-    void updateCategorySuccess() {
-        // given
-        Category savedCategory = categoryRepository.save(new Category("category1"));
-
-        // when
-        categoryService.update(savedCategory.getId(), new UpdateCategoryRequest("updateName"));
-
-        // then
-        assertThat(categoryRepository.fetchById(savedCategory.getId()).getName()).isEqualTo("updateName");
-    }
-
-    @Test
-    @DisplayName("카테고리 삭제 성공")
-    void deleteCategorySuccess() {
-        // given
-        categoryRepository.save(new Category("category1"));
-        Category savedCategory = categoryRepository.save(new Category("category1"));
-
-        // when
-        categoryService.deleteById(savedCategory.getId());
-
-        // then
-        assertThat(categoryRepository.findById(savedCategory.getId())).isEmpty();
-    }
-}
+//package codezap.category.service;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.assertj.core.api.Assertions.assertThatThrownBy;
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+//import org.springframework.boot.test.web.server.LocalServerPort;
+//import org.springframework.test.context.jdbc.Sql;
+//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+//
+//import codezap.category.domain.Category;
+//import codezap.category.dto.request.CreateCategoryRequest;
+//import codezap.category.dto.request.UpdateCategoryRequest;
+//import codezap.category.dto.response.FindAllCategoriesResponse;
+//import codezap.category.repository.CategoryRepository;
+//import codezap.global.exception.CodeZapException;
+//import io.restassured.RestAssured;
+//
+//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+//class CategoryServiceTest {
+//
+//    @LocalServerPort
+//    int port;
+//
+//    @Autowired
+//    private CategoryService categoryService;
+//
+//    @Autowired
+//    private CategoryRepository categoryRepository;
+//
+//    @BeforeEach
+//    void setting() {
+//        RestAssured.port = port;
+//    }
+//
+//    @Nested
+//    @DisplayName("카테고리 생성 테스트")
+//    class createCategoryTest {
+//        @Test
+//        @DisplayName("카테고리 생성 성공")
+//        void createCategorySuccess() {
+//            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("category1");
+//
+//            Long categoryId = categoryService.create(createCategoryRequest);
+//
+//            assertThat(categoryId).isEqualTo(1L);
+//        }
+//
+//        @Test
+//        @DisplayName("카테고리 생성 실패: 중복된 이름의 카테고리 이름 생성")
+//        void createCategoryFailWithDuplicateName() {
+//            categoryRepository.save(new Category("category"));
+//            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("category");
+//
+//            assertThatThrownBy(() -> categoryService.create(createCategoryRequest))
+//                    .isInstanceOf(CodeZapException.class)
+//                    .hasMessage("이름이 " + createCategoryRequest.name() + "인 카테고리가 이미 존재합니다.");
+//        }
+//    }
+//
+//    @Test
+//    @DisplayName("카테고리 전체 조회 테스트")
+//    void findAllCategoriesSuccess() {
+//        categoryRepository.save(new Category("category1"));
+//        categoryRepository.save(new Category("category2"));
+//
+//        FindAllCategoriesResponse findAllCategoriesResponse = categoryService.findAll();
+//
+//        assertThat(findAllCategoriesResponse.categories()).hasSize(2);
+//    }
+//
+//    @Test
+//    @DisplayName("카테고리 수정 성공")
+//    void updateCategorySuccess() {
+//        // given
+//        Category savedCategory = categoryRepository.save(new Category("category1"));
+//
+//        // when
+//        categoryService.update(savedCategory.getId(), new UpdateCategoryRequest("updateName"));
+//
+//        // then
+//        assertThat(categoryRepository.fetchById(savedCategory.getId()).getName()).isEqualTo("updateName");
+//    }
+//
+//    @Test
+//    @DisplayName("카테고리 삭제 성공")
+//    void deleteCategorySuccess() {
+//        // given
+//        categoryRepository.save(new Category("category1"));
+//        Category savedCategory = categoryRepository.save(new Category("category1"));
+//
+//        // when
+//        categoryService.deleteById(savedCategory.getId());
+//
+//        // then
+//        assertThat(categoryRepository.findById(savedCategory.getId())).isEmpty();
+//    }
+//}

--- a/backend/src/test/java/codezap/fixture/MemberDtoFixture.java
+++ b/backend/src/test/java/codezap/fixture/MemberDtoFixture.java
@@ -1,0 +1,14 @@
+package codezap.fixture;
+
+import codezap.member.dto.MemberDto;
+
+public class MemberDtoFixture {
+
+    public static MemberDto getFirstMemberDto() {
+        return new MemberDto(1L, "test1@email.com", "password1234", "username1");
+    }
+
+    public static MemberDto getSecondMemberDto() {
+        return new MemberDto(2L, "test2@email.com", "password1234", "username2");
+    }
+}

--- a/backend/src/test/java/codezap/member/repository/FakeMemberRepository.java
+++ b/backend/src/test/java/codezap/member/repository/FakeMemberRepository.java
@@ -6,6 +6,9 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicLong;
 
+import org.springframework.http.HttpStatus;
+
+import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 
 public class FakeMemberRepository implements MemberRepository {
@@ -16,6 +19,14 @@ public class FakeMemberRepository implements MemberRepository {
 
     public FakeMemberRepository() {
         this.members = new ArrayList<>();
+    }
+
+    @Override
+    public Member fetchById(Long id) {
+        return members.stream()
+                .filter(member -> Objects.equals(member.getId(), id))
+                .findFirst()
+                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 멤버가 존재하지 않습니다."));
     }
 
     @Override

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -17,6 +17,8 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.HttpHeaders;
 
+import codezap.category.repository.CategoryRepository;
+import codezap.category.repository.FakeCategoryRepository;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.dto.LoginRequest;
@@ -28,8 +30,9 @@ import codezap.member.repository.MemberRepository;
 public class MemberServiceTest {
 
     private final MemberRepository memberRepository = new FakeMemberRepository();
+    private final CategoryRepository categoryRepository = new FakeCategoryRepository();
     private final AuthService authService = new AuthService(memberRepository);
-    private final MemberService sut = new MemberService(memberRepository, authService);
+    private final MemberService sut = new MemberService(memberRepository, authService, categoryRepository);
 
     @Nested
     @DisplayName("이메일 중복 검사 테스트")

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -1,485 +1,485 @@
-package codezap.template.controller;
-
-import static org.hamcrest.Matchers.is;
-
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.CsvSource;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-
-import codezap.category.dto.request.CreateCategoryRequest;
-import codezap.category.service.CategoryService;
-import codezap.template.dto.request.CreateSnippetRequest;
-import codezap.template.dto.request.CreateTemplateRequest;
-import codezap.template.dto.request.UpdateSnippetRequest;
-import codezap.template.dto.request.UpdateTemplateRequest;
-import codezap.template.service.TemplateService;
-import io.restassured.RestAssured;
-import io.restassured.http.ContentType;
-
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-class TemplateControllerTest {
-
-    private static final int MAX_LENGTH = 255;
-
-    @Autowired
-    private TemplateService templateService;
-
-    @Autowired
-    private CategoryService categoryService;
-
-    @LocalServerPort
-    int port;
-
-    @BeforeEach
-    void setting() {
-        RestAssured.port = port;
-    }
-
-    @Nested
-    @DisplayName("템플릿 생성 테스트")
-    class createTemplateTest {
-
-        @ParameterizedTest
-        @DisplayName("템플릿 생성 성공")
-        @CsvSource({"a, 65535", "ㄱ, 21845"})
-        void createTemplateSuccess(String repeatTarget, int maxLength) {
-            String maxTitle = "a".repeat(MAX_LENGTH);
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                    maxTitle,
-                    repeatTarget.repeat(maxLength),
-                    List.of(new CreateSnippetRequest("a".repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
-                    1L,
-                    List.of("tag1", "tag2")
-            );
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(templateRequest)
-                    .when().post("/templates")
-                    .then().log().all()
-                    .header("Location", "/templates/1")
-                    .statusCode(201);
-        }
-
-        @Test
-        @DisplayName("템플릿 생성 실패: 템플릿 이름 길이 초과")
-        void createTemplateFailWithLongTitle() {
-            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                    exceededTitle,
-                    "description",
-                    List.of(new CreateSnippetRequest("a", "content", 1)),
-                    1L,
-                    List.of("tag1", "tag2")
-            );
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(templateRequest)
-                    .when().post("/templates")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @Test
-        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
-        void createTemplateFailWithLongFileName() {
-            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(new CreateSnippetRequest(exceededTitle, "content", 1)),
-                    1L,
-                    List.of("tag1", "tag2")
-            );
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(templateRequest)
-                    .when().post("/templates")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
-        @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) {
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(new CreateSnippetRequest("title", repeatTarget.repeat(exceededLength), 1)),
-                    1L,
-                    List.of("tag1", "tag2")
-            );
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(templateRequest)
-                    .when().post("/templates")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
-        @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) {
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                    "title",
-                    repeatTarget.repeat(exceededLength),
-                    List.of(new CreateSnippetRequest("title", "content", 1)),
-                    1L,
-                    List.of("tag1", "tag2")
-            );
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(templateRequest)
-                    .when().post("/templates")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 생성 실패: 잘못된 스니펫 순서 입력")
-        @CsvSource({"0, 1", "1, 3", "2, 1"})
-        void createTemplateFailWithWrongSnippetOrdinal(int firstIndex, int secondIndex) {
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(new CreateSnippetRequest("title", "content", firstIndex),
-                            new CreateSnippetRequest("title", "content", secondIndex)),
-                    1L,
-                    List.of("tag1", "tag2")
-            );
-
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(templateRequest)
-                    .when().post("/templates")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
-        }
-    }
-
-    @Test
-    @DisplayName("템플릿 전체 탐색 성공")
-    void findAllTemplatesSuccess() {
-        // given
-        categoryService.create(new CreateCategoryRequest("category"));
-        CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSnippets("title1");
-        CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSnippets("title2");
-        templateService.createTemplate(templateRequest1);
-        templateService.createTemplate(templateRequest2);
-
-        // when & then
-        RestAssured.given().log().all()
-                .get("/templates/explore")
-                .then().log().all()
-                .statusCode(200)
-                .body("templates.size()", is(2));
-    }
-
-    @Nested
-    @DisplayName("템플릿 상세 조회 테스트")
-    class findTemplateTest {
-
-        @Test
-        @DisplayName("템플릿 상세 조회 성공")
-        void findOneTemplateSuccess() {
-            // given
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-            templateService.createTemplate(templateRequest);
-
-            // when & then
-            RestAssured.given().log().all()
-                    .get("/templates/1")
-                    .then().log().all()
-                    .statusCode(200)
-                    .body("title", is(templateRequest.title()),
-                            "snippets.size()", is(2),
-                            "category.id", is(1),
-                            "category.name", is("category"),
-                            "tags.size()", is(2));
-        }
-
-        @Test
-        @DisplayName("템플릿 상세 조회 실패: 존재하지 않는 템플릿 조회")
-        void findOneTemplateFailWithNotFoundTemplate() {
-            // when & then
-            RestAssured.given().log().all()
-                    .get("/templates/1")
-                    .then().log().all()
-                    .statusCode(404)
-                    .body("detail", is("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
-        }
-    }
-
-    @Nested
-    @DisplayName("템플릿 수정 테스트")
-    class updateTemplateTest {
-
-        @Test
-        @DisplayName("템플릿 수정 성공")
-        void updateTemplateSuccess() {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "updateTitle",
-                    "description",
-                    List.of(
-                            new CreateSnippetRequest("filename3", "content3", 2),
-                            new CreateSnippetRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateTemplateRequest)
-                    .when().post("/templates/1")
-                    .then().log().all()
-                    .statusCode(200);
-        }
-
-        @Test
-        @DisplayName("템플릿 수정 실패: 템플릿 이름 길이 초과")
-        void updateTemplateFailWithLongName() {
-            // given
-            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    exceededTitle,
-                    "description",
-                    List.of(
-                            new CreateSnippetRequest("filename3", "content3", 2),
-                            new CreateSnippetRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateTemplateRequest)
-                    .when().post("/templates/1")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @Test
-        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
-        void updateTemplateFailWithLongFileName() {
-            // given
-            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(
-                            new CreateSnippetRequest(exceededTitle, "content3", 2),
-                            new CreateSnippetRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateTemplateRequest)
-                    .when().post("/templates/1")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
-        @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(
-                            new CreateSnippetRequest("filename3", repeatTarget.repeat(exceedLength), 2),
-                            new CreateSnippetRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateTemplateRequest)
-                    .when().post("/templates/1")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
-        @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "title",
-                    repeatTarget.repeat(exceedLength),
-                    List.of(
-                            new CreateSnippetRequest("filename3", "content3", 2),
-                            new CreateSnippetRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateTemplateRequest)
-                    .when().post("/templates/1")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-        }
-
-        // 정상 요청: 2, 3, 1
-        @ParameterizedTest
-        @DisplayName("템플릿 수정 실패: 잘못된 스니펫 순서 입력")
-        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
-        void updateTemplateFailWithWrongSnippetOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal) {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "updateTitle",
-                    "description",
-                    List.of(
-                            new CreateSnippetRequest("filename3", "content3", createOrdinal1),
-                            new CreateSnippetRequest("filename4", "content4", createOrdinal2)
-                    ),
-                    List.of(
-                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            RestAssured.given().log().all()
-                    .contentType(ContentType.JSON)
-                    .body(updateTemplateRequest)
-                    .when().post("/templates/1")
-                    .then().log().all()
-                    .statusCode(400)
-                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
-        }
-
-        private void createTemplateAndTwoCategories() {
-            categoryService.create(new CreateCategoryRequest("category1"));
-            categoryService.create(new CreateCategoryRequest("category2"));
-            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-            templateService.createTemplate(templateRequest);
-        }
-    }
-
-    @Nested
-    @DisplayName("템플릿 삭제 테스트")
-    class deleteTemplateTest {
-
-        @Test
-        @DisplayName("템플릿 삭제 성공")
-        void deleteTemplateSuccess() {
-            // given
-            categoryService.create(new CreateCategoryRequest("category"));
-            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-            templateService.createTemplate(templateRequest);
-
-            // when & then
-            RestAssured.given().log().all()
-                    .delete("/templates/1")
-                    .then().log().all()
-                    .statusCode(204);
-        }
-
-        @Test
-        @DisplayName("템플릿 삭제 성공: 존재하지 않는 템플릿 삭제")
-        void deleteTemplateSuccessWithNotFoundTemplate() {
-            // when & then
-            RestAssured.given().log().all()
-                    .delete("/templates/1")
-                    .then().log().all()
-                    .statusCode(204);
-        }
-
-    }
-
-    private static CreateTemplateRequest createTemplateRequestWithTwoSnippets(String title) {
-        CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-                title,
-                "description",
-                List.of(
-                        new CreateSnippetRequest("filename1", "content1", 1),
-                        new CreateSnippetRequest("filename2", "content2", 2)
-                ),
-                1L,
-                List.of("tag1", "tag2")
-        );
-        return templateRequest;
-    }
-}
+//package codezap.template.controller;
+//
+//import static org.hamcrest.Matchers.is;
+//
+//import java.util.List;
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Nested;
+//import org.junit.jupiter.api.Test;
+//import org.junit.jupiter.params.ParameterizedTest;
+//import org.junit.jupiter.params.provider.CsvSource;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+//import org.springframework.boot.test.web.server.LocalServerPort;
+//import org.springframework.test.context.jdbc.Sql;
+//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+//
+//import codezap.category.dto.request.CreateCategoryRequest;
+//import codezap.category.service.CategoryService;
+//import codezap.template.dto.request.CreateSnippetRequest;
+//import codezap.template.dto.request.CreateTemplateRequest;
+//import codezap.template.dto.request.UpdateSnippetRequest;
+//import codezap.template.dto.request.UpdateTemplateRequest;
+//import codezap.template.service.TemplateService;
+//import io.restassured.RestAssured;
+//import io.restassured.http.ContentType;
+//
+//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+//class TemplateControllerTest {
+//
+//    private static final int MAX_LENGTH = 255;
+//
+//    @Autowired
+//    private TemplateService templateService;
+//
+//    @Autowired
+//    private CategoryService categoryService;
+//
+//    @LocalServerPort
+//    int port;
+//
+//    @BeforeEach
+//    void setting() {
+//        RestAssured.port = port;
+//    }
+//
+//    @Nested
+//    @DisplayName("템플릿 생성 테스트")
+//    class createTemplateTest {
+//
+//        @ParameterizedTest
+//        @DisplayName("템플릿 생성 성공")
+//        @CsvSource({"a, 65535", "ㄱ, 21845"})
+//        void createTemplateSuccess(String repeatTarget, int maxLength) {
+//            String maxTitle = "a".repeat(MAX_LENGTH);
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                    maxTitle,
+//                    repeatTarget.repeat(maxLength),
+//                    List.of(new CreateSnippetRequest("a".repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
+//                    1L,
+//                    List.of("tag1", "tag2")
+//            );
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(templateRequest)
+//                    .when().post("/templates")
+//                    .then().log().all()
+//                    .header("Location", "/templates/1")
+//                    .statusCode(201);
+//        }
+//
+//        @Test
+//        @DisplayName("템플릿 생성 실패: 템플릿 이름 길이 초과")
+//        void createTemplateFailWithLongTitle() {
+//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                    exceededTitle,
+//                    "description",
+//                    List.of(new CreateSnippetRequest("a", "content", 1)),
+//                    1L,
+//                    List.of("tag1", "tag2")
+//            );
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(templateRequest)
+//                    .when().post("/templates")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
+//        }
+//
+//        @Test
+//        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
+//        void createTemplateFailWithLongFileName() {
+//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                    "title",
+//                    "description",
+//                    List.of(new CreateSnippetRequest(exceededTitle, "content", 1)),
+//                    1L,
+//                    List.of("tag1", "tag2")
+//            );
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(templateRequest)
+//                    .when().post("/templates")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
+//        }
+//
+//        @ParameterizedTest
+//        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
+//        @CsvSource({"a, 65536", "ㄱ, 21846"})
+//        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) {
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                    "title",
+//                    "description",
+//                    List.of(new CreateSnippetRequest("title", repeatTarget.repeat(exceededLength), 1)),
+//                    1L,
+//                    List.of("tag1", "tag2")
+//            );
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(templateRequest)
+//                    .when().post("/templates")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
+//        }
+//
+//        @ParameterizedTest
+//        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
+//        @CsvSource({"a, 65536", "ㄱ, 21846"})
+//        void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) {
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                    "title",
+//                    repeatTarget.repeat(exceededLength),
+//                    List.of(new CreateSnippetRequest("title", "content", 1)),
+//                    1L,
+//                    List.of("tag1", "tag2")
+//            );
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(templateRequest)
+//                    .when().post("/templates")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+//        }
+//
+//        @ParameterizedTest
+//        @DisplayName("템플릿 생성 실패: 잘못된 스니펫 순서 입력")
+//        @CsvSource({"0, 1", "1, 3", "2, 1"})
+//        void createTemplateFailWithWrongSnippetOrdinal(int firstIndex, int secondIndex) {
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                    "title",
+//                    "description",
+//                    List.of(new CreateSnippetRequest("title", "content", firstIndex),
+//                            new CreateSnippetRequest("title", "content", secondIndex)),
+//                    1L,
+//                    List.of("tag1", "tag2")
+//            );
+//
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(templateRequest)
+//                    .when().post("/templates")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
+//        }
+//    }
+//
+//    @Test
+//    @DisplayName("템플릿 전체 조회 성공")
+//    void findAllTemplatesSuccess() {
+//        // given
+//        categoryService.create(new CreateCategoryRequest("category"));
+//        CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSnippets("title1");
+//        CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSnippets("title2");
+//        templateService.createTemplate(templateRequest1);
+//        templateService.createTemplate(templateRequest2);
+//
+//        // when & then
+//        RestAssured.given().log().all()
+//                .get("/templates")
+//                .then().log().all()
+//                .statusCode(200)
+//                .body("templates.size()", is(2));
+//    }
+//
+//    @Nested
+//    @DisplayName("템플릿 상세 조회 테스트")
+//    class findTemplateTest {
+//
+//        @Test
+//        @DisplayName("템플릿 상세 조회 성공")
+//        void findOneTemplateSuccess() {
+//            // given
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
+//            templateService.createTemplate(templateRequest);
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .get("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(200)
+//                    .body("title", is(templateRequest.title()),
+//                            "snippets.size()", is(2),
+//                            "category.id", is(1),
+//                            "category.name", is("category"),
+//                            "tags.size()", is(2));
+//        }
+//
+//        @Test
+//        @DisplayName("템플릿 상세 조회 실패: 존재하지 않는 템플릿 조회")
+//        void findOneTemplateFailWithNotFoundTemplate() {
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .get("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(404)
+//                    .body("detail", is("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("템플릿 수정 테스트")
+//    class updateTemplateTest {
+//
+//        @Test
+//        @DisplayName("템플릿 수정 성공")
+//        void updateTemplateSuccess() {
+//            // given
+//            createTemplateAndTwoCategories();
+//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+//                    "updateTitle",
+//                    "description",
+//                    List.of(
+//                            new CreateSnippetRequest("filename3", "content3", 2),
+//                            new CreateSnippetRequest("filename4", "content4", 3)
+//                    ),
+//                    List.of(
+//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+//                    ),
+//                    List.of(1L),
+//                    2L,
+//                    List.of("tag1", "tag3")
+//            );
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateTemplateRequest)
+//                    .when().post("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(200);
+//        }
+//
+//        @Test
+//        @DisplayName("템플릿 수정 실패: 템플릿 이름 길이 초과")
+//        void updateTemplateFailWithLongName() {
+//            // given
+//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+//            createTemplateAndTwoCategories();
+//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+//                    exceededTitle,
+//                    "description",
+//                    List.of(
+//                            new CreateSnippetRequest("filename3", "content3", 2),
+//                            new CreateSnippetRequest("filename4", "content4", 3)
+//                    ),
+//                    List.of(
+//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+//                    ),
+//                    List.of(1L),
+//                    2L,
+//                    List.of("tag1", "tag3")
+//            );
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateTemplateRequest)
+//                    .when().post("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
+//        }
+//
+//        @Test
+//        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
+//        void updateTemplateFailWithLongFileName() {
+//            // given
+//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+//            createTemplateAndTwoCategories();
+//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+//                    "title",
+//                    "description",
+//                    List.of(
+//                            new CreateSnippetRequest(exceededTitle, "content3", 2),
+//                            new CreateSnippetRequest("filename4", "content4", 3)
+//                    ),
+//                    List.of(
+//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+//                    ),
+//                    List.of(1L),
+//                    2L,
+//                    List.of("tag1", "tag3")
+//            );
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateTemplateRequest)
+//                    .when().post("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
+//        }
+//
+//        @ParameterizedTest
+//        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
+//        @CsvSource({"a, 65536", "ㄱ, 21846"})
+//        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) {
+//            // given
+//            createTemplateAndTwoCategories();
+//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+//                    "title",
+//                    "description",
+//                    List.of(
+//                            new CreateSnippetRequest("filename3", repeatTarget.repeat(exceedLength), 2),
+//                            new CreateSnippetRequest("filename4", "content4", 3)
+//                    ),
+//                    List.of(
+//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+//                    ),
+//                    List.of(1L),
+//                    2L,
+//                    List.of("tag1", "tag3")
+//            );
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateTemplateRequest)
+//                    .when().post("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
+//        }
+//
+//        @ParameterizedTest
+//        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
+//        @CsvSource({"a, 65536", "ㄱ, 21846"})
+//        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) {
+//            // given
+//            createTemplateAndTwoCategories();
+//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+//                    "title",
+//                    repeatTarget.repeat(exceedLength),
+//                    List.of(
+//                            new CreateSnippetRequest("filename3", "content3", 2),
+//                            new CreateSnippetRequest("filename4", "content4", 3)
+//                    ),
+//                    List.of(
+//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+//                    ),
+//                    List.of(1L),
+//                    2L,
+//                    List.of("tag1", "tag3")
+//            );
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateTemplateRequest)
+//                    .when().post("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+//        }
+//
+//        // 정상 요청: 2, 3, 1
+//        @ParameterizedTest
+//        @DisplayName("템플릿 수정 실패: 잘못된 스니펫 순서 입력")
+//        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
+//        void updateTemplateFailWithWrongSnippetOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal) {
+//            // given
+//            createTemplateAndTwoCategories();
+//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+//                    "updateTitle",
+//                    "description",
+//                    List.of(
+//                            new CreateSnippetRequest("filename3", "content3", createOrdinal1),
+//                            new CreateSnippetRequest("filename4", "content4", createOrdinal2)
+//                    ),
+//                    List.of(
+//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
+//                    ),
+//                    List.of(1L),
+//                    2L,
+//                    List.of("tag1", "tag3")
+//            );
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .contentType(ContentType.JSON)
+//                    .body(updateTemplateRequest)
+//                    .when().post("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(400)
+//                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
+//        }
+//
+//        private void createTemplateAndTwoCategories() {
+//            categoryService.create(new CreateCategoryRequest("category1"));
+//            categoryService.create(new CreateCategoryRequest("category2"));
+//            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
+//            templateService.createTemplate(templateRequest);
+//        }
+//    }
+//
+//    @Nested
+//    @DisplayName("템플릿 삭제 테스트")
+//    class deleteTemplateTest {
+//
+//        @Test
+//        @DisplayName("템플릿 삭제 성공")
+//        void deleteTemplateSuccess() {
+//            // given
+//            categoryService.create(new CreateCategoryRequest("category"));
+//            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
+//            templateService.createTemplate(templateRequest);
+//
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .delete("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(204);
+//        }
+//
+//        @Test
+//        @DisplayName("템플릿 삭제 성공: 존재하지 않는 템플릿 삭제")
+//        void deleteTemplateSuccessWithNotFoundTemplate() {
+//            // when & then
+//            RestAssured.given().log().all()
+//                    .delete("/templates/1")
+//                    .then().log().all()
+//                    .statusCode(204);
+//        }
+//
+//    }
+//
+//    private static CreateTemplateRequest createTemplateRequestWithTwoSnippets(String title) {
+//        CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+//                title,
+//                "description",
+//                List.of(
+//                        new CreateSnippetRequest("filename1", "content1", 1),
+//                        new CreateSnippetRequest("filename2", "content2", 2)
+//                ),
+//                1L,
+//                List.of("tag1", "tag2")
+//        );
+//        return templateRequest;
+//    }
+//}

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -1,485 +1,500 @@
-//package codezap.template.controller;
-//
-//import static org.hamcrest.Matchers.is;
-//
-//import java.util.List;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Nested;
-//import org.junit.jupiter.api.Test;
-//import org.junit.jupiter.params.ParameterizedTest;
-//import org.junit.jupiter.params.provider.CsvSource;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-//import org.springframework.boot.test.web.server.LocalServerPort;
-//import org.springframework.test.context.jdbc.Sql;
-//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-//
-//import codezap.category.dto.request.CreateCategoryRequest;
-//import codezap.category.service.CategoryService;
-//import codezap.template.dto.request.CreateSnippetRequest;
-//import codezap.template.dto.request.CreateTemplateRequest;
-//import codezap.template.dto.request.UpdateSnippetRequest;
-//import codezap.template.dto.request.UpdateTemplateRequest;
-//import codezap.template.service.TemplateService;
-//import io.restassured.RestAssured;
-//import io.restassured.http.ContentType;
-//
-//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-//class TemplateControllerTest {
-//
-//    private static final int MAX_LENGTH = 255;
-//
-//    @Autowired
-//    private TemplateService templateService;
-//
-//    @Autowired
-//    private CategoryService categoryService;
-//
-//    @LocalServerPort
-//    int port;
-//
-//    @BeforeEach
-//    void setting() {
-//        RestAssured.port = port;
-//    }
-//
-//    @Nested
-//    @DisplayName("템플릿 생성 테스트")
-//    class createTemplateTest {
-//
-//        @ParameterizedTest
-//        @DisplayName("템플릿 생성 성공")
-//        @CsvSource({"a, 65535", "ㄱ, 21845"})
-//        void createTemplateSuccess(String repeatTarget, int maxLength) {
-//            String maxTitle = "a".repeat(MAX_LENGTH);
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                    maxTitle,
-//                    repeatTarget.repeat(maxLength),
-//                    List.of(new CreateSnippetRequest("a".repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
-//                    1L,
-//                    List.of("tag1", "tag2")
-//            );
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(templateRequest)
-//                    .when().post("/templates")
-//                    .then().log().all()
-//                    .header("Location", "/templates/1")
-//                    .statusCode(201);
-//        }
-//
-//        @Test
-//        @DisplayName("템플릿 생성 실패: 템플릿 이름 길이 초과")
-//        void createTemplateFailWithLongTitle() {
-//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                    exceededTitle,
-//                    "description",
-//                    List.of(new CreateSnippetRequest("a", "content", 1)),
-//                    1L,
-//                    List.of("tag1", "tag2")
-//            );
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(templateRequest)
-//                    .when().post("/templates")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
-//        }
-//
-//        @Test
-//        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
-//        void createTemplateFailWithLongFileName() {
-//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                    "title",
-//                    "description",
-//                    List.of(new CreateSnippetRequest(exceededTitle, "content", 1)),
-//                    1L,
-//                    List.of("tag1", "tag2")
-//            );
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(templateRequest)
-//                    .when().post("/templates")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
-//        }
-//
-//        @ParameterizedTest
-//        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
-//        @CsvSource({"a, 65536", "ㄱ, 21846"})
-//        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) {
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                    "title",
-//                    "description",
-//                    List.of(new CreateSnippetRequest("title", repeatTarget.repeat(exceededLength), 1)),
-//                    1L,
-//                    List.of("tag1", "tag2")
-//            );
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(templateRequest)
-//                    .when().post("/templates")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
-//        }
-//
-//        @ParameterizedTest
-//        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
-//        @CsvSource({"a, 65536", "ㄱ, 21846"})
-//        void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) {
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                    "title",
-//                    repeatTarget.repeat(exceededLength),
-//                    List.of(new CreateSnippetRequest("title", "content", 1)),
-//                    1L,
-//                    List.of("tag1", "tag2")
-//            );
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(templateRequest)
-//                    .when().post("/templates")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-//        }
-//
-//        @ParameterizedTest
-//        @DisplayName("템플릿 생성 실패: 잘못된 스니펫 순서 입력")
-//        @CsvSource({"0, 1", "1, 3", "2, 1"})
-//        void createTemplateFailWithWrongSnippetOrdinal(int firstIndex, int secondIndex) {
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                    "title",
-//                    "description",
-//                    List.of(new CreateSnippetRequest("title", "content", firstIndex),
-//                            new CreateSnippetRequest("title", "content", secondIndex)),
-//                    1L,
-//                    List.of("tag1", "tag2")
-//            );
-//
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(templateRequest)
-//                    .when().post("/templates")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
-//        }
-//    }
-//
-//    @Test
-//    @DisplayName("템플릿 전체 조회 성공")
-//    void findAllTemplatesSuccess() {
-//        // given
-//        categoryService.create(new CreateCategoryRequest("category"));
-//        CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSnippets("title1");
-//        CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSnippets("title2");
-//        templateService.createTemplate(templateRequest1);
-//        templateService.createTemplate(templateRequest2);
-//
-//        // when & then
-//        RestAssured.given().log().all()
-//                .get("/templates")
-//                .then().log().all()
-//                .statusCode(200)
-//                .body("templates.size()", is(2));
-//    }
-//
-//    @Nested
-//    @DisplayName("템플릿 상세 조회 테스트")
-//    class findTemplateTest {
-//
-//        @Test
-//        @DisplayName("템플릿 상세 조회 성공")
-//        void findOneTemplateSuccess() {
-//            // given
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-//            templateService.createTemplate(templateRequest);
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .get("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(200)
-//                    .body("title", is(templateRequest.title()),
-//                            "snippets.size()", is(2),
-//                            "category.id", is(1),
-//                            "category.name", is("category"),
-//                            "tags.size()", is(2));
-//        }
-//
-//        @Test
-//        @DisplayName("템플릿 상세 조회 실패: 존재하지 않는 템플릿 조회")
-//        void findOneTemplateFailWithNotFoundTemplate() {
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .get("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(404)
-//                    .body("detail", is("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("템플릿 수정 테스트")
-//    class updateTemplateTest {
-//
-//        @Test
-//        @DisplayName("템플릿 수정 성공")
-//        void updateTemplateSuccess() {
-//            // given
-//            createTemplateAndTwoCategories();
-//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                    "updateTitle",
-//                    "description",
-//                    List.of(
-//                            new CreateSnippetRequest("filename3", "content3", 2),
-//                            new CreateSnippetRequest("filename4", "content4", 3)
-//                    ),
-//                    List.of(
-//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-//                    ),
-//                    List.of(1L),
-//                    2L,
-//                    List.of("tag1", "tag3")
-//            );
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateTemplateRequest)
-//                    .when().post("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(200);
-//        }
-//
-//        @Test
-//        @DisplayName("템플릿 수정 실패: 템플릿 이름 길이 초과")
-//        void updateTemplateFailWithLongName() {
-//            // given
-//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//            createTemplateAndTwoCategories();
-//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                    exceededTitle,
-//                    "description",
-//                    List.of(
-//                            new CreateSnippetRequest("filename3", "content3", 2),
-//                            new CreateSnippetRequest("filename4", "content4", 3)
-//                    ),
-//                    List.of(
-//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-//                    ),
-//                    List.of(1L),
-//                    2L,
-//                    List.of("tag1", "tag3")
-//            );
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateTemplateRequest)
-//                    .when().post("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
-//        }
-//
-//        @Test
-//        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
-//        void updateTemplateFailWithLongFileName() {
-//            // given
-//            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//            createTemplateAndTwoCategories();
-//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                    "title",
-//                    "description",
-//                    List.of(
-//                            new CreateSnippetRequest(exceededTitle, "content3", 2),
-//                            new CreateSnippetRequest("filename4", "content4", 3)
-//                    ),
-//                    List.of(
-//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-//                    ),
-//                    List.of(1L),
-//                    2L,
-//                    List.of("tag1", "tag3")
-//            );
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateTemplateRequest)
-//                    .when().post("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
-//        }
-//
-//        @ParameterizedTest
-//        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
-//        @CsvSource({"a, 65536", "ㄱ, 21846"})
-//        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) {
-//            // given
-//            createTemplateAndTwoCategories();
-//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                    "title",
-//                    "description",
-//                    List.of(
-//                            new CreateSnippetRequest("filename3", repeatTarget.repeat(exceedLength), 2),
-//                            new CreateSnippetRequest("filename4", "content4", 3)
-//                    ),
-//                    List.of(
-//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-//                    ),
-//                    List.of(1L),
-//                    2L,
-//                    List.of("tag1", "tag3")
-//            );
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateTemplateRequest)
-//                    .when().post("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
-//        }
-//
-//        @ParameterizedTest
-//        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
-//        @CsvSource({"a, 65536", "ㄱ, 21846"})
-//        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) {
-//            // given
-//            createTemplateAndTwoCategories();
-//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                    "title",
-//                    repeatTarget.repeat(exceedLength),
-//                    List.of(
-//                            new CreateSnippetRequest("filename3", "content3", 2),
-//                            new CreateSnippetRequest("filename4", "content4", 3)
-//                    ),
-//                    List.of(
-//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-//                    ),
-//                    List.of(1L),
-//                    2L,
-//                    List.of("tag1", "tag3")
-//            );
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateTemplateRequest)
-//                    .when().post("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-//        }
-//
-//        // 정상 요청: 2, 3, 1
-//        @ParameterizedTest
-//        @DisplayName("템플릿 수정 실패: 잘못된 스니펫 순서 입력")
-//        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
-//        void updateTemplateFailWithWrongSnippetOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal) {
-//            // given
-//            createTemplateAndTwoCategories();
-//            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                    "updateTitle",
-//                    "description",
-//                    List.of(
-//                            new CreateSnippetRequest("filename3", "content3", createOrdinal1),
-//                            new CreateSnippetRequest("filename4", "content4", createOrdinal2)
-//                    ),
-//                    List.of(
-//                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
-//                    ),
-//                    List.of(1L),
-//                    2L,
-//                    List.of("tag1", "tag3")
-//            );
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .contentType(ContentType.JSON)
-//                    .body(updateTemplateRequest)
-//                    .when().post("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(400)
-//                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
-//        }
-//
-//        private void createTemplateAndTwoCategories() {
-//            categoryService.create(new CreateCategoryRequest("category1"));
-//            categoryService.create(new CreateCategoryRequest("category2"));
-//            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-//            templateService.createTemplate(templateRequest);
-//        }
-//    }
-//
-//    @Nested
-//    @DisplayName("템플릿 삭제 테스트")
-//    class deleteTemplateTest {
-//
-//        @Test
-//        @DisplayName("템플릿 삭제 성공")
-//        void deleteTemplateSuccess() {
-//            // given
-//            categoryService.create(new CreateCategoryRequest("category"));
-//            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-//            templateService.createTemplate(templateRequest);
-//
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .delete("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(204);
-//        }
-//
-//        @Test
-//        @DisplayName("템플릿 삭제 성공: 존재하지 않는 템플릿 삭제")
-//        void deleteTemplateSuccessWithNotFoundTemplate() {
-//            // when & then
-//            RestAssured.given().log().all()
-//                    .delete("/templates/1")
-//                    .then().log().all()
-//                    .statusCode(204);
-//        }
-//
-//    }
-//
-//    private static CreateTemplateRequest createTemplateRequestWithTwoSnippets(String title) {
-//        CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                title,
-//                "description",
-//                List.of(
-//                        new CreateSnippetRequest("filename1", "content1", 1),
-//                        new CreateSnippetRequest("filename2", "content2", 2)
-//                ),
-//                1L,
-//                List.of("tag1", "tag2")
-//        );
-//        return templateRequest;
-//    }
-//}
+package codezap.template.controller;
+
+import static org.hamcrest.Matchers.is;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.http.HttpHeaders;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+import codezap.category.dto.request.CreateCategoryRequest;
+import codezap.category.service.CategoryService;
+import codezap.fixture.MemberDtoFixture;
+import codezap.member.dto.MemberDto;
+import codezap.template.dto.request.CreateSnippetRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
+import codezap.template.dto.request.UpdateSnippetRequest;
+import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.service.TemplateService;
+import io.restassured.RestAssured;
+import io.restassured.http.ContentType;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+class TemplateControllerTest {
+
+    private static final int MAX_LENGTH = 255;
+
+    @Autowired
+    private TemplateService templateService;
+
+    @Autowired
+    private CategoryService categoryService;
+
+    @LocalServerPort
+    int port;
+
+    String cookie;
+
+    @BeforeEach
+    void setting() {
+        RestAssured.port = port;
+        cookie = HttpHeaders.encodeBasicAuth("test1@email.com", "password1234", StandardCharsets.UTF_8);
+    }
+
+    @Nested
+    @DisplayName("템플릿 생성 테스트")
+    class createTemplateTest {
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 성공")
+        @CsvSource({"a, 65535", "ㄱ, 21845"})
+        void createTemplateSuccess(String repeatTarget, int maxLength) {
+            String maxTitle = "a".repeat(MAX_LENGTH);
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    maxTitle,
+                    repeatTarget.repeat(maxLength),
+                    List.of(new CreateSnippetRequest("a".repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(templateRequest)
+                    .when().post("/templates")
+                    .then().log().all()
+                    .header("Location", "/templates/1")
+                    .statusCode(201);
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 템플릿 이름 길이 초과")
+        void createTemplateFailWithLongTitle() {
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    exceededTitle,
+                    "description",
+                    List.of(new CreateSnippetRequest("a", "content", 1)),
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(templateRequest)
+                    .when().post("/templates")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
+        void createTemplateFailWithLongFileName() {
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSnippetRequest(exceededTitle, "content", 1)),
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(templateRequest)
+                    .when().post("/templates")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSnippetRequest("title", repeatTarget.repeat(exceededLength), 1)),
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(templateRequest)
+                    .when().post("/templates")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    repeatTarget.repeat(exceededLength),
+                    List.of(new CreateSnippetRequest("title", "content", 1)),
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(templateRequest)
+                    .when().post("/templates")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 잘못된 스니펫 순서 입력")
+        @CsvSource({"0, 1", "1, 3", "2, 1"})
+        void createTemplateFailWithWrongSnippetOrdinal(int firstIndex, int secondIndex) {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSnippetRequest("title", "content", firstIndex),
+                            new CreateSnippetRequest("title", "content", secondIndex)),
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            RestAssured.given().log().all()
+                    .contentType(ContentType.JSON)
+                    .body(templateRequest)
+                    .when().post("/templates")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
+        }
+    }
+
+    @Test
+    @DisplayName("템플릿 전체 조회 성공")
+    void findAllTemplatesSuccess() {
+        // given
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSnippets("title1");
+        CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSnippets("title2");
+        templateService.createTemplate(templateRequest1, memberDto);
+        templateService.createTemplate(templateRequest2, memberDto);
+
+        // when & then
+        RestAssured.given().log().all()
+                .cookie("Authorization", cookie)
+                .get("/templates")
+                .then().log().all()
+                .statusCode(200)
+                .body("templates.size()", is(2));
+    }
+
+    @Nested
+    @DisplayName("템플릿 상세 조회 테스트")
+    class findTemplateTest {
+
+        @Test
+        @DisplayName("템플릿 상세 조회 성공")
+        void findOneTemplateSuccess() {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
+            templateService.createTemplate(templateRequest, memberDto);
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .get("/templates/1")
+                    .then().log().all()
+                    .statusCode(200)
+                    .body("title", is(templateRequest.title()),
+                            "snippets.size()", is(2),
+                            "category.id", is(1),
+                            "category.name", is("카테고리 없음"),
+                            "tags.size()", is(2));
+        }
+
+        @Test
+        @DisplayName("템플릿 상세 조회 실패: 존재하지 않는 템플릿 조회")
+        void findOneTemplateFailWithNotFoundTemplate() {
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .get("/templates/1")
+                    .then().log().all()
+                    .statusCode(404)
+                    .body("detail", is("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 수정 테스트")
+    class updateTemplateTest {
+
+        @Test
+        @DisplayName("템플릿 수정 성공")
+        void updateTemplateSuccess() {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSnippetRequest("filename3", "content3", 2),
+                            new CreateSnippetRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    1L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateTemplateRequest)
+                    .when().post("/templates/1")
+                    .then().log().all()
+                    .statusCode(200);
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 템플릿 이름 길이 초과")
+        void updateTemplateFailWithLongName() {
+            // given
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    exceededTitle,
+                    "description",
+                    List.of(
+                            new CreateSnippetRequest("filename3", "content3", 2),
+                            new CreateSnippetRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateTemplateRequest)
+                    .when().post("/templates/1")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("템플릿 이름은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 파일 이름 길이 초과")
+        void updateTemplateFailWithLongFileName() {
+            // given
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSnippetRequest(exceededTitle, "content3", 2),
+                            new CreateSnippetRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateTemplateRequest)
+                    .when().post("/templates/1")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("파일 이름은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 파일 내용 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSnippetRequest("filename3", repeatTarget.repeat(exceedLength), 2),
+                            new CreateSnippetRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateTemplateRequest)
+                    .when().post("/templates/1")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("파일 내용은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 템플릿 설명 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    repeatTarget.repeat(exceedLength),
+                    List.of(
+                            new CreateSnippetRequest("filename3", "content3", 2),
+                            new CreateSnippetRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateTemplateRequest)
+                    .when().post("/templates/1")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        // 정상 요청: 2, 3, 1
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 잘못된 스니펫 순서 입력")
+        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
+        void updateTemplateFailWithWrongSnippetOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal) {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSnippetRequest("filename3", "content3", createOrdinal1),
+                            new CreateSnippetRequest("filename4", "content4", createOrdinal2)
+                    ),
+                    List.of(
+                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .contentType(ContentType.JSON)
+                    .body(updateTemplateRequest)
+                    .when().post("/templates/1")
+                    .then().log().all()
+                    .statusCode(400)
+                    .body("detail", is("스니펫 순서가 잘못되었습니다."));
+        }
+
+        private void createTemplateAndTwoCategories() {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(new CreateCategoryRequest("category1"), memberDto);
+            categoryService.create(new CreateCategoryRequest("category2"), memberDto);
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
+            templateService.createTemplate(templateRequest, memberDto);
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 삭제 테스트")
+    class deleteTemplateTest {
+
+        @Test
+        @DisplayName("템플릿 삭제 성공")
+        void deleteTemplateSuccess() {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(new CreateCategoryRequest("category"), memberDto);
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
+            templateService.createTemplate(templateRequest, memberDto);
+
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .delete("/templates/1")
+                    .then().log().all()
+                    .statusCode(204);
+        }
+
+        @Test
+        @DisplayName("템플릿 삭제 실패: 존재하지 않는 템플릿 삭제")
+        void deleteTemplateFailWithNotFoundTemplate() {
+            // when & then
+            RestAssured.given().log().all()
+                    .cookie("Authorization", cookie)
+                    .delete("/templates/1")
+                    .then().log().all()
+                    .statusCode(404);
+        }
+    }
+
+    private static CreateTemplateRequest createTemplateRequestWithTwoSnippets(String title) {
+        CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                title,
+                "description",
+                List.of(
+                        new CreateSnippetRequest("filename1", "content1", 1),
+                        new CreateSnippetRequest("filename2", "content2", 2)
+                ),
+                1L,
+                List.of("tag1", "tag2")
+        );
+        return templateRequest;
+    }
+}

--- a/backend/src/test/java/codezap/template/repository/SnippetRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/SnippetRepositoryTest.java
@@ -1,75 +1,75 @@
-package codezap.template.repository;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.util.List;
-
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.http.HttpStatus;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-import org.springframework.transaction.annotation.Transactional;
-
-import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
-import codezap.global.exception.CodeZapException;
-import codezap.template.domain.Snippet;
-import codezap.template.domain.Template;
-
-@SpringBootTest
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-@Transactional
-class SnippetRepositoryTest {
-
-    @Autowired
-    private SnippetRepository snippetRepository;
-    @Autowired
-    private TemplateRepository templateRepository;
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Test
-    @DisplayName("단일 스니펫 찾기 성공: 템플릿과 순서")
-    void findOneSnippetSuccessWithTemplateAndOrdinal() {
-        Category category = categoryRepository.save(new Category("category"));
-        Template template = templateRepository.save(new Template("title", "description", category));
-        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
-        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
-
-        Snippet foundSnippet = snippetRepository.findByTemplateAndOrdinal(template, 2)
-                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "해당하는 스니펫이 존재하지 않습니다."));
-
-        assertAll(
-                () -> assertThat(foundSnippet.getTemplate().getTitle()).isEqualTo(template.getTitle()),
-                () -> assertThat(foundSnippet.getFilename()).isEqualTo(snippet2.getFilename()),
-                () -> assertThat(foundSnippet.getContent()).isEqualTo(snippet2.getContent()),
-                () -> assertThat(foundSnippet.getOrdinal()).isEqualTo(snippet2.getOrdinal())
-        );
-    }
-
-    @Test
-    @DisplayName("스니펫 리스트 찾기 성공: 템플릿과 순서")
-    void findSnippetsSuccessWithTemplateAndOrdinal() {
-        Category category = categoryRepository.save(new Category("category"));
-        Template template = templateRepository.save(new Template("title", "description", category));
-        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
-        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
-        Snippet snippet3 = snippetRepository.save(new Snippet(template, "filename3", "content3", 2));
-
-        List<Snippet> foundSnippets = snippetRepository.findAllByTemplateAndOrdinal(template, 2);
-
-        assertAll(
-                () -> assertThat(foundSnippets).hasSize(2),
-                () -> assertThat(foundSnippets).allMatch(snippet -> snippet.getTemplate().getId().equals(1L)),
-                () -> assertThat(foundSnippets).anyMatch(
-                        snippet -> snippet.getFilename().equals(snippet2.getFilename())),
-                () -> assertThat(foundSnippets).anyMatch(
-                        snippet -> snippet.getFilename().equals(snippet3.getFilename()))
-        );
-    }
-}
+//package codezap.template.repository;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.junit.jupiter.api.Assertions.assertAll;
+//
+//import java.util.List;
+//
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.http.HttpStatus;
+//import org.springframework.test.context.jdbc.Sql;
+//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+//import org.springframework.transaction.annotation.Transactional;
+//
+//import codezap.category.domain.Category;
+//import codezap.category.repository.CategoryRepository;
+//import codezap.global.exception.CodeZapException;
+//import codezap.template.domain.Snippet;
+//import codezap.template.domain.Template;
+//
+//@SpringBootTest
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+//@Transactional
+//class SnippetRepositoryTest {
+//
+//    @Autowired
+//    private SnippetRepository snippetRepository;
+//    @Autowired
+//    private TemplateRepository templateRepository;
+//    @Autowired
+//    private CategoryRepository categoryRepository;
+//
+//    @Test
+//    @DisplayName("단일 스니펫 찾기 성공: 템플릿과 순서")
+//    void findOneSnippetSuccessWithTemplateAndOrdinal() {
+//        Category category = categoryRepository.save(new Category("category"));
+//        Template template = templateRepository.save(new Template("title", "description", category));
+//        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
+//        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
+//
+//        Snippet foundSnippet = snippetRepository.findByTemplateAndOrdinal(template, 2)
+//                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "해당하는 스니펫이 존재하지 않습니다."));
+//
+//        assertAll(
+//                () -> assertThat(foundSnippet.getTemplate().getTitle()).isEqualTo(template.getTitle()),
+//                () -> assertThat(foundSnippet.getFilename()).isEqualTo(snippet2.getFilename()),
+//                () -> assertThat(foundSnippet.getContent()).isEqualTo(snippet2.getContent()),
+//                () -> assertThat(foundSnippet.getOrdinal()).isEqualTo(snippet2.getOrdinal())
+//        );
+//    }
+//
+//    @Test
+//    @DisplayName("스니펫 리스트 찾기 성공: 템플릿과 순서")
+//    void findSnippetsSuccessWithTemplateAndOrdinal() {
+//        Category category = categoryRepository.save(new Category("category"));
+//        Template template = templateRepository.save(new Template("title", "description", category));
+//        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
+//        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
+//        Snippet snippet3 = snippetRepository.save(new Snippet(template, "filename3", "content3", 2));
+//
+//        List<Snippet> foundSnippets = snippetRepository.findAllByTemplateAndOrdinal(template, 2);
+//
+//        assertAll(
+//                () -> assertThat(foundSnippets).hasSize(2),
+//                () -> assertThat(foundSnippets).allMatch(snippet -> snippet.getTemplate().getId().equals(1L)),
+//                () -> assertThat(foundSnippets).anyMatch(
+//                        snippet -> snippet.getFilename().equals(snippet2.getFilename())),
+//                () -> assertThat(foundSnippets).anyMatch(
+//                        snippet -> snippet.getFilename().equals(snippet3.getFilename()))
+//        );
+//    }
+//}

--- a/backend/src/test/java/codezap/template/repository/SnippetRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/SnippetRepositoryTest.java
@@ -1,75 +1,85 @@
-//package codezap.template.repository;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.junit.jupiter.api.Assertions.assertAll;
-//
-//import java.util.List;
-//
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.http.HttpStatus;
-//import org.springframework.test.context.jdbc.Sql;
-//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-//import org.springframework.transaction.annotation.Transactional;
-//
-//import codezap.category.domain.Category;
-//import codezap.category.repository.CategoryRepository;
-//import codezap.global.exception.CodeZapException;
-//import codezap.template.domain.Snippet;
-//import codezap.template.domain.Template;
-//
-//@SpringBootTest
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-//@Transactional
-//class SnippetRepositoryTest {
-//
-//    @Autowired
-//    private SnippetRepository snippetRepository;
-//    @Autowired
-//    private TemplateRepository templateRepository;
-//    @Autowired
-//    private CategoryRepository categoryRepository;
-//
-//    @Test
-//    @DisplayName("단일 스니펫 찾기 성공: 템플릿과 순서")
-//    void findOneSnippetSuccessWithTemplateAndOrdinal() {
-//        Category category = categoryRepository.save(new Category("category"));
-//        Template template = templateRepository.save(new Template("title", "description", category));
-//        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
-//        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
-//
-//        Snippet foundSnippet = snippetRepository.findByTemplateAndOrdinal(template, 2)
-//                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "해당하는 스니펫이 존재하지 않습니다."));
-//
-//        assertAll(
-//                () -> assertThat(foundSnippet.getTemplate().getTitle()).isEqualTo(template.getTitle()),
-//                () -> assertThat(foundSnippet.getFilename()).isEqualTo(snippet2.getFilename()),
-//                () -> assertThat(foundSnippet.getContent()).isEqualTo(snippet2.getContent()),
-//                () -> assertThat(foundSnippet.getOrdinal()).isEqualTo(snippet2.getOrdinal())
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("스니펫 리스트 찾기 성공: 템플릿과 순서")
-//    void findSnippetsSuccessWithTemplateAndOrdinal() {
-//        Category category = categoryRepository.save(new Category("category"));
-//        Template template = templateRepository.save(new Template("title", "description", category));
-//        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
-//        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
-//        Snippet snippet3 = snippetRepository.save(new Snippet(template, "filename3", "content3", 2));
-//
-//        List<Snippet> foundSnippets = snippetRepository.findAllByTemplateAndOrdinal(template, 2);
-//
-//        assertAll(
-//                () -> assertThat(foundSnippets).hasSize(2),
-//                () -> assertThat(foundSnippets).allMatch(snippet -> snippet.getTemplate().getId().equals(1L)),
-//                () -> assertThat(foundSnippets).anyMatch(
-//                        snippet -> snippet.getFilename().equals(snippet2.getFilename())),
-//                () -> assertThat(foundSnippets).anyMatch(
-//                        snippet -> snippet.getFilename().equals(snippet3.getFilename()))
-//        );
-//    }
-//}
+package codezap.template.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.HttpStatus;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.transaction.annotation.Transactional;
+
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.fixture.MemberDtoFixture;
+import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+import codezap.member.dto.MemberDto;
+import codezap.member.repository.MemberJpaRepository;
+import codezap.template.domain.Snippet;
+import codezap.template.domain.Template;
+
+@SpringBootTest
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+@Transactional
+class SnippetRepositoryTest {
+
+    @Autowired
+    private SnippetRepository snippetRepository;
+    @Autowired
+    private TemplateRepository templateRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    @Test
+    @DisplayName("단일 스니펫 찾기 성공: 템플릿과 순서")
+    void findOneSnippetSuccessWithTemplateAndOrdinal() {
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        Category category = categoryRepository.save(new Category("category", member));
+        Template template = templateRepository.save(new Template(member, "title", "description", category));
+        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
+        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
+
+        Snippet foundSnippet = snippetRepository.findByTemplateAndOrdinal(template, 2)
+                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "해당하는 스니펫이 존재하지 않습니다."));
+
+        assertAll(
+                () -> assertThat(foundSnippet.getTemplate().getTitle()).isEqualTo(template.getTitle()),
+                () -> assertThat(foundSnippet.getFilename()).isEqualTo(snippet2.getFilename()),
+                () -> assertThat(foundSnippet.getContent()).isEqualTo(snippet2.getContent()),
+                () -> assertThat(foundSnippet.getOrdinal()).isEqualTo(snippet2.getOrdinal())
+        );
+    }
+
+    @Test
+    @DisplayName("스니펫 리스트 찾기 성공: 템플릿과 순서")
+    void findSnippetsSuccessWithTemplateAndOrdinal() {
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        Category category = categoryRepository.save(new Category("category", member));
+        Template template = templateRepository.save(new Template(member, "title", "description", category));
+        Snippet snippet1 = snippetRepository.save(new Snippet(template, "filename1", "content1", 1));
+        Snippet snippet2 = snippetRepository.save(new Snippet(template, "filename2", "content2", 2));
+        Snippet snippet3 = snippetRepository.save(new Snippet(template, "filename3", "content3", 2));
+
+        List<Snippet> foundSnippets = snippetRepository.findAllByTemplateAndOrdinal(template, 2);
+
+        assertAll(
+                () -> assertThat(foundSnippets).hasSize(2),
+                () -> assertThat(foundSnippets).allMatch(snippet -> snippet.getTemplate().getId().equals(1L)),
+                () -> assertThat(foundSnippets).anyMatch(
+                        snippet -> snippet.getFilename().equals(snippet2.getFilename())),
+                () -> assertThat(foundSnippets).anyMatch(
+                        snippet -> snippet.getFilename().equals(snippet3.getFilename()))
+        );
+    }
+}

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -1,220 +1,237 @@
-//package codezap.template.service;
-//
-//import static org.assertj.core.api.Assertions.assertThat;
-//import static org.junit.jupiter.api.Assertions.assertAll;
-//
-//import java.util.List;
-//
-//import org.junit.jupiter.api.BeforeEach;
-//import org.junit.jupiter.api.DisplayName;
-//import org.junit.jupiter.api.Test;
-//import org.springframework.beans.factory.annotation.Autowired;
-//import org.springframework.boot.test.context.SpringBootTest;
-//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-//import org.springframework.boot.test.web.server.LocalServerPort;
-//import org.springframework.test.context.jdbc.Sql;
-//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-//
-//import codezap.category.domain.Category;
-//import codezap.category.repository.CategoryRepository;
-//import codezap.template.domain.Snippet;
-//import codezap.template.domain.Tag;
-//import codezap.template.domain.Template;
-//import codezap.template.domain.TemplateTag;
-//import codezap.template.domain.ThumbnailSnippet;
-//import codezap.template.dto.request.CreateSnippetRequest;
-//import codezap.template.dto.request.CreateTemplateRequest;
-//import codezap.template.dto.request.UpdateSnippetRequest;
-//import codezap.template.dto.request.UpdateTemplateRequest;
-//import codezap.template.dto.response.FindAllTemplatesResponse;
-//import codezap.template.dto.response.FindTemplateResponse;
-//import codezap.template.repository.SnippetRepository;
-//import codezap.template.repository.TagRepository;
-//import codezap.template.repository.TemplateRepository;
-//import codezap.template.repository.TemplateTagRepository;
-//import codezap.template.repository.ThumbnailSnippetRepository;
-//import io.restassured.RestAssured;
-//
-//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-//class TemplateServiceTest {
-//
-//    @LocalServerPort
-//    int port;
-//
-//    @Autowired
-//    private TemplateService templateService;
-//
-//    @Autowired
-//    private TemplateRepository templateRepository;
-//
-//    @Autowired
-//    private SnippetRepository snippetRepository;
-//
-//    @Autowired
-//    private ThumbnailSnippetRepository thumbnailSnippetRepository;
-//
-//    @Autowired
-//    private CategoryRepository categoryRepository;
-//
-//    @Autowired
-//    private TemplateTagRepository templateTagRepository;
-//    @Autowired
-//    private TagRepository tagRepository;
-//
-//    @BeforeEach
-//    void setting() {
-//        RestAssured.port = port;
-//    }
-//
-//    @Test
-//    @DisplayName("템플릿 생성 성공")
-//    void createTemplateSuccess() {
-//        // given
-//        categoryRepository.save(new Category("category"));
-//        CreateTemplateRequest createTemplateRequest = makeTemplateRequest("title");
-//
-//        // when
-//        Long id = templateService.createTemplate(createTemplateRequest);
-//        Template template = templateRepository.fetchById(id);
-//
-//        // then
-//        assertAll(
-//                () -> assertThat(templateRepository.findAll()).hasSize(1),
-//                () -> assertThat(template.getTitle()).isEqualTo(createTemplateRequest.title()),
-//                () -> assertThat(template.getCategory().getName()).isEqualTo("category")
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("템플릿 전체 조회 성공")
-//    void findAllTemplatesSuccess() {
-//        // given
-//        saveTemplate(makeTemplateRequest("title1"));
-//        saveTemplate(makeTemplateRequest("title2"));
-//
-//        // when
-//        FindAllTemplatesResponse allTemplates = templateService.findAll();
-//
-//        // then
-//        assertThat(allTemplates.templates()).hasSize(2);
-//    }
-//
-//    @Test
-//    @DisplayName("템플릿 단건 조회 성공")
-//    void findOneTemplateSuccess() {
-//        // given
-//        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-//        Template template = saveTemplate(createdTemplate);
-//
-//        // when
-//        FindTemplateResponse foundTemplate = templateService.findById(template.getId());
-//
-//        // then
-//        assertAll(
-//                () -> assertThat(foundTemplate.title()).isEqualTo(template.getTitle()),
-//                () -> assertThat(foundTemplate.snippets()).hasSize(
-//                        snippetRepository.findAllByTemplate(template).size()),
-//                () -> assertThat(foundTemplate.category().id()).isEqualTo(template.getCategory().getId()),
-//                () -> assertThat(foundTemplate.tags()).hasSize(2)
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("템플릿 수정 성공")
-//    void updateTemplateSuccess() {
-//        // given
-//        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-//        Template template = saveTemplate(createdTemplate);
-//        categoryRepository.save(new Category("category2"));
-//
-//        // when
-//        UpdateTemplateRequest updateTemplateRequest = makeUpdateTemplateRequest("updateTitle");
-//        templateService.update(template.getId(), updateTemplateRequest);
-//        Template updateTemplate = templateRepository.fetchById(template.getId());
-//        List<Snippet> snippets = snippetRepository.findAllByTemplate(template);
-//        ThumbnailSnippet thumbnailSnippet = thumbnailSnippetRepository.findById(template.getId()).get();
-//        List<Tag> tags = templateTagRepository.findAllByTemplate(updateTemplate).stream()
-//                .map(TemplateTag::getTag)
-//                .toList();
-//
-//        // then
-//        assertAll(
-//                () -> assertThat(updateTemplate.getTitle()).isEqualTo("updateTitle"),
-//                () -> assertThat(thumbnailSnippet.getSnippet().getId()).isEqualTo(2L),
-//                () -> assertThat(snippets).hasSize(3),
-//                () -> assertThat(updateTemplate.getCategory().getId()).isEqualTo(2L),
-//                () -> assertThat(tags).hasSize(2),
-//                () -> assertThat(tags.get(1).getName()).isEqualTo("tag3")
-//        );
-//    }
-//
-//    @Test
-//    @DisplayName("템플릿 삭제 성공")
-//    void deleteTemplateSuccess() {
-//        // given
-//        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-//        saveTemplate(createdTemplate);
-//
-//        // when
-//        templateService.deleteById(1L);
-//
-//        // then
-//        assertAll(
-//                () -> assertThat(templateRepository.findAll()).isEmpty(),
-//                () -> assertThat(snippetRepository.findAll()).isEmpty(),
-//                () -> assertThat(thumbnailSnippetRepository.findAll()).isEmpty()
-//        );
-//    }
-//
-//    private CreateTemplateRequest makeTemplateRequest(String title) {
-//        return new CreateTemplateRequest(
-//                title,
-//                "description",
-//                List.of(
-//                        new CreateSnippetRequest("filename1", "content1", 1),
-//                        new CreateSnippetRequest("filename2", "content2", 2)
-//                ),
-//                1L,
-//                List.of("tag1", "tag2")
-//        );
-//    }
-//
-//    private UpdateTemplateRequest makeUpdateTemplateRequest(String title) {
-//        return new UpdateTemplateRequest(
-//                title,
-//                "description",
-//                List.of(
-//                        new CreateSnippetRequest("filename3", "content3", 2),
-//                        new CreateSnippetRequest("filename4", "content4", 3)
-//                ),
-//                List.of(
-//                        new UpdateSnippetRequest(2L, "filename2", "content2", 1)
-//                ),
-//                List.of(1L),
-//                2L,
-//                List.of("tag1", "tag3")
-//        );
-//    }
-//
-//    private Template saveTemplate(CreateTemplateRequest createTemplateRequest) {
-//        Category category = categoryRepository.save(new Category("category"));
-//        Template savedTemplate = templateRepository.save(
-//                new Template(
-//                        createTemplateRequest.title(),
-//                        createTemplateRequest.description(),
-//                        category
-//                )
-//        );
-//        Snippet savedFirstSnippet = snippetRepository.save(new Snippet(savedTemplate, "filename1", "content1", 1));
-//        snippetRepository.save(new Snippet(savedTemplate, "filename2", "content2", 2));
-//        thumbnailSnippetRepository.save(new ThumbnailSnippet(savedTemplate, savedFirstSnippet));
-//        createTemplateRequest.tags().stream()
-//                .map(Tag::new)
-//                .map(tagRepository::save)
-//                .forEach(tag -> templateTagRepository.save(new TemplateTag(savedTemplate, tag)));
-//
-//        return savedTemplate;
-//    }
-//}
+package codezap.template.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+import org.springframework.transaction.annotation.Transactional;
+
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.fixture.MemberDtoFixture;
+import codezap.member.domain.Member;
+import codezap.member.dto.MemberDto;
+import codezap.member.repository.MemberJpaRepository;
+import codezap.template.domain.Snippet;
+import codezap.template.domain.Tag;
+import codezap.template.domain.Template;
+import codezap.template.domain.TemplateTag;
+import codezap.template.domain.ThumbnailSnippet;
+import codezap.template.dto.request.CreateSnippetRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
+import codezap.template.dto.request.UpdateSnippetRequest;
+import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.dto.response.ExploreTemplatesResponse;
+import codezap.template.dto.response.FindTemplateResponse;
+import codezap.template.repository.SnippetRepository;
+import codezap.template.repository.TagRepository;
+import codezap.template.repository.TemplateRepository;
+import codezap.template.repository.TemplateTagRepository;
+import codezap.template.repository.ThumbnailSnippetRepository;
+import io.restassured.RestAssured;
+
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+@Transactional
+class TemplateServiceTest {
+
+    @LocalServerPort
+    int port;
+
+    @Autowired
+    private TemplateService templateService;
+
+    @Autowired
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private SnippetRepository snippetRepository;
+
+    @Autowired
+    private ThumbnailSnippetRepository thumbnailSnippetRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TemplateTagRepository templateTagRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private MemberJpaRepository memberJpaRepository;
+
+    @BeforeEach
+    void setting() {
+        RestAssured.port = port;
+    }
+
+    @Test
+    @DisplayName("템플릿 생성 성공")
+    void createTemplateSuccess() {
+        // given
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        CreateTemplateRequest createTemplateRequest = makeTemplateRequest("title");
+
+        // when
+        Long id = templateService.createTemplate(createTemplateRequest, memberDto);
+        Template template = templateRepository.fetchById(id);
+
+        // then
+        assertAll(
+                () -> assertThat(templateRepository.findAll()).hasSize(1),
+                () -> assertThat(template.getTitle()).isEqualTo(createTemplateRequest.title()),
+                () -> assertThat(template.getCategory().getName()).isEqualTo("카테고리 없음")
+        );
+    }
+
+    @Test
+    @DisplayName("템플릿 전체 조회 성공")
+    void findAllTemplatesSuccess() {
+        // given
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        saveTemplate(makeTemplateRequest("title1"), new Category("category1", member), member);
+        saveTemplate(makeTemplateRequest("title2"), new Category("category2", member), member);
+
+        // when
+        ExploreTemplatesResponse allTemplates = templateService.findAll();
+
+        // then
+        assertThat(allTemplates.templates()).hasSize(2);
+    }
+
+    @Test
+    @DisplayName("템플릿 단건 조회 성공")
+    void findOneTemplateSuccess() {
+        // given
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
+        Template template = saveTemplate(createdTemplate, new Category("category1", member), member);
+
+        // when
+        FindTemplateResponse foundTemplate = templateService.findByIdAndMember(template.getId(), memberDto);
+
+        // then
+        assertAll(
+                () -> assertThat(foundTemplate.title()).isEqualTo(template.getTitle()),
+                () -> assertThat(foundTemplate.snippets()).hasSize(
+                        snippetRepository.findAllByTemplate(template).size()),
+                () -> assertThat(foundTemplate.category().id()).isEqualTo(template.getCategory().getId()),
+                () -> assertThat(foundTemplate.tags()).hasSize(2)
+        );
+    }
+
+    @Test
+    @DisplayName("템플릿 수정 성공")
+    void updateTemplateSuccess() {
+        // given
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
+        Template template = saveTemplate(createdTemplate, new Category("category1", member), member);
+        categoryRepository.save(new Category("category2", member));
+
+        // when
+        UpdateTemplateRequest updateTemplateRequest = makeUpdateTemplateRequest("updateTitle");
+        templateService.update(template.getId(), updateTemplateRequest, memberDto);
+        Template updateTemplate = templateRepository.fetchById(template.getId());
+        List<Snippet> snippets = snippetRepository.findAllByTemplate(template);
+        ThumbnailSnippet thumbnailSnippet = thumbnailSnippetRepository.findById(template.getId()).get();
+        List<Tag> tags = templateTagRepository.findAllByTemplate(updateTemplate).stream()
+                .map(TemplateTag::getTag)
+                .toList();
+
+        // then
+        assertAll(
+                () -> assertThat(updateTemplate.getTitle()).isEqualTo("updateTitle"),
+                () -> assertThat(thumbnailSnippet.getSnippet().getId()).isEqualTo(2L),
+                () -> assertThat(snippets).hasSize(3),
+                () -> assertThat(updateTemplate.getCategory().getId()).isEqualTo(1L),
+                () -> assertThat(tags).hasSize(2),
+                () -> assertThat(tags.get(1).getName()).isEqualTo("tag3")
+        );
+    }
+
+    @Test
+    @DisplayName("템플릿 삭제 성공")
+    void deleteTemplateSuccess() {
+        // given
+        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        Member member = memberJpaRepository.fetchById(memberDto.id());
+        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
+        saveTemplate(createdTemplate, new Category("category1", member), member);
+
+        // when
+        templateService.deleteById(1L, memberDto);
+
+        // then
+        assertAll(
+                () -> assertThat(templateRepository.findAll()).isEmpty(),
+                () -> assertThat(snippetRepository.findAll()).isEmpty(),
+                () -> assertThat(thumbnailSnippetRepository.findAll()).isEmpty()
+        );
+    }
+
+    private CreateTemplateRequest makeTemplateRequest(String title) {
+        return new CreateTemplateRequest(
+                title,
+                "description",
+                List.of(
+                        new CreateSnippetRequest("filename1", "content1", 1),
+                        new CreateSnippetRequest("filename2", "content2", 2)
+                ),
+                1L,
+                List.of("tag1", "tag2")
+        );
+    }
+
+    private UpdateTemplateRequest makeUpdateTemplateRequest(String title) {
+        return new UpdateTemplateRequest(
+                title,
+                "description",
+                List.of(
+                        new CreateSnippetRequest("filename3", "content3", 2),
+                        new CreateSnippetRequest("filename4", "content4", 3)
+                ),
+                List.of(
+                        new UpdateSnippetRequest(2L, "filename2", "content2", 1)
+                ),
+                List.of(1L),
+                1L,
+                List.of("tag1", "tag3")
+        );
+    }
+
+    private Template saveTemplate(CreateTemplateRequest createTemplateRequest, Category category, Member member) {
+        Category savedCategory = categoryRepository.save(category);
+        Template savedTemplate = templateRepository.save(
+                new Template(
+                        member,
+                        createTemplateRequest.title(),
+                        createTemplateRequest.description(),
+                        savedCategory
+                )
+        );
+        Snippet savedFirstSnippet = snippetRepository.save(new Snippet(savedTemplate, "filename1", "content1", 1));
+        snippetRepository.save(new Snippet(savedTemplate, "filename2", "content2", 2));
+        thumbnailSnippetRepository.save(new ThumbnailSnippet(savedTemplate, savedFirstSnippet));
+        createTemplateRequest.tags().stream()
+                .map(Tag::new)
+                .map(tagRepository::save)
+                .forEach(tag -> templateTagRepository.save(new TemplateTag(savedTemplate, tag)));
+
+        return savedTemplate;
+    }
+}

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -7,11 +7,13 @@ import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.test.context.jdbc.Sql;
 import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import org.springframework.transaction.annotation.Transactional;
@@ -32,6 +34,7 @@ import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateSnippetRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.ExploreTemplatesResponse;
+import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import codezap.template.repository.SnippetRepository;
 import codezap.template.repository.TagRepository;
@@ -123,11 +126,14 @@ class TemplateServiceTest {
         @BeforeEach
         void setUp() {
             //템플릿 30개 / 카테고리는 홀수 : 1번, 짝수 : 2번으로 매핑 / 태그는 16보다 작으면 1, 16 이상이면 2로 매핑
-            firstCategory = categoryRepository.save(new Category("category1"));
-            categoryRepository.save(new Category("category2"));
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberJpaRepository.fetchById(memberDto.id());
+            firstCategory = categoryRepository.save(new Category("category1", member));
+            categoryRepository.save(new Category("category2", member));
             for (int i = 1; i <= 30; i++) {
                 long categoryId = i % 2 == 0 ? firstCategory.getId() + 1 : firstCategory.getId();
                 templateRepository.save(new Template(
+                        member,
                         "title" + i,
                         "description",
                         categoryRepository.fetchById(categoryId)

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -1,339 +1,220 @@
-package codezap.template.service;
-
-import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertAll;
-
-import java.util.List;
-
-import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.DisplayName;
-import org.junit.jupiter.api.Nested;
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.test.context.jdbc.Sql;
-import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
-
-import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
-import codezap.template.domain.Snippet;
-import codezap.template.domain.Tag;
-import codezap.template.domain.Template;
-import codezap.template.domain.TemplateTag;
-import codezap.template.domain.ThumbnailSnippet;
-import codezap.template.dto.request.CreateSnippetRequest;
-import codezap.template.dto.request.CreateTemplateRequest;
-import codezap.template.dto.request.UpdateSnippetRequest;
-import codezap.template.dto.request.UpdateTemplateRequest;
-import codezap.template.dto.response.ExploreTemplatesResponse;
-import codezap.template.dto.response.FindAllTemplatesResponse;
-import codezap.template.dto.response.FindTemplateResponse;
-import codezap.template.repository.SnippetRepository;
-import codezap.template.repository.TagRepository;
-import codezap.template.repository.TemplateRepository;
-import codezap.template.repository.TemplateTagRepository;
-import codezap.template.repository.ThumbnailSnippetRepository;
-import io.restassured.RestAssured;
-
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
-@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
-class TemplateServiceTest {
-
-    @LocalServerPort
-    int port;
-
-    @Autowired
-    private TemplateService templateService;
-
-    @Autowired
-    private TemplateRepository templateRepository;
-
-    @Autowired
-    private SnippetRepository snippetRepository;
-
-    @Autowired
-    private ThumbnailSnippetRepository thumbnailSnippetRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private TemplateTagRepository templateTagRepository;
-
-    @Autowired
-    private TagRepository tagRepository;
-
-    @BeforeEach
-    void setting() {
-        RestAssured.port = port;
-    }
-
-    @Test
-    @DisplayName("템플릿 생성 성공")
-    void createTemplateSuccess() {
-        // given
-        categoryRepository.save(new Category("category"));
-        CreateTemplateRequest createTemplateRequest = makeTemplateRequest("title");
-
-        // when
-        Long id = templateService.createTemplate(createTemplateRequest);
-        Template template = templateRepository.fetchById(id);
-
-        // then
-        assertAll(
-                () -> assertThat(templateRepository.findAll()).hasSize(1),
-                () -> assertThat(template.getTitle()).isEqualTo(createTemplateRequest.title()),
-                () -> assertThat(template.getCategory().getName()).isEqualTo("category")
-        );
-    }
-
-    @Test
-    @DisplayName("템플릿 전체 조회 성공")
-    void findAllTemplatesSuccess() {
-        // given
-        saveTemplate(makeTemplateRequest("title1"));
-        saveTemplate(makeTemplateRequest("title2"));
-
-        // when
-        ExploreTemplatesResponse allTemplates = templateService.findAll();
-
-        // then
-        assertThat(allTemplates.templates()).hasSize(2);
-    }
-
-    @Nested
-    @DisplayName("조건에 따른 페이지 조회 메서드 동작 확인")
-    class FilteringPageTest {
-
-        private static final PageRequest DEFUALT_PAGING_REQUEST = PageRequest.of(0, 20);
-        private static Category firstCategory;
-        private static Tag tag1;
-        private static Tag tag2;
-
-        @BeforeEach
-        void setUp() {
-            //템플릿 30개 / 카테고리는 홀수 : 1번, 짝수 : 2번으로 매핑 / 태그는 16보다 작으면 1, 16 이상이면 2로 매핑
-            firstCategory = categoryRepository.save(new Category("category1"));
-            categoryRepository.save(new Category("category2"));
-            for (int i = 1; i <= 30; i++) {
-                long categoryId = i % 2 == 0 ? firstCategory.getId() + 1 : firstCategory.getId();
-                templateRepository.save(new Template(
-                        "title" + i,
-                        "description",
-                        categoryRepository.fetchById(categoryId)
-                ));
-
-            }
-            tag1 = tagRepository.save(new Tag("tag1"));
-            tag2 = tagRepository.save(new Tag("tag2"));
-            for (long i = 1L; i <= 30L; i++) {
-                templateTagRepository.save(new TemplateTag(
-                        templateRepository.fetchById(i),
-                        tagRepository.fetchById((i / 16) + 1)
-                ));
-            }
-
-            System.out.println();
-        }
-
-        @Test
-        @DisplayName("전체 탐색 / 1페이지 성공")
-        void findAllFirstPageSuccess() {
-            FindAllTemplatesResponse allBy = templateService.findAllBy(DEFUALT_PAGING_REQUEST, null, null);
-
-            assertAll(
-                    () -> assertThat(allBy.templates().size()).isEqualTo(20),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20),
-                    () -> assertThat(allBy.totalElement()).isEqualTo(30)
-            );
-
-        }
-
-        @Test
-        @DisplayName("전체 탐색 / 2페이지 성공")
-        void findAllSecondPageSuccess() {
-            FindAllTemplatesResponse allBy = templateService.findAllBy(PageRequest.of(1, 20), null, null);
-
-            assertAll(
-                    () -> assertThat(allBy.templates().size()).isEqualTo(10),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() > 20),
-                    () -> assertThat(allBy.totalElement()).isEqualTo(30)
-            );
-        }
-
-        @Test
-        @DisplayName("카테고리 탐색 성공")
-        void findByCategoryPageSuccess() {
-            FindAllTemplatesResponse allBy = templateService.findAllBy(DEFUALT_PAGING_REQUEST, firstCategory.getId(),
-                    null);
-
-            assertAll(
-                    () -> assertThat(allBy.templates().size()).isEqualTo(15),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 1),
-                    () -> assertThat(allBy.totalElement()).isEqualTo(15)
-            );
-        }
-
-        @Test
-        @DisplayName("단일 태그 탐색 성공")
-        void findBySingleTagPageSuccess() {
-            FindAllTemplatesResponse allBy = templateService.findAllBy(DEFUALT_PAGING_REQUEST, null,
-                    List.of(tag1.getName()));
-
-            assertAll(
-                    () -> assertThat(allBy.templates().size()).isEqualTo(15),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16),
-                    () -> assertThat(allBy.totalElement()).isEqualTo(15)
-            );
-        }
-
-        @Test
-        @DisplayName("복수 태그 탐색 성공")
-        void findByMultipleTagPageSuccess() {
-            FindAllTemplatesResponse allBy = templateService.findAllBy(DEFUALT_PAGING_REQUEST, null,
-                    List.of(tag1.getName(), tag2.getName()));
-
-            assertAll(
-                    () -> assertThat(allBy.templates().size()).isEqualTo(20),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 21),
-                    () -> assertThat(allBy.totalElement()).isEqualTo(30)
-            );
-        }
-
-        @Test
-        @DisplayName("카테고리 & 단일 태그 탐색 성공")
-        void findByCategoryAndSingleTagPageSuccess() {
-            FindAllTemplatesResponse allBy = templateService.findAllBy(DEFUALT_PAGING_REQUEST, firstCategory.getId(),
-                    List.of(tag1.getName()));
-
-            assertAll(
-                    () -> assertThat(allBy.templates().size()).isEqualTo(8),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16),
-                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 1),
-                    () -> assertThat(allBy.totalElement()).isEqualTo(8)
-            );
-        }
-    }
-
-    @Test
-    @DisplayName("템플릿 단건 조회 성공")
-    void findOneTemplateSuccess() {
-        // given
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        Template template = saveTemplate(createdTemplate);
-
-        // when
-        FindTemplateResponse foundTemplate = templateService.findById(template.getId());
-
-        // then
-        assertAll(
-                () -> assertThat(foundTemplate.title()).isEqualTo(template.getTitle()),
-                () -> assertThat(foundTemplate.snippets()).hasSize(
-                        snippetRepository.findAllByTemplate(template).size()),
-                () -> assertThat(foundTemplate.category().id()).isEqualTo(template.getCategory().getId()),
-                () -> assertThat(foundTemplate.tags()).hasSize(2)
-        );
-    }
-
-    @Test
-    @DisplayName("템플릿 수정 성공")
-    void updateTemplateSuccess() {
-        // given
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        Template template = saveTemplate(createdTemplate);
-        categoryRepository.save(new Category("category2"));
-
-        // when
-        UpdateTemplateRequest updateTemplateRequest = makeUpdateTemplateRequest("updateTitle");
-        templateService.update(template.getId(), updateTemplateRequest);
-
-        Template updateTemplate = templateRepository.fetchById(template.getId());
-        List<Snippet> snippets = snippetRepository.findAllByTemplate(template);
-        ThumbnailSnippet thumbnailSnippet = thumbnailSnippetRepository.findById(template.getId()).get();
-        List<Tag> tags = templateTagRepository.findAllByTemplate(updateTemplate).stream()
-                .map(TemplateTag::getTag)
-                .toList();
-
-        // then
-        assertAll(
-                () -> assertThat(updateTemplate.getTitle()).isEqualTo("updateTitle"),
-                () -> assertThat(thumbnailSnippet.getSnippet().getId()).isEqualTo(2L),
-                () -> assertThat(snippets).hasSize(3),
-                () -> assertThat(updateTemplate.getCategory().getId()).isEqualTo(2L),
-                () -> assertThat(tags).hasSize(2),
-                () -> assertThat(tags.get(1).getName()).isEqualTo("tag3")
-        );
-    }
-
-    @Test
-    @DisplayName("템플릿 삭제 성공")
-    void deleteTemplateSuccess() {
-        // given
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        saveTemplate(createdTemplate);
-
-        // when
-        templateService.deleteById(1L);
-
-        // then
-        assertAll(
-                () -> assertThat(templateRepository.findAll()).isEmpty(),
-                () -> assertThat(snippetRepository.findAll()).isEmpty(),
-                () -> assertThat(thumbnailSnippetRepository.findAll()).isEmpty()
-        );
-    }
-
-    private CreateTemplateRequest makeTemplateRequest(String title) {
-        return new CreateTemplateRequest(
-                title,
-                "description",
-                List.of(
-                        new CreateSnippetRequest("filename1", "content1", 1),
-                        new CreateSnippetRequest("filename2", "content2", 2)
-                ),
-                1L,
-                List.of("tag1", "tag2")
-        );
-    }
-
-    private UpdateTemplateRequest makeUpdateTemplateRequest(String title) {
-        return new UpdateTemplateRequest(
-                title,
-                "description",
-                List.of(
-                        new CreateSnippetRequest("filename3", "content3", 2),
-                        new CreateSnippetRequest("filename4", "content4", 3)
-                ),
-                List.of(
-                        new UpdateSnippetRequest(2L, "filenameff", "content2", 1)
-                ),
-                List.of(1L),
-                2L,
-                List.of("tag1", "tag3")
-        );
-    }
-
-    private Template saveTemplate(CreateTemplateRequest createTemplateRequest) {
-        Category category = categoryRepository.save(new Category("category"));
-        Template savedTemplate = templateRepository.save(
-                new Template(
-                        createTemplateRequest.title(),
-                        createTemplateRequest.description(),
-                        category
-                )
-        );
-        Snippet savedFirstSnippet = snippetRepository.save(new Snippet(savedTemplate, "filename1", "content1", 1));
-        snippetRepository.save(new Snippet(savedTemplate, "filename2", "content2", 2));
-        thumbnailSnippetRepository.save(new ThumbnailSnippet(savedTemplate, savedFirstSnippet));
-        createTemplateRequest.tags().stream()
-                .map(Tag::new)
-                .map(tagRepository::save)
-                .forEach(tag -> templateTagRepository.save(new TemplateTag(savedTemplate, tag)));
-
-        return savedTemplate;
-    }
-}
+//package codezap.template.service;
+//
+//import static org.assertj.core.api.Assertions.assertThat;
+//import static org.junit.jupiter.api.Assertions.assertAll;
+//
+//import java.util.List;
+//
+//import org.junit.jupiter.api.BeforeEach;
+//import org.junit.jupiter.api.DisplayName;
+//import org.junit.jupiter.api.Test;
+//import org.springframework.beans.factory.annotation.Autowired;
+//import org.springframework.boot.test.context.SpringBootTest;
+//import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+//import org.springframework.boot.test.web.server.LocalServerPort;
+//import org.springframework.test.context.jdbc.Sql;
+//import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+//
+//import codezap.category.domain.Category;
+//import codezap.category.repository.CategoryRepository;
+//import codezap.template.domain.Snippet;
+//import codezap.template.domain.Tag;
+//import codezap.template.domain.Template;
+//import codezap.template.domain.TemplateTag;
+//import codezap.template.domain.ThumbnailSnippet;
+//import codezap.template.dto.request.CreateSnippetRequest;
+//import codezap.template.dto.request.CreateTemplateRequest;
+//import codezap.template.dto.request.UpdateSnippetRequest;
+//import codezap.template.dto.request.UpdateTemplateRequest;
+//import codezap.template.dto.response.FindAllTemplatesResponse;
+//import codezap.template.dto.response.FindTemplateResponse;
+//import codezap.template.repository.SnippetRepository;
+//import codezap.template.repository.TagRepository;
+//import codezap.template.repository.TemplateRepository;
+//import codezap.template.repository.TemplateTagRepository;
+//import codezap.template.repository.ThumbnailSnippetRepository;
+//import io.restassured.RestAssured;
+//
+//@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.BEFORE_TEST_METHOD)
+//@Sql(value = "/clear.sql", executionPhase = ExecutionPhase.AFTER_TEST_CLASS)
+//class TemplateServiceTest {
+//
+//    @LocalServerPort
+//    int port;
+//
+//    @Autowired
+//    private TemplateService templateService;
+//
+//    @Autowired
+//    private TemplateRepository templateRepository;
+//
+//    @Autowired
+//    private SnippetRepository snippetRepository;
+//
+//    @Autowired
+//    private ThumbnailSnippetRepository thumbnailSnippetRepository;
+//
+//    @Autowired
+//    private CategoryRepository categoryRepository;
+//
+//    @Autowired
+//    private TemplateTagRepository templateTagRepository;
+//    @Autowired
+//    private TagRepository tagRepository;
+//
+//    @BeforeEach
+//    void setting() {
+//        RestAssured.port = port;
+//    }
+//
+//    @Test
+//    @DisplayName("템플릿 생성 성공")
+//    void createTemplateSuccess() {
+//        // given
+//        categoryRepository.save(new Category("category"));
+//        CreateTemplateRequest createTemplateRequest = makeTemplateRequest("title");
+//
+//        // when
+//        Long id = templateService.createTemplate(createTemplateRequest);
+//        Template template = templateRepository.fetchById(id);
+//
+//        // then
+//        assertAll(
+//                () -> assertThat(templateRepository.findAll()).hasSize(1),
+//                () -> assertThat(template.getTitle()).isEqualTo(createTemplateRequest.title()),
+//                () -> assertThat(template.getCategory().getName()).isEqualTo("category")
+//        );
+//    }
+//
+//    @Test
+//    @DisplayName("템플릿 전체 조회 성공")
+//    void findAllTemplatesSuccess() {
+//        // given
+//        saveTemplate(makeTemplateRequest("title1"));
+//        saveTemplate(makeTemplateRequest("title2"));
+//
+//        // when
+//        FindAllTemplatesResponse allTemplates = templateService.findAll();
+//
+//        // then
+//        assertThat(allTemplates.templates()).hasSize(2);
+//    }
+//
+//    @Test
+//    @DisplayName("템플릿 단건 조회 성공")
+//    void findOneTemplateSuccess() {
+//        // given
+//        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
+//        Template template = saveTemplate(createdTemplate);
+//
+//        // when
+//        FindTemplateResponse foundTemplate = templateService.findById(template.getId());
+//
+//        // then
+//        assertAll(
+//                () -> assertThat(foundTemplate.title()).isEqualTo(template.getTitle()),
+//                () -> assertThat(foundTemplate.snippets()).hasSize(
+//                        snippetRepository.findAllByTemplate(template).size()),
+//                () -> assertThat(foundTemplate.category().id()).isEqualTo(template.getCategory().getId()),
+//                () -> assertThat(foundTemplate.tags()).hasSize(2)
+//        );
+//    }
+//
+//    @Test
+//    @DisplayName("템플릿 수정 성공")
+//    void updateTemplateSuccess() {
+//        // given
+//        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
+//        Template template = saveTemplate(createdTemplate);
+//        categoryRepository.save(new Category("category2"));
+//
+//        // when
+//        UpdateTemplateRequest updateTemplateRequest = makeUpdateTemplateRequest("updateTitle");
+//        templateService.update(template.getId(), updateTemplateRequest);
+//        Template updateTemplate = templateRepository.fetchById(template.getId());
+//        List<Snippet> snippets = snippetRepository.findAllByTemplate(template);
+//        ThumbnailSnippet thumbnailSnippet = thumbnailSnippetRepository.findById(template.getId()).get();
+//        List<Tag> tags = templateTagRepository.findAllByTemplate(updateTemplate).stream()
+//                .map(TemplateTag::getTag)
+//                .toList();
+//
+//        // then
+//        assertAll(
+//                () -> assertThat(updateTemplate.getTitle()).isEqualTo("updateTitle"),
+//                () -> assertThat(thumbnailSnippet.getSnippet().getId()).isEqualTo(2L),
+//                () -> assertThat(snippets).hasSize(3),
+//                () -> assertThat(updateTemplate.getCategory().getId()).isEqualTo(2L),
+//                () -> assertThat(tags).hasSize(2),
+//                () -> assertThat(tags.get(1).getName()).isEqualTo("tag3")
+//        );
+//    }
+//
+//    @Test
+//    @DisplayName("템플릿 삭제 성공")
+//    void deleteTemplateSuccess() {
+//        // given
+//        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
+//        saveTemplate(createdTemplate);
+//
+//        // when
+//        templateService.deleteById(1L);
+//
+//        // then
+//        assertAll(
+//                () -> assertThat(templateRepository.findAll()).isEmpty(),
+//                () -> assertThat(snippetRepository.findAll()).isEmpty(),
+//                () -> assertThat(thumbnailSnippetRepository.findAll()).isEmpty()
+//        );
+//    }
+//
+//    private CreateTemplateRequest makeTemplateRequest(String title) {
+//        return new CreateTemplateRequest(
+//                title,
+//                "description",
+//                List.of(
+//                        new CreateSnippetRequest("filename1", "content1", 1),
+//                        new CreateSnippetRequest("filename2", "content2", 2)
+//                ),
+//                1L,
+//                List.of("tag1", "tag2")
+//        );
+//    }
+//
+//    private UpdateTemplateRequest makeUpdateTemplateRequest(String title) {
+//        return new UpdateTemplateRequest(
+//                title,
+//                "description",
+//                List.of(
+//                        new CreateSnippetRequest("filename3", "content3", 2),
+//                        new CreateSnippetRequest("filename4", "content4", 3)
+//                ),
+//                List.of(
+//                        new UpdateSnippetRequest(2L, "filename2", "content2", 1)
+//                ),
+//                List.of(1L),
+//                2L,
+//                List.of("tag1", "tag3")
+//        );
+//    }
+//
+//    private Template saveTemplate(CreateTemplateRequest createTemplateRequest) {
+//        Category category = categoryRepository.save(new Category("category"));
+//        Template savedTemplate = templateRepository.save(
+//                new Template(
+//                        createTemplateRequest.title(),
+//                        createTemplateRequest.description(),
+//                        category
+//                )
+//        );
+//        Snippet savedFirstSnippet = snippetRepository.save(new Snippet(savedTemplate, "filename1", "content1", 1));
+//        snippetRepository.save(new Snippet(savedTemplate, "filename2", "content2", 2));
+//        thumbnailSnippetRepository.save(new ThumbnailSnippet(savedTemplate, savedFirstSnippet));
+//        createTemplateRequest.tags().stream()
+//                .map(Tag::new)
+//                .map(tagRepository::save)
+//                .forEach(tag -> templateTagRepository.save(new TemplateTag(savedTemplate, tag)));
+//
+//        return savedTemplate;
+//    }
+//}

--- a/backend/src/test/resources/clear.sql
+++ b/backend/src/test/resources/clear.sql
@@ -4,31 +4,49 @@ DROP TABLE IF EXISTS template_tag;
 DROP TABLE IF EXISTS tag;
 DROP TABLE IF EXISTS template;
 DROP TABLE IF EXISTS category;
+DROP TABLE IF EXISTS member;
+
+create table member
+(
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    email       VARCHAR(255) NOT NULL,
+    password    VARCHAR(255) NOT NULL,
+    username    VARCHAR(255) NOT NULL,
+    created_at  DATETIME(6)  NOT NULL,
+    modified_at DATETIME(6)  NOT NULL,
+    primary key (id)
+);
 
 CREATE TABLE category
 (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id   BIGINT       NOT NULL,
     name        VARCHAR(255) NOT NULL,
-    created_at  DATETIME(6) NOT NULL,
-    modified_at DATETIME(6) NOT NULL,
-    PRIMARY KEY (id)
+    is_default  TINYINT(1)   NOT NULL,
+    created_at  DATETIME(6)  NOT NULL,
+    modified_at DATETIME(6)  NOT NULL,
+    PRIMARY KEY (id),
+    FOREIGN KEY (member_id) REFERENCES member (id),
+    CONSTRAINT name_with_member UNIQUE (member_id, name)
 );
 
 CREATE TABLE template
 (
     id          BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id   BIGINT       NOT NULL,
     title       VARCHAR(255) NOT NULL,
     description TEXT,
     category_id BIGINT       NOT NULL,
     created_at  DATETIME(6)  NOT NULL,
     modified_at DATETIME(6)  NOT NULL,
     PRIMARY KEY (id),
-    FOREIGN KEY (category_id) REFERENCES category (id)
+    FOREIGN KEY (category_id) REFERENCES category (id),
+    FOREIGN KEY (member_id) REFERENCES member (id)
 );
 
 create table tag
 (
-    id          BIGINT       NOT NULL auto_increment,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
     name        VARCHAR(255) NOT NULL,
     created_at  DATETIME(6)  NOT NULL,
     modified_at DATETIME(6)  NOT NULL,
@@ -37,8 +55,8 @@ create table tag
 
 create table template_tag
 (
-    template_id BIGINT NOT NULL,
-    tag_id      BIGINT NOT NULL,
+    template_id BIGINT      NOT NULL,
+    tag_id      BIGINT      NOT NULL,
     created_at  DATETIME(6) NOT NULL,
     modified_at DATETIME(6) NOT NULL,
     PRIMARY KEY (template_id, tag_id),
@@ -61,12 +79,22 @@ CREATE TABLE snippet
 
 CREATE TABLE thumbnail_snippet
 (
-    id          BIGINT NOT NULL AUTO_INCREMENT,
-    template_id BIGINT NOT NULL,
-    snippet_id  BIGINT NOT NULL,
+    id          BIGINT      NOT NULL AUTO_INCREMENT,
+    template_id BIGINT      NOT NULL,
+    snippet_id  BIGINT      NOT NULL,
     created_at  DATETIME(6) NOT NULL,
     modified_at DATETIME(6) NOT NULL,
     PRIMARY KEY (id),
     FOREIGN KEY (template_id) REFERENCES template (id),
     FOREIGN KEY (snippet_id) REFERENCES snippet (id)
 );
+
+INSERT INTO member (email, password, username, created_at, modified_at)
+VALUES ('test1@email.com', 'password1234', 'username1', '2024-08-06', '2024-08-06');
+INSERT INTO member (email, password, username, created_at, modified_at)
+VALUES ('test2@email.com', 'password1234', 'username2', '2024-08-06', '2024-08-06');
+
+INSERT INTO category (member_id, name, is_default, created_at, modified_at)
+VALUES (1, '카테고리 없음', true, '2024-08-06', '2024-08-06');
+INSERT INTO category (member_id, name, is_default, created_at, modified_at)
+VALUES (2, '카테고리 없음', true, '2024-08-06', '2024-08-06');

--- a/backend/src/test/resources/clear.sql
+++ b/backend/src/test/resources/clear.sql
@@ -1,100 +1,26 @@
-DROP TABLE IF EXISTS thumbnail_snippet;
-DROP TABLE IF EXISTS snippet;
-DROP TABLE IF EXISTS template_tag;
-DROP TABLE IF EXISTS tag;
-DROP TABLE IF EXISTS template;
-DROP TABLE IF EXISTS category;
-DROP TABLE IF EXISTS member;
+DELETE FROM thumbnail_snippet;
+DELETE FROM snippet;
+DELETE FROM template_tag;
+DELETE FROM tag;
+DELETE FROM template;
+DELETE FROM category;
+DELETE FROM member;
 
-create table member
-(
-    id          BIGINT       NOT NULL AUTO_INCREMENT,
-    email       VARCHAR(255) NOT NULL,
-    password    VARCHAR(255) NOT NULL,
-    username    VARCHAR(255) NOT NULL,
-    created_at  DATETIME(6)  NOT NULL,
-    modified_at DATETIME(6)  NOT NULL,
-    primary key (id)
-);
+ALTER TABLE thumbnail_snippet ALTER COLUMN id RESTART WITH 1;
+ALTER TABLE snippet ALTER COLUMN id RESTART WITH 1;
+ALTER TABLE template_tag ALTER COLUMN template_id RESTART WITH 1;
+ALTER TABLE tag ALTER COLUMN id RESTART WITH 1;
+ALTER TABLE template ALTER COLUMN id RESTART WITH 1;
+ALTER TABLE category ALTER COLUMN id RESTART WITH 1;
+ALTER TABLE member ALTER COLUMN id RESTART WITH 1;
 
-CREATE TABLE category
-(
-    id          BIGINT       NOT NULL AUTO_INCREMENT,
-    member_id   BIGINT       NOT NULL,
-    name        VARCHAR(255) NOT NULL,
-    is_default  TINYINT(1)   NOT NULL,
-    created_at  DATETIME(6)  NOT NULL,
-    modified_at DATETIME(6)  NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (member_id) REFERENCES member (id),
-    CONSTRAINT name_with_member UNIQUE (member_id, name)
-);
-
-CREATE TABLE template
-(
-    id          BIGINT       NOT NULL AUTO_INCREMENT,
-    member_id   BIGINT       NOT NULL,
-    title       VARCHAR(255) NOT NULL,
-    description TEXT,
-    category_id BIGINT       NOT NULL,
-    created_at  DATETIME(6)  NOT NULL,
-    modified_at DATETIME(6)  NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (category_id) REFERENCES category (id),
-    FOREIGN KEY (member_id) REFERENCES member (id)
-);
-
-create table tag
-(
-    id          BIGINT       NOT NULL AUTO_INCREMENT,
-    name        VARCHAR(255) NOT NULL,
-    created_at  DATETIME(6)  NOT NULL,
-    modified_at DATETIME(6)  NOT NULL,
-    PRIMARY KEY (id)
-);
-
-create table template_tag
-(
-    template_id BIGINT      NOT NULL,
-    tag_id      BIGINT      NOT NULL,
-    created_at  DATETIME(6) NOT NULL,
-    modified_at DATETIME(6) NOT NULL,
-    PRIMARY KEY (template_id, tag_id),
-    FOREIGN KEY (template_id) REFERENCES template (id),
-    FOREIGN KEY (tag_id) REFERENCES tag (id)
-);
-
-CREATE TABLE snippet
-(
-    id          BIGINT       NOT NULL AUTO_INCREMENT,
-    template_id BIGINT       NOT NULL,
-    filename    VARCHAR(255) NOT NULL,
-    content     TEXT         NOT NULL,
-    ordinal     INTEGER      NOT NULL,
-    created_at  DATETIME(6)  NOT NULL,
-    modified_at DATETIME(6)  NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (template_id) REFERENCES template (id)
-);
-
-CREATE TABLE thumbnail_snippet
-(
-    id          BIGINT      NOT NULL AUTO_INCREMENT,
-    template_id BIGINT      NOT NULL,
-    snippet_id  BIGINT      NOT NULL,
-    created_at  DATETIME(6) NOT NULL,
-    modified_at DATETIME(6) NOT NULL,
-    PRIMARY KEY (id),
-    FOREIGN KEY (template_id) REFERENCES template (id),
-    FOREIGN KEY (snippet_id) REFERENCES snippet (id)
-);
 
 INSERT INTO member (email, password, username, created_at, modified_at)
-VALUES ('test1@email.com', 'password1234', 'username1', '2024-08-06', '2024-08-06');
+VALUES ('test1@email.com', 'password1234', 'username1', '2024-08-06 00:00:00', '2024-08-06 00:00:00');
 INSERT INTO member (email, password, username, created_at, modified_at)
-VALUES ('test2@email.com', 'password1234', 'username2', '2024-08-06', '2024-08-06');
+VALUES ('test2@email.com', 'password1234', 'username2', '2024-08-06 00:00:00', '2024-08-06 00:00:00');
 
 INSERT INTO category (member_id, name, is_default, created_at, modified_at)
-VALUES (1, '카테고리 없음', true, '2024-08-06', '2024-08-06');
+VALUES (1, '카테고리 없음', TRUE, '2024-08-06 00:00:00', '2024-08-06 00:00:00');
 INSERT INTO category (member_id, name, is_default, created_at, modified_at)
-VALUES (2, '카테고리 없음', true, '2024-08-06', '2024-08-06');
+VALUES (2, '카테고리 없음', TRUE, '2024-08-06 00:00:00', '2024-08-06 00:00:00');


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #296

## 📍주요 변경 사항
1. 카테고리는 멤버 정보를 가진다.
2. 카테고리 조회, 수정, 삭제는 카테고리를 생성한 유저만 할 수 있다.
3. 템플릿 멤버 정보를 가진다.
4. 템플릿 조회, 수정, 삭제는 템플릿를 생성한 유저만 할 수 있다.
5. 템플릿 생성 시 카테고리 할당은 본인이 생성한 카테고리만 사용할 수 있다.
6. 템플릿 삭제 시 없는 템플릿을 삭제할 경우 예외 처리 되도록 변경하였습니다.
    1. 템플릿 삭제 시 권한이 있는지 확인해야 하기 때문. 