### PR TITLE
GlobalExceptionHandler를 ResponseEntityExceptionHandler를 상속

### DIFF
--- a/backend/src/main/java/codezap/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codezap/global/exception/GlobalExceptionHandler.java
@@ -10,12 +10,13 @@ import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RestControllerAdvice
-public class GlobalExceptionHandler {
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @ExceptionHandler
     public ResponseEntity<ProblemDetail> handleCodeZapException(CodeZapException codeZapException) {

--- a/backend/src/main/java/codezap/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codezap/global/exception/GlobalExceptionHandler.java
@@ -3,13 +3,16 @@ package codezap.global.exception;
 import java.util.List;
 
 import org.springframework.context.support.DefaultMessageSourceResolvable;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ProblemDetail;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.BindingResult;
 import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
 import lombok.extern.slf4j.Slf4j;
@@ -28,9 +31,9 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
                 );
     }
 
-    @ExceptionHandler
-    public ResponseEntity<ProblemDetail> handleMethodArgumentNotValidException(
-            MethodArgumentNotValidException exception
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException exception, HttpHeaders headers, HttpStatusCode status, WebRequest request
     ) {
         BindingResult bindingResult = exception.getBindingResult();
         List<String> errorMessages = bindingResult.getAllErrors().stream()


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #393

## 📍주요 변경 사항
1. GlobalExceptionHandler를 Spring이 제공하는 에러 핸들링에 대한 base class로 ResponseEntityExceptionHandler를 상속받도록 수정하였습니다.

## 🎸 기타

ResponseEntityExceptionHandler 는 Spring MVC에서 발생시키는 예외를 처리하는 핸들러입니다.

NoResourceFoundException 부터 MethodArgumentNotValidException 등등 예외를 처리하는 로직이 포함되어 있습니다.

[ResponseEntityExceptionHandler](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/web/servlet/mvc/method/annotation/ResponseEntityExceptionHandler.html)

+) MethodArgumentNotValid가 ResponseEntityExceptionHandler에서 처리되고 있어 재정의하도록 파라미터와 메서드명 수정하였습니다.

---

내일 1시 전까지 리뷰 완료 부탁드립니다.