### PR TITLE
logback springProfile 재지정

### DIFF
--- a/backend/src/main/resources/logback-spring.xml
+++ b/backend/src/main/resources/logback-spring.xml
@@ -8,11 +8,19 @@
         <include resource="logger/logback-spring-local.xml"/>
     </springProfile>
 
-    <springProfile name="dev">
+    <springProfile name="dev-1">
         <include resource="logger/logback-spring-dev.xml"/>
     </springProfile>
 
-    <springProfile name="prod">
+    <springProfile name="dev-2">
+        <include resource="logger/logback-spring-dev.xml"/>
+    </springProfile>
+
+    <springProfile name="prod-1">
+        <include resource="logger/logback-spring-prod.xml"/>
+    </springProfile>
+
+    <springProfile name="prod-2">
         <include resource="logger/logback-spring-prod.xml"/>
     </springProfile>
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #294

## 📍주요 변경 사항
1. logback springProfile을 그룹이 아닌 각각으로 설정

> logback 설정이 실행중인 스프링 프로파일에 맞게 각 환경별 로그 구성 되도록 해놓았었습니다. 따라서 dev 환경에서는 dev 프로파일을 기준으로 로그 구성을 실행 시킴. 그런데 active 프로파일 dev-1로 바꾸니까 됩니다.
spring.config.location가 위치를 지정하는 거지 active 프로파일이 아니였습니다.

## 🎸기타
1. 