### PR TITLE
flyway 설정 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,6 +2,7 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.6'
+    id 'org.flywaydb.flyway' version '8.5.13'
 }
 
 group = 'woowacourse'
@@ -32,7 +33,10 @@ dependencies {
 
     runtimeOnly 'com.mysql:mysql-connector-j:9.0.0'
     runtimeOnly 'com.h2database:h2'
-    
+
+    implementation 'org.flywaydb:flyway-core'
+    implementation 'org.flywaydb:flyway-mysql'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -2,7 +2,6 @@ plugins {
     id 'java'
     id 'org.springframework.boot' version '3.3.1'
     id 'io.spring.dependency-management' version '1.1.6'
-    id 'org.flywaydb.flyway' version '8.5.13'
 }
 
 group = 'woowacourse'

--- a/backend/src/main/java/codezap/global/flyway/FlywayRepairConfiguration.java
+++ b/backend/src/main/java/codezap/global/flyway/FlywayRepairConfiguration.java
@@ -1,0 +1,17 @@
+package codezap.global.flyway;
+
+import org.springframework.boot.autoconfigure.flyway.FlywayMigrationStrategy;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FlywayRepairConfiguration {
+
+    @Bean
+    public FlywayMigrationStrategy flywayMigrationStrategy() {
+        return flyway -> {
+            flyway.repair();
+            flyway.migrate();
+        };
+    }
+}

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,0 +1,116 @@
+create table category
+(
+    is_default  bit          not null,
+    created_at  datetime(6) not null,
+    id          bigint       not null auto_increment,
+    member_id   bigint       not null,
+    modified_at datetime(6) not null,
+    name        varchar(255) not null,
+    primary key (id)
+);
+
+create table member
+(
+    created_at  datetime(6) not null,
+    id          bigint       not null auto_increment,
+    modified_at datetime(6) not null,
+    email       varchar(255) not null,
+    password    varchar(255) not null,
+    username    varchar(255) not null,
+    primary key (id)
+);
+
+create table snippet
+(
+    ordinal     integer      not null,
+    created_at  datetime(6) not null,
+    id          bigint       not null auto_increment,
+    modified_at datetime(6) not null,
+    template_id bigint       not null,
+    content     TEXT         not null,
+    filename    varchar(255) not null,
+    primary key (id)
+);
+
+create table tag
+(
+    created_at  datetime(6) not null,
+    id          bigint       not null auto_increment,
+    modified_at datetime(6) not null,
+    name        varchar(255) not null,
+    primary key (id)
+);
+
+create table template
+(
+    category_id bigint       not null,
+    created_at  datetime(6) not null,
+    id          bigint       not null auto_increment,
+    member_id   bigint       not null,
+    modified_at datetime(6) not null,
+    description TEXT,
+    title       varchar(255) not null,
+    primary key (id)
+);
+
+create table template_tag
+(
+    created_at  datetime(6) not null,
+    modified_at datetime(6) not null,
+    tag_id      bigint not null,
+    template_id bigint not null,
+    primary key (tag_id, template_id)
+);
+
+create table thumbnail_snippet
+(
+    created_at  datetime(6) not null,
+    id          bigint not null auto_increment,
+    modified_at datetime(6) not null,
+    snippet_id  bigint not null,
+    template_id bigint not null,
+    primary key (id)
+);
+
+alter table category
+    add constraint name_with_member unique (member_id, name);
+alter table member
+    add constraint UKmbmcqelty0fbrvxp1q58dn57t unique (email);
+alter table member
+    add constraint UKgc3jmn7c2abyo3wf6syln5t2i unique (username);
+alter table thumbnail_snippet
+    add constraint UKg3n4dnryxewrvb8du167uijwn unique (snippet_id);
+alter table thumbnail_snippet
+    add constraint UKpj1ejy0otq23kfkis7o3mioqx unique (template_id);
+alter table category
+    add constraint FKd7qtd46ngp06lnc19g6wtoh8t
+        foreign key (member_id)
+            references member (id);
+alter table snippet
+    add constraint FKlft9j4cliatmtij1yr5xh6xk2
+        foreign key (template_id)
+            references template (id);
+alter table template
+    add constraint FKfke34lch7qf4xixqnyj3h12m7
+        foreign key (category_id)
+            references category (id);
+alter table template
+    add constraint FKodvst19gfi7in0ox3dfocuejx
+        foreign key (member_id)
+            references member (id);
+alter table template_tag
+    add constraint FK460d2kdmrpffumqaahvh414mv
+        foreign key (tag_id)
+            references tag (id);
+alter table template_tag
+    add constraint FKnq3tyggcae26yafql1l0rc91l
+        foreign key (template_id)
+            references template (id);
+alter table thumbnail_snippet
+    add constraint FK5adu2g3fumims6lwiu4w4srcs
+        foreign key (snippet_id)
+            references snippet (id);
+alter table thumbnail_snippet
+    add constraint FKs3gprh3h7k6b9v414ib76ys9q
+        foreign key (template_id)
+            references template (id);

--- a/backend/src/main/resources/db/migration/V1__init.sql
+++ b/backend/src/main/resources/db/migration/V1__init.sql
@@ -1,116 +1,101 @@
-create table category
+-- Create tables
+CREATE TABLE category
 (
-    is_default  bit          not null,
-    created_at  datetime(6) not null,
-    id          bigint       not null auto_increment,
-    member_id   bigint       not null,
-    modified_at datetime(6) not null,
-    name        varchar(255) not null,
-    primary key (id)
-);
+    is_default  BIT          NOT NULL,
+    created_at  DATETIME(6) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id   BIGINT       NOT NULL,
+    modified_at DATETIME(6) NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 
-create table member
+CREATE TABLE member
 (
-    created_at  datetime(6) not null,
-    id          bigint       not null auto_increment,
-    modified_at datetime(6) not null,
-    email       varchar(255) not null,
-    password    varchar(255) not null,
-    username    varchar(255) not null,
-    primary key (id)
-);
+    created_at  DATETIME(6) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    modified_at DATETIME(6) NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    password    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 
-create table snippet
+CREATE TABLE source_code
 (
-    ordinal     integer      not null,
-    created_at  datetime(6) not null,
-    id          bigint       not null auto_increment,
-    modified_at datetime(6) not null,
-    template_id bigint       not null,
-    content     TEXT         not null,
-    filename    varchar(255) not null,
-    primary key (id)
-);
+    ordinal     INTEGER      NOT NULL,
+    created_at  DATETIME(6) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    modified_at DATETIME(6) NOT NULL,
+    template_id BIGINT       NOT NULL,
+    content     TEXT         NOT NULL,
+    filename    VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 
-create table tag
+CREATE TABLE tag
 (
-    created_at  datetime(6) not null,
-    id          bigint       not null auto_increment,
-    modified_at datetime(6) not null,
-    name        varchar(255) not null,
-    primary key (id)
-);
+    created_at  DATETIME(6) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    modified_at DATETIME(6) NOT NULL,
+    name        VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 
-create table template
+CREATE TABLE template
 (
-    category_id bigint       not null,
-    created_at  datetime(6) not null,
-    id          bigint       not null auto_increment,
-    member_id   bigint       not null,
-    modified_at datetime(6) not null,
+    category_id BIGINT       NOT NULL,
+    created_at  DATETIME(6) NOT NULL,
+    id          BIGINT       NOT NULL AUTO_INCREMENT,
+    member_id   BIGINT       NOT NULL,
+    modified_at DATETIME(6) NOT NULL,
     description TEXT,
-    title       varchar(255) not null,
-    primary key (id)
-);
+    title       VARCHAR(255) NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 
-create table template_tag
+CREATE TABLE template_tag
 (
-    created_at  datetime(6) not null,
-    modified_at datetime(6) not null,
-    tag_id      bigint not null,
-    template_id bigint not null,
-    primary key (tag_id, template_id)
-);
+    created_at  DATETIME(6) NOT NULL,
+    modified_at DATETIME(6) NOT NULL,
+    tag_id      BIGINT NOT NULL,
+    template_id BIGINT NOT NULL,
+    PRIMARY KEY (tag_id, template_id)
+) ENGINE=InnoDB;
 
-create table thumbnail_snippet
+CREATE TABLE thumbnail
 (
-    created_at  datetime(6) not null,
-    id          bigint not null auto_increment,
-    modified_at datetime(6) not null,
-    snippet_id  bigint not null,
-    template_id bigint not null,
-    primary key (id)
-);
+    created_at     DATETIME(6) NOT NULL,
+    id             BIGINT NOT NULL AUTO_INCREMENT,
+    modified_at    DATETIME(6) NOT NULL,
+    source_code_id BIGINT NOT NULL,
+    template_id    BIGINT NOT NULL,
+    PRIMARY KEY (id)
+) ENGINE=InnoDB;
 
-alter table category
-    add constraint name_with_member unique (member_id, name);
-alter table member
-    add constraint UKmbmcqelty0fbrvxp1q58dn57t unique (email);
-alter table member
-    add constraint UKgc3jmn7c2abyo3wf6syln5t2i unique (username);
-alter table thumbnail_snippet
-    add constraint UKg3n4dnryxewrvb8du167uijwn unique (snippet_id);
-alter table thumbnail_snippet
-    add constraint UKpj1ejy0otq23kfkis7o3mioqx unique (template_id);
-alter table category
-    add constraint FKd7qtd46ngp06lnc19g6wtoh8t
-        foreign key (member_id)
-            references member (id);
-alter table snippet
-    add constraint FKlft9j4cliatmtij1yr5xh6xk2
-        foreign key (template_id)
-            references template (id);
-alter table template
-    add constraint FKfke34lch7qf4xixqnyj3h12m7
-        foreign key (category_id)
-            references category (id);
-alter table template
-    add constraint FKodvst19gfi7in0ox3dfocuejx
-        foreign key (member_id)
-            references member (id);
-alter table template_tag
-    add constraint FK460d2kdmrpffumqaahvh414mv
-        foreign key (tag_id)
-            references tag (id);
-alter table template_tag
-    add constraint FKnq3tyggcae26yafql1l0rc91l
-        foreign key (template_id)
-            references template (id);
-alter table thumbnail_snippet
-    add constraint FK5adu2g3fumims6lwiu4w4srcs
-        foreign key (snippet_id)
-            references snippet (id);
-alter table thumbnail_snippet
-    add constraint FKs3gprh3h7k6b9v414ib76ys9q
-        foreign key (template_id)
-            references template (id);
+-- Add constraints
+ALTER TABLE category
+    ADD CONSTRAINT name_with_member UNIQUE (member_id, name);
+ALTER TABLE member
+    ADD CONSTRAINT UK9esvgikrmti1v7ci6v453imdc UNIQUE (name);
+ALTER TABLE thumbnail
+    ADD CONSTRAINT UKi6dbyoqre1oeei7309am7m65p UNIQUE (source_code_id);
+ALTER TABLE thumbnail
+    ADD CONSTRAINT UKqvae6g2xuj6an3wjyc7wau2eb UNIQUE (template_id);
+
+-- Add foreign key constraints
+ALTER TABLE category
+    ADD CONSTRAINT FKd7qtd46ngp06lnc19g6wtoh8t FOREIGN KEY (member_id) REFERENCES member (id);
+ALTER TABLE source_code
+    ADD CONSTRAINT FKjax3t3l28tqs65iqfd3ty5dxw FOREIGN KEY (template_id) REFERENCES template (id);
+ALTER TABLE template
+    ADD CONSTRAINT FKfke34lch7qf4xixqnyj3h12m7 FOREIGN KEY (category_id) REFERENCES category (id);
+ALTER TABLE template
+    ADD CONSTRAINT FKodvst19gfi7in0ox3dfocuejx FOREIGN KEY (member_id) REFERENCES member (id);
+ALTER TABLE template_tag
+    ADD CONSTRAINT FK460d2kdmrpffumqaahvh414mv FOREIGN KEY (tag_id) REFERENCES tag (id);
+ALTER TABLE template_tag
+    ADD CONSTRAINT FKnq3tyggcae26yafql1l0rc91l FOREIGN KEY (template_id) REFERENCES template (id);
+ALTER TABLE thumbnail
+    ADD CONSTRAINT FKssc68bv1tyrlqpi3fet97rbi FOREIGN KEY (source_code_id) REFERENCES source_code (id);
+ALTER TABLE thumbnail
+    ADD CONSTRAINT FKgxg8st4s8hfkmbb3mbm34ww49 FOREIGN KEY (template_id) REFERENCES template (id);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #423

## 📍주요 변경 사항
1. flyway 의존성 추가

## 🎸기타
1. 스키마 체크를 부탁드립니당 (휴먼 에러 발생 가능 폴폴)
2. 앞으로 db 스키마 마이그레이션 시 flyway 문법에 맞춰 파일을 작성해야 합니다
3. ddl-auto 옵션도 none 또는 validate로 변경해야 합니다.
4. FlywayMigrationStrategy 재정의를 통해 repair 후 migration 작업을 수행하도록 변경

인프라 담당분 application-db.yml에 해당 부분 추가가 필요합니다. 
```
spring:
  flyway:
    enabled: true
    baseline-on-migrate: true
    locations: classpath:db/migration
```
각 옵션의 의미는 다음과 같습니다.

+ spring.flyway.enabled=true
  + Spring Boot 애플리케이션에서 Flyway를 활성화합니다.
  + 애플리케이션 시작 시 Flyway가 자동으로 마이그레이션을 실행합니다.
+ spring.flyway.baseline-on-migrate=true
  + 비어있지 않은 데이터베이스에 대해 자동으로 baseline을 설정합니다.
  + 기존 데이터베이스에 Flyway를 처음 적용할 때 발생할 수 있는 문제를 예방합니다.
+ spring.flyway.locations=classpath:db/migration
  + 마이그레이션 스크립트 파일의 위치를 지정합니다.
  + 지정된 경로에서 마이그레이션 스크립트를 찾아 실행합니다.

다른 참고사항은 아래 글을 참고하여 구현해주세요.

[달록의 데이터베이스 마이그레이션을 위한 Flyway 적용기](https://hudi.blog/dallog-flyway/#%EC%B2%AB%EB%B2%88%EC%A7%B8-%EB%A7%88%EC%9D%B4%EA%B7%B8%EB%A0%88%EC%9D%B4%EC%85%98-%EC%8A%A4%ED%81%AC%EB%A6%BD%ED%8A%B8-%EC%9E%91%EC%84%B1)

---

+) 마이그레이션 파일 작성 시 문법 잘 체크해주세용