### PR TITLE
에러 바운더리에 query reset과 key 추가

### DIFF
--- a/frontend/src/api/customFetch.ts
+++ b/frontend/src/api/customFetch.ts
@@ -26,7 +26,7 @@ export const customFetch = async <T>({ url, headers, method = 'GET', body }: Pro
     let responseBody;
     const contentType = response.headers.get('Content-Type');
 
-    if (contentType && contentType.includes('application/json')) {
+    if (contentType && (contentType.includes('application/json') || contentType.includes('application/problem+json'))) {
       responseBody = await response.json();
     } else {
       responseBody = null;

--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,6 +1,7 @@
 import { ErrorBoundary } from '@sentry/react';
+import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { useEffect, useRef } from 'react';
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 
 import { Header } from '@/components';
 import { useHeaderHeight } from '@/hooks/utils/useHeaderHeight';
@@ -10,6 +11,7 @@ import * as S from './Layout.style';
 const Layout = () => {
   const headerRef = useRef<HTMLDivElement>(null);
   const { setHeaderHeight } = useHeaderHeight();
+  const location = useLocation();
 
   useEffect(() => {
     if (headerRef.current) {
@@ -21,9 +23,17 @@ const Layout = () => {
     <S.LayoutContainer>
       <Header headerRef={headerRef} />
       <S.Wrapper>
-        <ErrorBoundary fallback={() => <NotFoundPage />}>
-          <Outlet />
-        </ErrorBoundary>
+        <QueryErrorResetBoundary>
+          {({ reset }) => (
+            <ErrorBoundary
+              fallback={(fallbackProps) => <NotFoundPage {...fallbackProps} />}
+              onReset={reset}
+              key={location.pathname}
+            >
+              <Outlet />
+            </ErrorBoundary>
+          )}
+        </QueryErrorResetBoundary>
       </S.Wrapper>
     </S.LayoutContainer>
   );

--- a/frontend/src/hooks/authentication/useSignupForm.ts
+++ b/frontend/src/hooks/authentication/useSignupForm.ts
@@ -1,13 +1,13 @@
 import { FormEvent, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 
-import { postSignup } from '@/api/authentication';
 import { useInputWithValidate } from '@/hooks/utils';
-import { useCheckEmailQuery, useCheckUsernameQuery } from '@/queries/authentication';
+import { useCheckEmailQuery, useCheckUsernameQuery, useSignupMutation } from '@/queries/authentication';
 import { validateEmail, validateUsername, validatePassword, validateConfirmPassword } from '@/service';
 
 export const useSignupForm = () => {
   const navigate = useNavigate();
+  const { mutateAsync: postSignup } = useSignupMutation();
 
   const {
     value: email,

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -95,8 +95,12 @@ const authenticationHandler = [
   http.post(
     `${LOGIN_API_URL}`,
     () =>
-      new HttpResponse(null, {
+      new HttpResponse(JSON.stringify({ memberId: 1, username: 'jay' }), {
         status: 200,
+        headers: {
+          'Content-Type': 'application/json',
+          'Set-Cookie': 'Authorization=abc123; HttpOnly; Path=/; Max-Age=3600',
+        },
       }),
   ),
   http.post(

--- a/frontend/src/pages/NotFoundPage/NotFoundPage.tsx
+++ b/frontend/src/pages/NotFoundPage/NotFoundPage.tsx
@@ -4,7 +4,11 @@ import { tigger } from '@/assets/images';
 import { Button, Flex, Heading, Text } from '@/components';
 import { theme } from '@/style/theme';
 
-const NotFoundPage = () => {
+interface props {
+  resetError?: () => void;
+}
+
+const NotFoundPage = ({ resetError }: props) => {
   const navigate = useNavigate();
 
   return (
@@ -27,6 +31,7 @@ const NotFoundPage = () => {
       <Button
         weight='bold'
         onClick={() => {
+          resetError && resetError();
           navigate('/');
         }}
       >

--- a/frontend/src/queries/authentication/index.ts
+++ b/frontend/src/queries/authentication/index.ts
@@ -3,3 +3,4 @@ export { useCheckUsernameQuery } from './useCheckUsernameQuery';
 export { useLoginStateQuery } from './useLoginStateQuery';
 export { useLoginMutation } from './useLoginMutation';
 export { useLogoutMutation } from './useLogoutMutation';
+export { useSignupMutation } from './useSignupMutation';

--- a/frontend/src/queries/authentication/useSignupMutation.ts
+++ b/frontend/src/queries/authentication/useSignupMutation.ts
@@ -1,0 +1,24 @@
+import { useMutation } from '@tanstack/react-query';
+import { useNavigate } from 'react-router-dom';
+
+import { postSignup } from '@/api/authentication';
+import { ToastContext } from '@/contexts';
+import { useCustomContext } from '@/hooks/utils';
+import { SignupRequest } from '@/types';
+
+export const useSignupMutation = () => {
+  const { failAlert, successAlert } = useCustomContext(ToastContext);
+  const navigate = useNavigate();
+
+  return useMutation({
+    mutationFn: (signupInfo: SignupRequest) => postSignup(signupInfo),
+    onSuccess: () => {
+      navigate('/login');
+      successAlert('회원가입 성공!');
+    },
+    onError: (error) => {
+      console.error(error);
+      failAlert(error.message);
+    },
+  });
+};

--- a/frontend/src/queries/template/useTemplateListQuery.ts
+++ b/frontend/src/queries/template/useTemplateListQuery.ts
@@ -28,6 +28,7 @@ export const useTemplateListQuery = ({
   return useQuery<TemplateListResponse, Error>({
     queryKey: [QUERY_KEY.TEMPLATE_LIST, keyword, categoryId, tagIds, sort, page, pageSize, memberId],
     queryFn: () => getTemplateList({ keyword, categoryId, tagIds, sort, page, pageSize, memberId }),
+    throwOnError: true,
     placeholderData: keepPreviousData,
   });
 };


### PR DESCRIPTION
## ⚡️ 관련 이슈
#439 

## 📍주요 변경 사항
1. ErrorBoundary에 query reset과 key를 추가합니다.
 - 에러 바운더리에서 홈으로 가기 버튼이나 네비게이션을 클릭해도 url만 바뀔 뿐, 에러 바운더리가 언마운트되지 않는 현상을 해결합니다.

2. templateList 쿼리의 throwOnError 옵션을 true로 하여 에러바운더리에서 캐치하도록 변경합니다.

3. 회원가입의 api 함수를 tanstack-query의 mutation을 이용하도록 합니다.

