### PR TITLE
하나의 status에 대해 예외 상황이 여러개일 경우, 문서가 덮어씌워지는 에러 해결

### DIFF
--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -51,20 +51,19 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
     }
 
     private String getDescriptionByStatus(HttpStatusCode httpStatusCode) {
+        String description = httpStatusCode.value() + " - ";
         if (httpStatusCode.is4xxClientError()) {
-            return "클라이언트 오류";
+            return description + "클라이언트 오류";
         }
         if (httpStatusCode.is5xxServerError()) {
-            return "서버 오류";
+            return description + "서버 오류";
         }
-        return "문서화에 오류가 발생했습니다. 서버팀에게 문의해주세요 😭";
+        return description + "문서화에 오류가 발생했습니다. 서버팀에게 문의해주세요 😭";
     }
 
     private MediaType makeMediaType(ApiErrorResponse apiErrorResponse) {
-        ErrorCase[] errorCases = apiErrorResponse.errorCases();
-
         MediaType mediaType = new MediaType();
-        Arrays.stream(errorCases).forEach(
+        Arrays.stream(apiErrorResponse.errorCases()).forEach(
                 errorCase -> mediaType.addExamples(errorCase.description(), makeExample(apiErrorResponse, errorCase)));
         return mediaType;
     }

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -31,8 +31,9 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
     }
 
     private ApiResponse makeFailResponse(ApiErrorResponse apiErrorResponse) {
-        ApiResponse apiResponse = new ApiResponse().description(getDescriptionByStatus(apiErrorResponse.status()));
-        return apiResponse.content(new Content().addMediaType("application/json", makeMediaType(apiErrorResponse)));
+        return new ApiResponse()
+                .description(getDescriptionByStatus(apiErrorResponse.status()))
+                .content(new Content().addMediaType("application/json", makeMediaType(apiErrorResponse)));
     }
 
     private String getDescriptionByStatus(HttpStatusCode httpStatusCode) {
@@ -54,8 +55,9 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
         return mediaType;
     }
 
-    private Example makeExample(ApiErrorResponse apiErrorResponse, ErrorCase failResponse) {
-        Example example = new Example().summary(failResponse.description());
-        return example.value(ProblemDetailSchema.of(apiErrorResponse, failResponse.exampleMessage()));
+    private Example makeExample(ApiErrorResponse apiErrorResponse, ErrorCase errorCase) {
+        return new Example()
+                .summary(errorCase.description())
+                .value(ProblemDetailSchema.of(apiErrorResponse, errorCase.exampleMessage()));
     }
 }

--- a/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
+++ b/backend/src/main/java/codezap/global/swagger/error/ApiErrorResponsesCustomizer.java
@@ -67,8 +67,11 @@ public class ApiErrorResponsesCustomizer implements OperationCustomizer {
 
     private MediaType makeMediaType(ApiErrorResponse apiErrorResponse) {
         MediaType mediaType = new MediaType();
-        Arrays.stream(apiErrorResponse.errorCases()).forEach(
-                errorCase -> mediaType.addExamples(errorCase.description(), makeExample(apiErrorResponse, errorCase)));
+        ErrorCase[] errorCases = apiErrorResponse.errorCases();
+        for (ErrorCase errorCase : errorCases) {
+            Example example = makeExample(apiErrorResponse, errorCase);
+            mediaType.addExamples(errorCase.description(), example);
+        }
         return mediaType;
     }
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #270 

## 📍주요 변경 사항
1. 이전 pr을 통해 하나의 api에 대해 여러 실패 예시를 정의할 수 있었으나,  하나의 status에 대해 예외 상황이 여러개일 경우 가장 먼저 정의된 하나만 적용되는 에러를 해결하였습니다.
2. ApiResponses의 addApiResponse 는 map을 사용하기 때문에 기존 "클라이언트 오류"와 같은 description을 key로 저장하게 되면 다른 에러가 덮어씌워지는 문제가 발생했습니다. 
 따라서 description에 상태 코드를 추가하여 구분하였습니다.
