### PR TITLE
템플릿 태그 검색 시 모든 태그가 포함된 템플릿만 검색되도록 수정

### DIFF
--- a/backend/src/main/java/codezap/template/repository/TemplateTagRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateTagRepository.java
@@ -3,8 +3,8 @@ package codezap.template.repository;
 import java.util.List;
 
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
-import codezap.template.domain.Tag;
 import codezap.template.domain.Template;
 import codezap.template.domain.TemplateTag;
 
@@ -14,5 +14,12 @@ public interface TemplateTagRepository extends JpaRepository<TemplateTag, Long> 
 
     void deleteAllByTemplateId(Long id);
 
-    List<TemplateTag> findByTagIn(List<Tag> tags);
+    @Query("""
+            SELECT DISTINCT tt.id.templateId
+            FROM TemplateTag tt
+            WHERE tt.id.tagId IN :tagIds
+            GROUP BY tt.id.templateId
+            HAVING COUNT(DISTINCT tt.id.tagId) = :tagSize
+            """)
+    List<Long> findAllTemplateIdInTagIds(List<Long> tagIds, long tagSize);
 }

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -147,7 +147,7 @@ public class TemplateService {
         pageable = PageRequest.of(pageable.getPageNumber() - 1, pageable.getPageSize(), pageable.getSort());
 
         if (categoryId != null && tagIds != null) {
-            List<Long> templateIds = filterTemplatesBy(tagIds);
+            List<Long> templateIds = templateTagRepository.findAllTemplateIdInTagIds(tagIds, tagIds.size());
             Page<Template> templatePage =
                     templateRepository.searchBy(memberId, keyword, categoryId, templateIds, pageable);
             return makeTemplatesResponseBy(templatePage);
@@ -157,21 +157,12 @@ public class TemplateService {
             return makeTemplatesResponseBy(templatePage);
         }
         if (tagIds != null) {
-            List<Long> templateIds = filterTemplatesBy(tagIds);
+            List<Long> templateIds = templateTagRepository.findAllTemplateIdInTagIds(tagIds, tagIds.size());
             Page<Template> templatePage = templateRepository.searchBy(memberId, keyword, templateIds, pageable);
             return makeTemplatesResponseBy(templatePage);
         }
         Page<Template> templatePage = templateRepository.searchBy(memberId, keyword, pageable);
         return makeTemplatesResponseBy(templatePage);
-    }
-
-    private List<Long> filterTemplatesBy(List<Long> tagIds) {
-        List<Tag> tags = tagRepository.findByIdIn(tagIds);
-        List<TemplateTag> templateTags = templateTagRepository.findByTagIn(tags);
-        return templateTags.stream()
-                .map(TemplateTag::getTemplate)
-                .map(Template::getId)
-                .toList();
     }
 
     private FindAllTemplatesResponse makeTemplatesResponseBy(Page<Template> page) {

--- a/backend/src/test/java/codezap/template/service/TemplateServiceSearchTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceSearchTest.java
@@ -373,15 +373,20 @@ class TemplateServiceSearchTest {
             saveDefault15Templates(member, category2);
             for (long i = 1L; i <= 30L; i++) {
                 templateTagRepository.save(
-                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 3) + 1)));
+                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) + 1)));
+            }
+
+            for (long i = 1L; i <= 30L; i++) {
+                templateTagRepository.save(
+                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById(3L)));
             }
 
             FindAllTemplatesResponse allBy = templateService.findAllBy(
-                    member.getId(), "", null, List.of(1L, 2L), DEFAULT_PAGING_REQUEST
+                    member.getId(), "", null, List.of(1L, 3L), DEFAULT_PAGING_REQUEST
             );
 
-            assertAll(() -> assertThat(allBy.templates()).hasSize(20),
-                    () -> assertThat(allBy.totalElements()).isEqualTo(20));
+            assertAll(() -> assertThat(allBy.templates()).hasSize(15),
+                    () -> assertThat(allBy.totalElements()).isEqualTo(15));
         }
 
         @Test


### PR DESCRIPTION
## ⚡️ 관련 이슈


## 📍주요 변경 사항
템플릿 태그 검색 시 모든 태그가 포함된 템플릿만 검색되도록 수정

### AS-IS
- 'Login', 'JWT' 두개의 태그를 선택해서 검색했을 시, 'Login'과 'JWT' 태그 둘 중 하나라도 포함된 경우 검색된다.

### TO-BE
- 'Login', 'JWT' 두개의 태그를 선택해서 검색했을 시, 'Login'과 'JWT' 태그 둘 다 포함된 경우만 검색된다.

## 🎸기타