### PR TITLE
auth 전역 상태에 멤버 정보 추가, 템플릿 목록 조회 및 카테고리 목록 조회 요청의 Params에 memberId 추가

### DIFF
--- a/frontend/src/api/authentication.ts
+++ b/frontend/src/api/authentication.ts
@@ -1,4 +1,5 @@
 import type { LoginRequest, SignupRequest } from '@/types';
+import { MemberInfo } from '@/types/authentication';
 import { customFetch } from './customFetch';
 
 const API_URL = process.env.REACT_APP_API_URL;
@@ -17,14 +18,16 @@ export const postSignup = async (signupInfo: SignupRequest) =>
     body: JSON.stringify(signupInfo),
   });
 
-export const postLogin = async (loginInfo: LoginRequest) => {
+export const postLogin = async (loginInfo: LoginRequest): Promise<MemberInfo> => {
   const response = await customFetch({
     method: 'POST',
     url: `${LOGIN_API_URL}`,
     body: JSON.stringify(loginInfo),
   });
 
-  return response;
+  const data = await response.json();
+
+  return data;
 };
 
 export const postLogout = async () => {

--- a/frontend/src/api/categories.ts
+++ b/frontend/src/api/categories.ts
@@ -1,14 +1,20 @@
 import type { CategoryListResponse, CategoryRequest } from '@/types';
+import { MemberInfo } from '@/types/authentication';
 import { customFetch } from './customFetch';
 
 const API_URL = process.env.REACT_APP_API_URL;
 
 export const CATEGORY_API_URL = `${API_URL}/categories`;
 
-export const getCategoryList = async (): Promise<CategoryListResponse> =>
-  await customFetch({
-    url: `${CATEGORY_API_URL}`,
+export const getCategoryList = async ({ memberId }: Pick<MemberInfo, 'memberId'>): Promise<CategoryListResponse> => {
+  const url = new URL(CATEGORY_API_URL);
+
+  url.searchParams.append('memberId', String(memberId));
+
+  return await customFetch({
+    url: url.toString(),
   });
+};
 
 export const postCategory = async (newCategory: CategoryRequest) =>
   await customFetch({

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -19,10 +19,12 @@ export const getTemplateList = async ({
   page = 1,
   pageSize = PAGE_SIZE,
   keyword = '',
+  memberId,
 }: TemplateListRequest): Promise<TemplateListResponse> => {
   const url = new URL(TEMPLATE_API_URL);
 
   url.searchParams.append('keyword', keyword);
+  url.searchParams.append('memberId', String(memberId));
 
   if (categoryId) {
     url.searchParams.append('categoryId', categoryId.toString());

--- a/frontend/src/contexts/authContext.tsx
+++ b/frontend/src/contexts/authContext.tsx
@@ -1,18 +1,36 @@
 import { createContext, useState, ReactNode } from 'react';
 
+import { MemberInfo } from '@/types/authentication';
+
 interface AuthContextProps {
   isLogin: boolean;
+  memberInfo: MemberInfo;
   handleLoginState: (state: boolean) => void;
+  handleMemberInfo: (newMemberInfo: MemberInfo) => void;
 }
 
 export const AuthContext = createContext<AuthContextProps | undefined>(undefined);
 
 export const AuthProvider = ({ children }: { children: ReactNode }) => {
   const [isLogin, setIsLogin] = useState(false);
+  const [memberInfo, setMemberInfo] = useState<MemberInfo>({
+    memberId: undefined,
+    username: undefined,
+  });
 
   const handleLoginState = (state: boolean) => {
     setIsLogin(state);
   };
 
-  return <AuthContext.Provider value={{ isLogin, handleLoginState }}>{children}</AuthContext.Provider>;
+  const handleMemberInfo = (newMemberInfo: MemberInfo) => {
+    setMemberInfo(newMemberInfo);
+
+    console.log('newMemberInfo', newMemberInfo);
+  };
+
+  return (
+    <AuthContext.Provider value={{ isLogin, memberInfo, handleLoginState, handleMemberInfo }}>
+      {children}
+    </AuthContext.Provider>
+  );
 };

--- a/frontend/src/hooks/authentication/useLoginForm.ts
+++ b/frontend/src/hooks/authentication/useLoginForm.ts
@@ -1,18 +1,11 @@
 import { FormEvent } from 'react';
-import { useNavigate } from 'react-router-dom';
 
-import { postLogin } from '@/api/authentication';
-import { ToastContext } from '@/context/ToastContext';
+import { useLoginMutation } from '@/queries/authentication/useLoginMutation';
 import { useInputWithValidate } from '../useInputWithValidate';
-import useCustomContext from '../utils/useCustomContext';
-import { useAuth } from './useAuth';
 import { validateEmail, validatePassword } from './validates';
 
 export const useLoginForm = () => {
-  const navigate = useNavigate();
-  const { failAlert, successAlert } = useCustomContext(ToastContext);
-
-  const { handleLoginState } = useAuth();
+  const { mutateAsync } = useLoginMutation();
 
   const {
     value: email,
@@ -32,18 +25,7 @@ export const useLoginForm = () => {
     e.preventDefault();
 
     if (isFormValid()) {
-      const response = await postLogin({ email, password });
-
-      if (!response.ok) {
-        console.error(response);
-        failAlert('로그인에 실패하였습니다.');
-
-        return;
-      }
-
-      handleLoginState(true);
-      navigate('/');
-      successAlert('로그인 성공!');
+      await mutateAsync({ email, password });
     }
   };
 

--- a/frontend/src/queries/authentication/useLoginMutation.ts
+++ b/frontend/src/queries/authentication/useLoginMutation.ts
@@ -1,0 +1,28 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { postLogin } from '@/api/authentication';
+import { ToastContext } from '@/context/ToastContext';
+import { useAuth } from '@/hooks/authentication/useAuth';
+import useCustomContext from '@/hooks/utils/useCustomContext';
+import { LoginRequest } from '@/types';
+
+export const useLoginMutation = () => {
+  const { handleLoginState, handleMemberInfo } = useAuth();
+  const { failAlert, successAlert } = useCustomContext(ToastContext);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (loginInfo: LoginRequest) => postLogin(loginInfo),
+    onSuccess: (res) => {
+      handleLoginState(true);
+      handleMemberInfo(res);
+      navigate('/');
+      successAlert('로그인 성공!');
+    },
+    onError: (error) => {
+      console.error(error);
+      failAlert('로그인에 실패하였습니다.');
+    },
+  });
+};

--- a/frontend/src/queries/category/useCategoryListQuery.ts
+++ b/frontend/src/queries/category/useCategoryListQuery.ts
@@ -1,10 +1,16 @@
 import { useQuery } from '@tanstack/react-query';
 
 import { QUERY_KEY, getCategoryList } from '@/api';
+import { useAuth } from '@/hooks/authentication/useAuth';
 import type { CategoryListResponse } from '@/types';
 
-export const useCategoryListQuery = () =>
-  useQuery<CategoryListResponse, Error>({
+export const useCategoryListQuery = () => {
+  const {
+    memberInfo: { memberId },
+  } = useAuth();
+
+  return useQuery<CategoryListResponse, Error>({
     queryKey: [QUERY_KEY.CATEGORY_LIST],
-    queryFn: getCategoryList,
+    queryFn: () => getCategoryList({ memberId }),
   });
+};

--- a/frontend/src/queries/template/useTemplateListQuery.ts
+++ b/frontend/src/queries/template/useTemplateListQuery.ts
@@ -1,6 +1,7 @@
 import { keepPreviousData, useQuery } from '@tanstack/react-query';
 
 import { PAGE_SIZE, QUERY_KEY, getTemplateList } from '@/api';
+import { useAuth } from '@/hooks/authentication/useAuth';
 import type { TemplateListResponse } from '@/types';
 
 interface Props {
@@ -11,9 +12,14 @@ interface Props {
   keyword?: string;
 }
 
-export const useTemplateListQuery = ({ categoryId, tagIds, page = 1, pageSize = PAGE_SIZE, keyword }: Props) =>
-  useQuery<TemplateListResponse, Error>({
-    queryKey: [QUERY_KEY.TEMPLATE_LIST, categoryId, tagIds, page, pageSize, keyword],
-    queryFn: () => getTemplateList({ categoryId, tagIds, page, pageSize, keyword }),
+export const useTemplateListQuery = ({ categoryId, tagIds, page = 1, pageSize = PAGE_SIZE, keyword }: Props) => {
+  const {
+    memberInfo: { memberId },
+  } = useAuth();
+
+  return useQuery<TemplateListResponse, Error>({
+    queryKey: [QUERY_KEY.TEMPLATE_LIST, categoryId, tagIds, page, pageSize, keyword, memberId],
+    queryFn: () => getTemplateList({ categoryId, tagIds, page, pageSize, keyword, memberId }),
     placeholderData: keepPreviousData,
   });
+};

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -39,4 +39,5 @@ export interface TemplateListRequest {
   page?: number;
   pageSize?: number;
   keyword?: string;
+  memberId: number | undefined;
 }

--- a/frontend/src/types/authentication.ts
+++ b/frontend/src/types/authentication.ts
@@ -12,3 +12,8 @@ export interface LoginRequest {
 export interface CheckUsernameResponse {
   check: boolean;
 }
+
+export interface MemberInfo {
+  memberId: number | undefined;
+  username: string | undefined;
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
#241 #315  #330 

## 📍주요 변경 사항
1. 로그인 요청에 대한 response 추가
2. useAuth 전역 context에 로그인 후 받아온 멤버 정보인 memberId, username 관리
3. 템플릿 목록 조회 및 카테고리 목록 조회 요청의 Params에 memberId 추가

## 🎸기타
1. sort 기능 구현 PR과 conflict가 나서 resolve 했습니다. 제일 마지막 merge 커밋 한번 봐주시면 좋을거 같아요. (`keyword=''` 이런거 지운게 아니라 중복되어 있는 것 지웠어요!)
<img width="1401" alt="스크린샷 2024-08-07 오후 10 35 47" src="https://github.com/user-attachments/assets/59a5d204-f36a-4288-b4a8-5765e4584988">
