### PR TITLE
font 404 에러 해결

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,6 +1,11 @@
 <!doctype html>
 <html lang="en">
   <head>
+    <link
+      rel="stylesheet"
+      type="text/css"
+      href="https://cdn.jsdelivr.net/gh/orioncactus/pretendard/dist/web/static/pretendard.css"
+    />
     <!-- Google Tag Manager -->
     <script>
       (function (w, d, s, l, i) {

--- a/frontend/src/style/GlobalStyles.tsx
+++ b/frontend/src/style/GlobalStyles.tsx
@@ -3,27 +3,6 @@ import { css, Global } from '@emotion/react';
 import { theme } from './theme';
 
 const globalStyles = css`
-  @font-face {
-    font-family: 'Pretendard';
-    font-weight: ${theme.font.weight.light};
-    font-style: normal;
-    src: url('/fonts/Pretendard-ExtraLight.woff2') format('woff2');
-  }
-
-  @font-face {
-    font-family: 'Pretendard';
-    font-weight: ${theme.font.weight.regular};
-    font-style: normal;
-    src: url('/fonts/Pretendard-Regular.woff2') format('woff2');
-  }
-
-  @font-face {
-    font-family: 'Pretendard';
-    font-weight: ${theme.font.weight.bold};
-    font-style: normal;
-    src: url('/fonts/Pretendard-Bold.woff2') format('woff2');
-  }
-
   * {
     box-sizing: border-box;
     margin: 0;


### PR DESCRIPTION
## 관련 이슈
#442 

## 주요 변경 사항
1. 브라우저에서 font의 경로를 찾지 못해 error, warn 이 나는 현상을 해결합니다.