### PR TITLE
fix(tag): 템플릿 태그 조회 API 변경 및 인증 확인 추가

### DIFF
--- a/backend/src/main/java/codezap/tag/controller/SpringDocTagController.java
+++ b/backend/src/main/java/codezap/tag/controller/SpringDocTagController.java
@@ -1,0 +1,22 @@
+package codezap.tag.controller;
+
+import org.springframework.http.ResponseEntity;
+
+import codezap.member.dto.MemberDto;
+import codezap.template.dto.response.FindAllTagsResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+
+@Tag(name = "태그 API", description = "템플릿 조회 API")
+public interface SpringDocTagController {
+    @Operation(summary = "태그 목록 조회", description = """
+            유저가 가지고 있는 태그 목록을 조회합니다.
+            """)
+    @ApiResponse(responseCode = "200", description = "태그 목록 조회 성공",
+            content = {@Content(schema = @Schema(implementation = FindAllTagsResponse.class))})
+    ResponseEntity<FindAllTagsResponse> getTags(MemberDto memberDto, Long memberId);
+
+}

--- a/backend/src/main/java/codezap/tag/controller/TagController.java
+++ b/backend/src/main/java/codezap/tag/controller/TagController.java
@@ -1,0 +1,32 @@
+package codezap.tag.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import codezap.member.configuration.BasicAuthentication;
+import codezap.member.dto.MemberDto;
+import codezap.template.dto.response.FindAllTagsResponse;
+import codezap.template.service.TemplateService;
+
+@RestController
+@RequestMapping("/tags")
+public class TagController implements SpringDocTagController {
+
+    private final TemplateService templateService;
+
+    public TagController(TemplateService templateService) {
+        this.templateService = templateService;
+    }
+
+    @GetMapping
+    public ResponseEntity<FindAllTagsResponse> getTags(
+            @BasicAuthentication MemberDto memberDto,
+            @RequestParam Long memberId
+    ) {
+        FindAllTagsResponse response = templateService.findAllTagsByMemberId(memberId);
+        return ResponseEntity.ok(response);
+    }
+}

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -5,8 +5,6 @@ import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 
 import codezap.global.swagger.error.ApiErrorResponse;
 import codezap.global.swagger.error.ErrorCase;
@@ -14,7 +12,6 @@ import codezap.member.dto.MemberDto;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.ExploreTemplatesResponse;
-import codezap.template.dto.response.FindAllTagsResponse;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import io.swagger.v3.oas.annotations.Operation;
@@ -69,13 +66,6 @@ public interface SpringDocTemplateController {
             List<Long> tagIds,
             Pageable pageable
     );
-
-    @Operation(summary = "태그 목록 조회", description = """
-            유저가 가지고 있는 태그 목록을 조회합니다.
-            """)
-    @ApiResponse(responseCode = "200", description = "태그 목록 조회 성공",
-            content = {@Content(schema = @Schema(implementation = FindAllTagsResponse.class))})
-    ResponseEntity<FindAllTagsResponse> getTags(Long memberId);
 
     @Operation(summary = "템플릿 단건 조회", description = "해당하는 식별자의 템플릿을 조회합니다.")
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공",

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -22,7 +22,6 @@ import codezap.member.dto.MemberDto;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.ExploreTemplatesResponse;
-import codezap.template.dto.response.FindAllTagsResponse;
 import codezap.template.dto.response.FindAllTemplatesResponse;
 import codezap.template.dto.response.FindTemplateResponse;
 import codezap.template.service.TemplateService;
@@ -58,12 +57,6 @@ public class TemplateController implements SpringDocTemplateController {
     ) {
         FindAllTemplatesResponse response =
                 templateService.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-        return ResponseEntity.ok(response);
-    }
-
-    @GetMapping("/tags")
-    public ResponseEntity<FindAllTagsResponse> getTags(@RequestParam Long memberId) {
-        FindAllTagsResponse response = templateService.findAllTagsByMemberId(memberId);
         return ResponseEntity.ok(response);
     }
 

--- a/backend/src/test/java/codezap/tag/service/TagSearchTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagSearchTest.java
@@ -1,4 +1,4 @@
-package codezap.template.service;
+package codezap.tag.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertAll;
@@ -33,6 +33,7 @@ import codezap.template.repository.TagRepository;
 import codezap.template.repository.TemplateRepository;
 import codezap.template.repository.TemplateTagRepository;
 import codezap.template.repository.ThumbnailSnippetRepository;
+import codezap.template.service.TemplateService;
 import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)


### PR DESCRIPTION
## ⚡️ 관련 이슈

## 📍주요 변경 사항
- 템플릿 태그 조회 API 변경
   - `/templates/tags?memberId=1` -> `/tags/memberId=1`  
- 인증 확인 추가
   - memberDto

## 🎸기타

