### PR TITLE
충돌한 테스트 코드 해결 및 equals 재정의

### DIFF
--- a/backend/src/main/java/codezap/auth/configuration/AuthorizationInterceptor.java
+++ b/backend/src/main/java/codezap/auth/configuration/AuthorizationInterceptor.java
@@ -20,8 +20,7 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler
-    ) {
+    public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) {
         String token = credentialManager.getCredential(request);
         validatedTokeIsBlank(token);
         validatedExistMember(token);

--- a/backend/src/main/java/codezap/auth/configuration/AuthorizationInterceptor.java
+++ b/backend/src/main/java/codezap/auth/configuration/AuthorizationInterceptor.java
@@ -20,7 +20,8 @@ public class AuthorizationInterceptor implements HandlerInterceptor {
     }
 
     @Override
-    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler) {
+    public boolean preHandle(final HttpServletRequest request, final HttpServletResponse response, final Object handler
+    ) {
         String token = credentialManager.getCredential(request);
         validatedTokeIsBlank(token);
         validatedExistMember(token);

--- a/backend/src/main/java/codezap/auth/controller/AuthController.java
+++ b/backend/src/main/java/codezap/auth/controller/AuthController.java
@@ -27,7 +27,9 @@ public class AuthController implements SpringDocAuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest, HttpServletResponse httpServletResponse) {
+    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
+            HttpServletResponse httpServletResponse
+    ) {
         LoginAndCredentialDto loginAndCredentialDto = authService.login(loginRequest);
         credentialManager.setCredential(httpServletResponse, loginAndCredentialDto.credential());
         return ResponseEntity.ok(loginAndCredentialDto.loginResponse());

--- a/backend/src/main/java/codezap/auth/controller/AuthController.java
+++ b/backend/src/main/java/codezap/auth/controller/AuthController.java
@@ -27,7 +27,8 @@ public class AuthController implements SpringDocAuthController {
     private final AuthService authService;
 
     @PostMapping("/login")
-    public ResponseEntity<LoginResponse> login(@Valid @RequestBody LoginRequest loginRequest,
+    public ResponseEntity<LoginResponse> login(
+            @Valid @RequestBody LoginRequest loginRequest,
             HttpServletResponse httpServletResponse
     ) {
         LoginAndCredentialDto loginAndCredentialDto = authService.login(loginRequest);

--- a/backend/src/main/java/codezap/category/domain/Category.java
+++ b/backend/src/main/java/codezap/category/domain/Category.java
@@ -1,5 +1,7 @@
 package codezap.category.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -14,7 +16,6 @@ import codezap.global.auditing.BaseTimeEntity;
 import codezap.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +23,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(callSuper = false)
 @Table(
         uniqueConstraints = {
                 @UniqueConstraint(
@@ -60,5 +60,22 @@ public class Category extends BaseTimeEntity {
 
     public void updateName(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Category category = (Category) o;
+        return Objects.equals(getId(), category.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/member/domain/Member.java
+++ b/backend/src/main/java/codezap/member/domain/Member.java
@@ -11,7 +11,6 @@ import jakarta.persistence.Id;
 import codezap.global.auditing.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -19,7 +18,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(callSuper = false)
 public class Member extends BaseTimeEntity {
 
     @Id
@@ -38,5 +36,22 @@ public class Member extends BaseTimeEntity {
 
     public boolean matchPassword(String password) {
         return Objects.equals(this.password, password);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Member member = (Member) o;
+        return Objects.equals(getId(), member.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/template/domain/SourceCode.java
+++ b/backend/src/main/java/codezap/template/domain/SourceCode.java
@@ -1,6 +1,7 @@
 package codezap.template.domain;
 
 import java.util.Arrays;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import jakarta.persistence.Column;
@@ -14,7 +15,6 @@ import jakarta.persistence.ManyToOne;
 import codezap.global.auditing.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -22,7 +22,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(callSuper = true, of = {"id"})
 public class SourceCode extends BaseTimeEntity {
 
     private static final String LINE_BREAK = "\n";
@@ -61,5 +60,22 @@ public class SourceCode extends BaseTimeEntity {
         this.filename = filename;
         this.content = content;
         this.ordinal = ordinal;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        SourceCode that = (SourceCode) o;
+        return Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/template/domain/Tag.java
+++ b/backend/src/main/java/codezap/template/domain/Tag.java
@@ -1,5 +1,7 @@
 package codezap.template.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
@@ -9,7 +11,6 @@ import jakarta.persistence.Id;
 import codezap.global.auditing.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +18,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(callSuper = true, of = {"id"})
 public class Tag extends BaseTimeEntity {
 
     @Id
@@ -29,5 +29,22 @@ public class Tag extends BaseTimeEntity {
 
     public Tag(String name) {
         this.name = name;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Tag tag = (Tag) o;
+        return Objects.equals(getId(), tag.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -2,6 +2,7 @@ package codezap.template.domain;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -17,7 +18,6 @@ import codezap.global.auditing.BaseTimeEntity;
 import codezap.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -25,13 +25,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(callSuper = true, of = {"id"})
 public class Template extends BaseTimeEntity {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
-
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Member member;
@@ -63,5 +61,22 @@ public class Template extends BaseTimeEntity {
 
     public void updateSourceCodes(List<SourceCode> sourceCode) {
         sourceCodes.addAll(sourceCode);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Template template = (Template) o;
+        return Objects.equals(getId(), template.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/template/domain/TemplateTag.java
+++ b/backend/src/main/java/codezap/template/domain/TemplateTag.java
@@ -1,6 +1,7 @@
 package codezap.template.domain;
 
 import java.io.Serializable;
+import java.util.Objects;
 
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.EmbeddedId;
@@ -12,24 +13,38 @@ import jakarta.persistence.MapsId;
 import codezap.global.auditing.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EqualsAndHashCode(callSuper = true, of = {"template_tag_id"})
 public class TemplateTag extends BaseTimeEntity {
 
     @Embeddable
     @NoArgsConstructor(access = AccessLevel.PROTECTED)
     @AllArgsConstructor
     @Getter
-    @EqualsAndHashCode
     private static class TemplateTagId implements Serializable {
         private Long templateId;
         private Long tagId;
+
+        @Override
+        public boolean equals(Object o) {
+            if (this == o) {
+                return true;
+            }
+            if (o == null || getClass() != o.getClass()) {
+                return false;
+            }
+            TemplateTagId that = (TemplateTagId) o;
+            return Objects.equals(getTemplateId(), that.getTemplateId()) && Objects.equals(getTagId(), that.getTagId());
+        }
+
+        @Override
+        public int hashCode() {
+            return Objects.hash(getTemplateId(), getTagId());
+        }
     }
 
     @EmbeddedId
@@ -49,5 +64,22 @@ public class TemplateTag extends BaseTimeEntity {
         this.id = new TemplateTagId(template.getId(), tag.getId());
         this.template = template;
         this.tag = tag;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        TemplateTag that = (TemplateTag) o;
+        return Objects.equals(getId(), that.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/template/domain/TemplateTag.java
+++ b/backend/src/main/java/codezap/template/domain/TemplateTag.java
@@ -19,7 +19,7 @@ import lombok.NoArgsConstructor;
 @Entity
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @Getter
-@EqualsAndHashCode(callSuper = true, of = {"TemplateTagId"})
+@EqualsAndHashCode(callSuper = true, of = {"template_tag_id"})
 public class TemplateTag extends BaseTimeEntity {
 
     @Embeddable

--- a/backend/src/main/java/codezap/template/domain/Thumbnail.java
+++ b/backend/src/main/java/codezap/template/domain/Thumbnail.java
@@ -1,5 +1,7 @@
 package codezap.template.domain;
 
+import java.util.Objects;
+
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
@@ -9,7 +11,6 @@ import jakarta.persistence.OneToOne;
 import codezap.global.auditing.BaseTimeEntity;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
-import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -17,7 +18,6 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Getter
-@EqualsAndHashCode(callSuper = true, of = {"id"})
 public class Thumbnail extends BaseTimeEntity {
 
     @Id
@@ -37,5 +37,22 @@ public class Thumbnail extends BaseTimeEntity {
 
     public void updateThumbnail(SourceCode sourceCode) {
         this.sourceCode = sourceCode;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        Thumbnail thumbnail = (Thumbnail) o;
+        return Objects.equals(getId(), thumbnail.getId());
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(getId());
     }
 }

--- a/backend/src/main/java/codezap/template/dto/request/validation/SourceCodesCountValidator.java
+++ b/backend/src/main/java/codezap/template/dto/request/validation/SourceCodesCountValidator.java
@@ -3,7 +3,8 @@ package codezap.template.dto.request.validation;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class SourceCodesCountValidator implements ConstraintValidator<SourceCodesCount, ValidatedSourceCodesCountRequest> {
+public class SourceCodesCountValidator implements
+        ConstraintValidator<SourceCodesCount, ValidatedSourceCodesCountRequest> {
 
     @Override
     public boolean isValid(ValidatedSourceCodesCountRequest validatedSourceCodesCountRequest,

--- a/backend/src/main/java/codezap/template/dto/request/validation/SourceCodesOrdinalValidator.java
+++ b/backend/src/main/java/codezap/template/dto/request/validation/SourceCodesOrdinalValidator.java
@@ -6,7 +6,8 @@ import java.util.stream.IntStream;
 import jakarta.validation.ConstraintValidator;
 import jakarta.validation.ConstraintValidatorContext;
 
-public class SourceCodesOrdinalValidator implements ConstraintValidator<SourceCodesOrdinal, ValidatedSourceCodesOrdinalRequest> {
+public class SourceCodesOrdinalValidator implements
+        ConstraintValidator<SourceCodesOrdinal, ValidatedSourceCodesOrdinalRequest> {
 
     @Override
     public boolean isValid(ValidatedSourceCodesOrdinalRequest validatedSourceCodesOrdinalRequest,

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -165,7 +165,7 @@ public class TemplateService {
     }
 
     private void validateCategoryId(Long categoryId) {
-        if(!categoryRepository.existsById(categoryId)) {
+        if (!categoryRepository.existsById(categoryId)) {
             throw new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + categoryId + "에 해당하는 카테고리가 존재하지 않습니다.");
         }
     }
@@ -189,7 +189,7 @@ public class TemplateService {
     }
 
     private void validateTagId(Long tagId) {
-        if(!tagRepository.existsById(tagId)) {
+        if (!tagRepository.existsById(tagId)) {
             throw new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + tagId + "에 해당하는 태그가 존재하지 않습니다.");
         }
     }

--- a/backend/src/test/java/codezap/auth/provider/basic/BasicAuthDecoderTest.java
+++ b/backend/src/test/java/codezap/auth/provider/basic/BasicAuthDecoderTest.java
@@ -49,7 +49,7 @@ class BasicAuthDecoderTest {
     @DisplayName("BasicAuth 인증 정보 디코딩 실패: 구분자 누락")
     void throwExceptionForMissingSeparator() {
         String invalidCredential = Base64.getEncoder()
-                .encodeToString("userexample.com" .getBytes(StandardCharsets.UTF_8));
+                .encodeToString("userexample.com".getBytes(StandardCharsets.UTF_8));
 
         assertThatCode(() -> BasicAuthDecoder.decodeBasicAuth(invalidCredential))
                 .isInstanceOf(CodeZapException.class)

--- a/backend/src/test/java/codezap/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/codezap/auth/service/AuthServiceTest.java
@@ -90,7 +90,11 @@ public class AuthServiceTest {
         @DisplayName("쿠키 인증 실패: 잘못된 크레덴셜")
         void checkLogin_WithInvalidCredential_ThrowsException() {
             Member member = memberRepository.save(MemberFixture.memberFixture());
-            String invalidCredential = HttpHeaders.encodeBasicAuth(member.getName(),  member.getPassword() + "wrong", StandardCharsets.UTF_8);
+            String invalidCredential = HttpHeaders.encodeBasicAuth(
+                    member.getName(),
+                    member.getPassword() + "wrong",
+                    StandardCharsets.UTF_8
+            );
 
             assertThatThrownBy(() -> authService.checkLogin(invalidCredential))
                     .isInstanceOf(CodeZapException.class)

--- a/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
@@ -49,7 +49,9 @@ class CategoryControllerTest extends MockMvcTest {
             Long categoryId = 1L;
             CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("category");
 
-            when(categoryService.create(MemberDto.from(MemberFixture.memberFixture()), createCategoryRequest)).thenReturn(categoryId);
+            when(categoryService.create(
+                    MemberDto.from(MemberFixture.memberFixture()), createCategoryRequest))
+                    .thenReturn(categoryId);
 
             mvc.perform(post("/categories")
                             .contentType(MediaType.APPLICATION_JSON)
@@ -76,7 +78,7 @@ class CategoryControllerTest extends MockMvcTest {
         @Test
         @DisplayName("카테고리 생성 실패: 카테고리 이름 길이 초과")
         void createCategoryFailWithLongName() throws Exception {
-            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a" .repeat(MAX_LENGTH + 1));
+            CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH + 1));
 
             mvc.perform(post("/categories")
                             .accept(MediaType.APPLICATION_JSON)
@@ -127,7 +129,7 @@ class CategoryControllerTest extends MockMvcTest {
         @DisplayName("카테고리 수정 실패: 권한 없음")
         void updateCategoryFailWithUnauthorized() throws Exception {
             Long categoryId = 1L;
-            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a" .repeat(MAX_LENGTH));
+            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH));
 
             doThrow(new CodeZapException(HttpStatus.UNAUTHORIZED, "인증에 대한 쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."))
                     .when(credentialProvider).extractMember(anyString());
@@ -143,7 +145,7 @@ class CategoryControllerTest extends MockMvcTest {
         @DisplayName("카테고리 수정 실패: 카테고리 이름 길이 초과")
         void updateCategoryFailWithLongName() throws Exception {
             Long categoryId = 1L;
-            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a" .repeat(MAX_LENGTH + 1));
+            UpdateCategoryRequest updateCategoryRequest = new UpdateCategoryRequest("a".repeat(MAX_LENGTH + 1));
 
             mvc.perform(put("/categories/" + categoryId)
                             .contentType(MediaType.APPLICATION_JSON)

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -25,12 +25,13 @@ import codezap.template.repository.TemplateRepository;
 
 class CategoryServiceTest {
 
-    private CategoryRepository categoryRepository = new FakeCategoryRepository();
-    private TemplateRepository templateRepository = new FakeTemplateRepository();
-    private MemberRepository memberRepository = new FakeMemberRepository();
+    private final CategoryRepository categoryRepository = new FakeCategoryRepository();
+    private final TemplateRepository templateRepository = new FakeTemplateRepository();
+    private final MemberRepository memberRepository = new FakeMemberRepository();
 
-    private CategoryService categoryService = new CategoryService(categoryRepository, templateRepository,
-            memberRepository);
+    private final CategoryService categoryService = new CategoryService(
+            categoryRepository, templateRepository, memberRepository
+    );
 
     @Nested
     @DisplayName("카테고리 생성 테스트")
@@ -57,8 +58,9 @@ class CategoryServiceTest {
             CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest(duplicatedCategoryName);
 
             assertThatThrownBy(
-                    () -> categoryService.create(MemberDto.from(member), createCategoryRequest)).isInstanceOf(
-                    CodeZapException.class).hasMessage("이름이 " + duplicatedCategoryName + "인 카테고리가 이미 존재합니다.");
+                    () -> categoryService.create(MemberDto.from(member), createCategoryRequest))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("이름이 " + duplicatedCategoryName + "인 카테고리가 이미 존재합니다.");
         }
 
         @Test

--- a/backend/src/test/java/codezap/fixture/MemberDtoFixture.java
+++ b/backend/src/test/java/codezap/fixture/MemberDtoFixture.java
@@ -5,10 +5,18 @@ import codezap.member.dto.MemberDto;
 public class MemberDtoFixture {
 
     public static MemberDto getFirstMemberDto() {
-        return new MemberDto(1L,  "name1", "password1234");
+        return new MemberDto(
+                1L,
+                "몰리",
+                "password1234"
+        );
     }
 
     public static MemberDto getSecondMemberDto() {
-        return new MemberDto(2L, "name2", "password1234");
+        return new MemberDto(
+                2L,
+                "몰리2",
+                "password1234"
+        );
     }
 }

--- a/backend/src/test/java/codezap/member/controller/MemberControllerTest.java
+++ b/backend/src/test/java/codezap/member/controller/MemberControllerTest.java
@@ -2,7 +2,6 @@ package codezap.member.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doNothing;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;

--- a/backend/src/test/java/codezap/member/domain/MemberTest.java
+++ b/backend/src/test/java/codezap/member/domain/MemberTest.java
@@ -1,6 +1,7 @@
 package codezap.member.domain;
 
-import static org.junit.jupiter.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;

--- a/backend/src/test/java/codezap/member/fixture/MemberFixture.java
+++ b/backend/src/test/java/codezap/member/fixture/MemberFixture.java
@@ -14,7 +14,7 @@ public class MemberFixture {
 
     public static Member createFixture(String name) {
         return new Member(
-                "몰리",
+                name,
                 "password1234"
         );
     }

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -1,1550 +1,906 @@
-// <<<<<<< feat/remove-tempates
-// package codezap.template.controller;
-
-// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-// import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-// import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-// import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-// import java.nio.charset.StandardCharsets;
-// import java.util.List;
-
-// import jakarta.servlet.http.Cookie;
-
-// import org.junit.jupiter.api.BeforeEach;
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Nested;
-// import org.junit.jupiter.api.Test;
-// import org.junit.jupiter.params.ParameterizedTest;
-// import org.junit.jupiter.params.provider.CsvSource;
-// import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
-// import org.springframework.http.HttpHeaders;
-// import org.springframework.http.MediaType;
-// import org.springframework.test.web.servlet.MockMvc;
-// import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-
-// import com.fasterxml.jackson.databind.ObjectMapper;
-
-// import codezap.category.dto.request.CreateCategoryRequest;
-// import codezap.category.repository.CategoryRepository;
-// import codezap.category.repository.FakeCategoryRepository;
-// import codezap.category.service.CategoryService;
-// import codezap.fixture.CategoryFixture;
-// import codezap.fixture.MemberDtoFixture;
-// import codezap.fixture.MemberFixture;
-// import codezap.global.exception.GlobalExceptionHandler;
-// import codezap.member.configuration.AuthArgumentResolver;
-// import codezap.member.domain.Member;
-// import codezap.member.dto.MemberDto;
-// import codezap.member.repository.FakeMemberRepository;
-// import codezap.member.repository.MemberRepository;
-// import codezap.member.service.AuthService;
-// import codezap.member.service.MemberService;
-// import codezap.template.dto.request.CreateSourceCodeRequest;
-// import codezap.template.dto.request.CreateTemplateRequest;
-// import codezap.template.dto.request.UpdateSourceCodeRequest;
-// import codezap.template.dto.request.UpdateTemplateRequest;
-// import codezap.template.repository.FakeSourceCodeRepository;
-// import codezap.template.repository.FakeTagRepository;
-// import codezap.template.repository.FakeTemplateRepository;
-// import codezap.template.repository.FakeTemplateTagRepository;
-// import codezap.template.repository.FakeThumbnailRepository;
-// import codezap.template.repository.SourceCodeRepository;
-// import codezap.template.repository.TagRepository;
-// import codezap.template.repository.TemplateRepository;
-// import codezap.template.repository.TemplateTagRepository;
-// import codezap.template.repository.ThumbnailRepository;
-// import codezap.template.service.TemplateApplicationService;
-// import codezap.template.service.TemplateService;
-
-// class TemplateControllerTest {
-
-//     private static final int MAX_LENGTH = 255;
-
-//     private final TemplateRepository templateRepository = new FakeTemplateRepository();
-//     private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
-//     private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();
-//     private final CategoryRepository categoryRepository = new FakeCategoryRepository(
-//             List.of(CategoryFixture.getFirstCategory(), CategoryFixture.getSecondCategory())
-//     );
-//     private final TemplateTagRepository templateTagRepository = new FakeTemplateTagRepository();
-//     private final TagRepository tagRepository = new FakeTagRepository();
-//     private final MemberRepository memberRepository = new FakeMemberRepository(
-//             List.of(MemberFixture.getFirstMember(), MemberFixture.getSecondMember())
-//     );
-//     private final TemplateService templateService = new TemplateService(
-//             thumbnailRepository,
-//             templateRepository,
-//             sourceCodeRepository,
-//             categoryRepository,
-//             tagRepository,
-//             templateTagRepository,
-//             memberRepository);
-//     private final CategoryService categoryService = new CategoryService(
-//             categoryRepository, templateRepository, memberRepository
-//     );
-//     private final AuthService authService = new AuthService(memberRepository);
-
-//     private final MemberService memberService = new MemberService(memberRepository, authService, categoryRepository);
-
-//     private final TemplateApplicationService applicationService = new TemplateApplicationService(
-//             memberService, templateService
-//     );
-
-//     private final TemplateController templateController = new TemplateController(templateService, applicationService);
-
-//     private final MockMvc mvc = MockMvcBuilders.standaloneSetup(templateController)
-//             .setControllerAdvice(new GlobalExceptionHandler())
-//             .setCustomArgumentResolvers(new AuthArgumentResolver(authService),
-//                     new PageableHandlerMethodArgumentResolver())
-//             .build();
-//     private final ObjectMapper objectMapper = new ObjectMapper();
-
-//     Cookie cookie;
-
-//     @BeforeEach
-//     void setCookie() {
-//         String basicAuth = HttpHeaders.encodeBasicAuth(
-//                 MemberFixture.getFirstMember().getEmail(),
-//                 MemberFixture.getFirstMember().getPassword(),
-//                 StandardCharsets.UTF_8
-//         );
-//         cookie = new Cookie("Authorization", basicAuth);
-//     }
-
-//     @Nested
-//     @DisplayName("템플릿 생성 테스트")
-//     class createTemplateTest {
-
-//         @ParameterizedTest
-//         @DisplayName("템플릿 생성 성공")
-//         @CsvSource({"a, 65535", "ㄱ, 21845"})
-//         void createTemplateSuccess(String repeatTarget, int maxLength) throws Exception {
-//             String maxTitle = "a".repeat(MAX_LENGTH);
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     maxTitle,
-//                     repeatTarget.repeat(maxLength),
-//                     List.of(new CreateSourceCodeRequest("a".repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isCreated());
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 생성 실패: 템플릿명 길이 초과")
-//         void createTemplateFailWithLongTitle() throws Exception {
-//             String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     exceededTitle,
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("a", "content", 1)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
-//         }
-
-//         @ParameterizedTest
-//         @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
-//         @CsvSource({"a, 65536", "ㄱ, 21846"})
-//         void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     repeatTarget.repeat(exceededLength),
-//                     List.of(new CreateSourceCodeRequest("title", "content", 1)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 생성 실패: 파일명 길이 초과")
-//         void createTemplateFailWithLongFileName() throws Exception {
-//             String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest(exceededTitle, "content", 1)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
-//         }
-
-//         @ParameterizedTest
-//         @DisplayName("템플릿 생성 실패: 소스 코드 길이 초과")
-//         @CsvSource({"a, 65536", "ㄱ, 21846"})
-//         void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("title", repeatTarget.repeat(exceededLength), 1)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
-//         }
-
-//         @ParameterizedTest
-//         @DisplayName("템플릿 생성 실패: 잘못된 소스 코드 순서 입력")
-//         @CsvSource({"0, 1", "1, 3", "2, 1"})
-//         void createTemplateFailWithWrongSourceCodeOrdinal(int firstIndex, int secondIndex) throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("title", "content", firstIndex),
-//                             new CreateSourceCodeRequest("title", "content", secondIndex)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("소스 코드 순서가 잘못되었습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 생성 실패: 인증 정보가 없거나 잘못된 경우")
-//         void createTemplateFailWithNotLogin() throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("filename", "content", 1)),
-//                     1,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("인증에 실패했습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 생성 실패: 카테고리 권한이 없는 경우")
-//         void createTemplateFailWithNoMatchCategory() throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("filename", "content", 1)),
-//                     1,
-//                     2L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("해당 카테고리에 대한 권한이 없습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 생성 실패: 카테고리가 없는 경우")
-//         void createTemplateFailWithNotCategory() throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("filename", "content", 1)),
-//                     1,
-//                     3L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isNotFound())
-//                     .andExpect(jsonPath("$.detail").value("식별자 3에 해당하는 카테고리가 존재하지 않습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 생성 실패: 해당 순서인 소스 코드 없는 경우")
-//         void createTemplateFailWithNotSourceCode() throws Exception {
-//             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(new CreateSourceCodeRequest("filename", "content", 1)),
-//                     10,
-//                     1L,
-//                     List.of("tag1", "tag2")
-//             );
-
-//             mvc.perform(post("/templates")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(templateRequest)))
-//                     .andExpect(status().isNotFound())
-//                     .andExpect(jsonPath("$.detail").value("템플릿에 10번째 소스 코드가 존재하지 않습니다."));
-//         }
-//     }
-
-//     @Nested
-//     @DisplayName("템플릿 검색 테스트")
-//     class getTemplatesTest {
-
-//         @Test
-//         @DisplayName("템플릿 검색 성공")
-//         void findAllTemplatesSuccess() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
-//             CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSourceCodes("title2");
-//             templateService.createTemplate(memberDto, templateRequest1);
-//             templateService.createTemplate(memberDto, templateRequest2);
-
-//             // when & then
-//             mvc.perform(get("/templates")
-//                             .cookie(cookie)
-//                             .param("memberId", "1")
-//                             .param("keyword", "")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isOk())
-//                     .andExpect(jsonPath("$.templates.size()").value(2));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 검색 실패: 태그 ID가 0개인 경우")
-//         void findAllTemplatesFailWithZeroTagIds() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
-//             templateService.createTemplate(memberDto, templateRequest1);
-
-//             // when & then
-//             mvc.perform(get("/templates")
-//                             .cookie(cookie)
-//                             .param("memberId", "1")
-//                             .param("keyword", "")
-//                             .param("tagIds", "")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("태그 ID가 0개입니다. 필터링 하지 않을 경우 null로 전달해주세요."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 검색 실패: 인증 정보가 없거나 잘못된 경우")
-//         void findAllTemplatesFailWithCookie() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
-//             templateService.createTemplate(memberDto, templateRequest1);
-
-//             // when & then
-//             mvc.perform(get("/templates")
-//                             .param("memberId", "1")
-//                             .param("keyword", "")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("인증에 실패했습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 검색 실패: 인증 정보와 멤버 ID가 다른 경우")
-//         void findAllTemplatesFailNonMatchMemberIdAndMemberDto() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
-//             templateService.createTemplate(memberDto, templateRequest1);
-
-//             // when & then
-//             mvc.perform(get("/templates")
-//                             .cookie(cookie)
-//                             .param("memberId", "100")
-//                             .param("keyword", "")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("인증 정보에 포함된 멤버 ID와 파라미터로 받은 멤버 ID가 다릅니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 검색 실패: 카테고리가 없는 경우")
-//         void findAllTemplatesFailNotFoundCategory() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
-//             templateService.createTemplate(memberDto, templateRequest1);
-
-//             // when & then
-//             mvc.perform(get("/templates")
-//                             .cookie(cookie)
-//                             .param("memberId", "1")
-//                             .param("keyword", "")
-//                             .param("categoryId", "100")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isNotFound())
-//                     .andExpect(jsonPath("$.detail").value("식별자 100에 해당하는 카테고리가 존재하지 않습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 검색 실패: 태그가 없는 경우")
-//         void findAllTemplatesFailNotFoundTag() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
-//             templateService.createTemplate(memberDto, templateRequest1);
-
-//             // when & then
-//             mvc.perform(get("/templates")
-//                             .cookie(cookie)
-//                             .param("memberId", "1")
-//                             .param("keyword", "")
-//                             .param("tagIds", "100")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isNotFound())
-//                     .andExpect(jsonPath("$.detail").value("식별자 100에 해당하는 태그가 존재하지 않습니다."));
-//         }
-//     }
-
-//     @Nested
-//     @DisplayName("템플릿 단건 조회 테스트")
-//     class findTemplateTest {
-//         @Test
-//         @DisplayName("템플릿 단건 조회 성공")
-//         void findOneTemplateSuccess() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-
-//             // when & then
-//             mvc.perform(get("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isOk())
-//                     .andExpect(jsonPath("$.title").value(templateRequest.title()))
-//                     .andExpect(jsonPath("$.sourceCodes.size()").value(2))
-//                     .andExpect(jsonPath("$.category.id").value(1))
-//                     .andExpect(jsonPath("$.category.name").value("카테고리 없음"))
-//                     .andExpect(jsonPath("$.tags.size()").value(2));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 단건 조회 실패: 존재하지 않는 템플릿 조회")
-//         void findOneTemplateFailWithNotFoundTemplate() throws Exception {
-//             // when & then
-//             mvc.perform(get("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isNotFound())
-//                     .andExpect(jsonPath("$.detail").value("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 단건 조회 실패: 자신의 템플릿이 아닐 경우")
-//         void findOneTemplateFailWithUnauthorized() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-
-//             // then
-//             mvc.perform(get("/templates/1")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("인증에 실패했습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 단건 조회 실패: 자신의 템플릿이 아닐 경우")
-//         void findOneTemplateFailWithNotMine() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-//             Member secondMember = MemberFixture.getSecondMember();
-
-//             // when
-//             String basicAuth = HttpHeaders.encodeBasicAuth(secondMember.getEmail(), secondMember.getPassword(),
-//                     StandardCharsets.UTF_8);
-//             cookie = new Cookie("Authorization", basicAuth);
-
-//             // then
-//             mvc.perform(get("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-//         }
-//     }
-
-//     @Nested
-//     @DisplayName("템플릿 수정 테스트")
-//     class updateTemplateTest {
-
-//         @Test
-//         @DisplayName("템플릿 수정 성공")
-//         void updateTemplateSuccess() throws Exception {
-//             // given
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     "updateTitle",
-//                     "description",
-//                     List.of(
-//                             new CreateSourceCodeRequest("filename3", "content3", 2),
-//                             new CreateSourceCodeRequest("filename4", "content4", 3)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-//                     ),
-//                     List.of(1L),
-//                     1L,
-//                     List.of("tag1", "tag3")
-//             );
-
-//             // when & then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isOk());
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 수정 실패: 권한 없음")
-//         void updateTemplateFailWithUnauthorized() throws Exception {
-//             // given
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     "updateTitle",
-//                     "description",
-//                     List.of(
-//                             new CreateSourceCodeRequest("filename3", "content3", 2),
-//                             new CreateSourceCodeRequest("filename4", "content4", 3)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-//                     ),
-//                     List.of(1L),
-//                     2L,
-//                     List.of("tag1", "tag3")
-//             );
-//             Member secondMember = MemberFixture.getSecondMember();
-
-//             // when
-//             String basicAuth = HttpHeaders.encodeBasicAuth(secondMember.getEmail(), secondMember.getPassword(),
-//                     StandardCharsets.UTF_8);
-//             cookie = new Cookie("Authorization", basicAuth);
-
-//             // then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 수정 실패: 템플릿명 길이 초과")
-//         void updateTemplateFailWithLongName() throws Exception {
-//             // given
-//             String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     exceededTitle,
-//                     "description",
-//                     List.of(
-//                             new CreateSourceCodeRequest("filename3", "content3", 2),
-//                             new CreateSourceCodeRequest("filename4", "content4", 3)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-//                     ),
-//                     List.of(1L),
-//                     2L,
-//                     List.of("tag1", "tag3")
-//             );
-
-//             // when & then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 수정 실패: 파일 이름 길이 초과")
-//         void updateTemplateFailWithLongFileName() throws Exception {
-//             // given
-//             String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(
-//                             new CreateSourceCodeRequest(exceededTitle, "content3", 2),
-//                             new CreateSourceCodeRequest("filename4", "content4", 3)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-//                     ),
-//                     List.of(1L),
-//                     2L,
-//                     List.of("tag1", "tag3")
-//             );
-
-//             // when & then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
-//         }
-
-//         @ParameterizedTest
-//         @DisplayName("템플릿 수정 실패: 파일 내용 길이 초과")
-//         @CsvSource({"a, 65536", "ㄱ, 21846"})
-//         void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) throws Exception {
-//             // given
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     "title",
-//                     "description",
-//                     List.of(
-//                             new CreateSourceCodeRequest("filename3", repeatTarget.repeat(exceedLength), 2),
-//                             new CreateSourceCodeRequest("filename4", "content4", 3)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-//                     ),
-//                     List.of(1L),
-//                     2L,
-//                     List.of("tag1", "tag3")
-//             );
-
-//             // when & then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
-//         }
-
-//         @ParameterizedTest
-//         @DisplayName("템플릿 수정 실패: 템플릿 설명 길이 초과")
-//         @CsvSource({"a, 65536", "ㄱ, 21846"})
-//         void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) throws Exception {
-//             // given
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     "title",
-//                     repeatTarget.repeat(exceedLength),
-//                     List.of(
-//                             new CreateSourceCodeRequest("filename3", "content3", 2),
-//                             new CreateSourceCodeRequest("filename4", "content4", 3)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-//                     ),
-//                     List.of(1L),
-//                     2L,
-//                     List.of("tag1", "tag3")
-//             );
-
-//             // when & then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-//         }
-
-//         // 정상 요청: 2, 3, 1
-//         @ParameterizedTest
-//         @DisplayName("템플릿 수정 실패: 잘못된 소스 코드 순서 입력")
-//         @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
-//         void updateTemplateFailWithWrongSourceCodeOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal)
-//                 throws Exception {
-//             // given
-//             createTemplateAndTwoCategories();
-//             UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-//                     "updateTitle",
-//                     "description",
-//                     List.of(
-//                             new CreateSourceCodeRequest("filename3", "content3", createOrdinal1),
-//                             new CreateSourceCodeRequest("filename4", "content4", createOrdinal2)
-//                     ),
-//                     List.of(
-//                             new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
-//                     ),
-//                     List.of(1L),
-//                     2L,
-//                     List.of("tag1", "tag3")
-//             );
-
-//             // when & then
-//             mvc.perform(post("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON)
-//                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("소스 코드 순서가 잘못되었습니다."));
-//         }
-
-//         private void createTemplateAndTwoCategories() {
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             categoryService.create(new CreateCategoryRequest("category1"), memberDto);
-//             categoryService.create(new CreateCategoryRequest("category2"), memberDto);
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-//         }
-//     }
-
-//     @Nested
-//     @DisplayName("템플릿 삭제 테스트")
-//     class deleteTemplateTest {
-
-//         @Test
-//         @DisplayName("템플릿 삭제 성공: 1개")
-//         void deleteTemplateSuccess() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             categoryService.create(new CreateCategoryRequest("category"), memberDto);
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-
-//             // when & then
-//             mvc.perform(delete("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isNoContent());
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 삭제 성공: 여러개")
-//         void deleteTemplatesSuccess() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             categoryService.create(new CreateCategoryRequest("category"), memberDto);
-//             CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title");
-//             CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest1);
-//             templateService.createTemplate(memberDto, templateRequest2);
-
-//             // when & then
-//             mvc.perform(delete("/templates/1,2")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isNoContent());
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 삭제 실패: 템플릿 ID가 중복된 경우")
-//         void deleteTemplateFailWithDuplication() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             categoryService.create(new CreateCategoryRequest("category"), memberDto);
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-
-//             // when & then
-//             mvc.perform(delete("/templates/1,1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isBadRequest())
-//                     .andExpect(jsonPath("$.detail").value("삭제하고자 하는 템플릿 ID가 중복되었습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 삭제 실패: 인증 정보가 없거나 잘못된 경우")
-//         void deleteTemplateFailWithUnauthorized() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             categoryService.create(new CreateCategoryRequest("category"), memberDto);
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-
-//             // when & then
-//             mvc.perform(delete("/templates/1")
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("인증에 실패했습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 삭제 실패: 자신의 템플릿이 아닐 경우")
-//         void deleteTemplateFailNotMine() throws Exception {
-//             // given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             categoryService.create(new CreateCategoryRequest("category"), memberDto);
-//             CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
-//             templateService.createTemplate(memberDto, templateRequest);
-//             Member secondMember = MemberFixture.getSecondMember();
-
-//             // when
-//             String basicAuth = HttpHeaders.encodeBasicAuth(secondMember.getEmail(), secondMember.getPassword(),
-//                     StandardCharsets.UTF_8);
-//             cookie = new Cookie("Authorization", basicAuth);
-
-//             // then
-//             mvc.perform(delete("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isUnauthorized())
-//                     .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-//         }
-
-//         @Test
-//         @DisplayName("템플릿 삭제 실패: 존재 하지 않는 템플릿 삭제")
-//         void deleteTemplateFailWithNotFoundTemplate() throws Exception {
-//             // when & then
-//             mvc.perform(delete("/templates/1")
-//                             .cookie(cookie)
-//                             .accept(MediaType.APPLICATION_JSON)
-//                             .contentType(MediaType.APPLICATION_JSON))
-//                     .andExpect(status().isNotFound())
-//                     .andExpect(jsonPath("$.detail").value("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
-//         }
-//     }
-
-//     private static CreateTemplateRequest createTemplateRequestWithTwoSourceCodes(String title) {
-//         return new CreateTemplateRequest(
-//                 title,
-//                 "description",
-//                 List.of(
-//                         new CreateSourceCodeRequest("filename1", "content1", 1),
-//                         new CreateSourceCodeRequest("filename2", "content2", 2)
-//                 ),
-//                 1,
-//                 1L,
-//                 List.of("tag1", "tag2")
-//         );
-//     }
-// }
-// =======
-// //package codezap.template.controller;
-// //
-// //import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
-// //import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-// //import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
-// //import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-// //import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-// //
-// //import java.nio.charset.StandardCharsets;
-// //import java.util.List;
-// //
-// //import jakarta.servlet.http.Cookie;
-// //
-// //import org.junit.jupiter.api.BeforeEach;
-// //import org.junit.jupiter.api.DisplayName;
-// //import org.junit.jupiter.api.Nested;
-// //import org.junit.jupiter.api.Test;
-// //import org.junit.jupiter.params.ParameterizedTest;
-// //import org.junit.jupiter.params.provider.CsvSource;
-// //import org.mockito.Mock;
-// //import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
-// //import org.springframework.http.HttpHeaders;
-// //import org.springframework.http.MediaType;
-// //import org.springframework.test.web.servlet.MockMvc;
-// //import org.springframework.test.web.servlet.setup.MockMvcBuilders;
-// //
-// //import com.fasterxml.jackson.databind.ObjectMapper;
-// //
-// //import codezap.auth.configuration.AuthArgumentResolver;
-// //import codezap.auth.manager.CredentialManager;
-// //import codezap.auth.manager.FakeCredentialManager;
-// //import codezap.auth.provider.CredentialProvider;
-// //import codezap.auth.provider.FakeCredentialProvider;
-// //import codezap.category.domain.Category;
-// //import codezap.category.dto.request.CreateCategoryRequest;
-// //import codezap.category.repository.CategoryRepository;
-// //import codezap.category.repository.FakeCategoryRepository;
-// //import codezap.category.service.CategoryService;
-// //import codezap.fixture.MemberDtoFixture;
-// //import codezap.global.exception.GlobalExceptionHandler;
-// //import codezap.member.domain.Member;
-// //import codezap.member.dto.MemberDto;
-// //import codezap.member.repository.FakeMemberRepository;
-// //import codezap.member.repository.MemberRepository;
-// //import codezap.template.dto.request.CreateSnippetRequest;
-// //import codezap.template.dto.request.CreateTemplateRequest;
-// //import codezap.template.dto.request.UpdateSnippetRequest;
-// //import codezap.template.dto.request.UpdateTemplateRequest;
-// //import codezap.template.repository.FakeSnippetRepository;
-// //import codezap.template.repository.FakeTagRepository;
-// //import codezap.template.repository.FakeTemplateRepository;
-// //import codezap.template.repository.FakeTemplateTagRepository;
-// //import codezap.template.repository.FakeThumbnailSnippetRepository;
-// //import codezap.template.repository.SnippetRepository;
-// //import codezap.template.repository.TagRepository;
-// //import codezap.template.repository.TemplateRepository;
-// //import codezap.template.repository.TemplateTagRepository;
-// //import codezap.template.repository.ThumbnailSnippetRepository;
-// //import codezap.template.service.TemplateService;
-// //
-// //class TemplateControllerTest {
-// //
-// //    private static final int MAX_LENGTH = 255;
-// //
-// //    private Member firstMember = new Member(1L, "test1@email.com", "password1234", "username1");
-// //    private Member secondMember = new Member(2L, "test2@email.com", "password1234", "username2");
-// //    private Category firstCategory = new Category(1L, firstMember, "카테고리 없음", true);
-// //    private Category secondCategory = new Category(2L, secondMember, "카테고리 없음", true);
-// //
-// //    private final TemplateRepository templateRepository = new FakeTemplateRepository();
-// //    private final SnippetRepository snippetRepository = new FakeSnippetRepository();
-// //    private final ThumbnailSnippetRepository thumbnailSnippetRepository = new FakeThumbnailSnippetRepository();
-// //    private final CategoryRepository categoryRepository = new FakeCategoryRepository(
-// //            List.of(firstCategory, secondCategory));
-// //    private final TemplateTagRepository templateTagRepository = new FakeTemplateTagRepository();
-// //    private final TagRepository tagRepository = new FakeTagRepository();
-// //    private final MemberRepository memberRepository = new FakeMemberRepository(List.of(firstMember, secondMember));
-// //    private final TemplateService templateService = new TemplateService(
-// //            thumbnailSnippetRepository,
-// //            templateRepository,
-// //            snippetRepository,
-// //            categoryRepository,
-// //            tagRepository,
-// //            templateTagRepository,
-// //            memberRepository);
-// //    private final CategoryService categoryService = new CategoryService(categoryRepository, templateRepository,
-// //            memberRepository);
-// //    private final TemplateController templateController = new TemplateController(templateService);
-// //    private final CredentialProvider credentialProvider = new FakeCredentialProvider();
-// //    private final CredentialManager credentialManager = new FakeCredentialManager();
-// //
-// //    private final MockMvc mvc = MockMvcBuilders.standaloneSetup(templateController)
-// //            .setControllerAdvice(new GlobalExceptionHandler())
-// //            .setCustomArgumentResolvers(new AuthArgumentResolver(credentialManager, credentialProvider),
-// //                    new PageableHandlerMethodArgumentResolver())
-// //            .build();
-// //    private final ObjectMapper objectMapper = new ObjectMapper();
-// //
-// //    Cookie cookie;
-// //
-// //    @BeforeEach
-// //    void setCookie() {
-// //        String basicAuth = HttpHeaders.encodeBasicAuth(firstMember.getEmail(), firstMember.getPassword(),
-// //                StandardCharsets.UTF_8);
-// //        cookie = new Cookie("credential", basicAuth);
-// //    }
-// //
-// //    @Nested
-// //    @DisplayName("템플릿 생성 테스트")
-// //    class createTemplateTest {
-// //
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 생성 성공")
-// //        @CsvSource({"a, 65535", "ㄱ, 21845"})
-// //        void createTemplateSuccess(String repeatTarget, int maxLength) throws Exception {
-// //            String maxTitle = "a" .repeat(MAX_LENGTH);
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    maxTitle,
-// //                    repeatTarget.repeat(maxLength),
-// //                    List.of(new CreateSnippetRequest("a" .repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isCreated());
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 생성 실패: 로그인을 하지 않은 유저")
-// //        void createTemplateFailWithNotLogin() throws Exception {
-// //            String maxTitle = "title";
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    maxTitle,
-// //                    "description",
-// //                    List.of(new CreateSnippetRequest("filename", "content", 1)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isUnauthorized());
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 생성 실패: 템플릿 이름 길이 초과")
-// //        void createTemplateFailWithLongTitle() throws Exception {
-// //            String exceededTitle = "a" .repeat(MAX_LENGTH + 1);
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    exceededTitle,
-// //                    "description",
-// //                    List.of(new CreateSnippetRequest("a", "content", 1)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 생성 실패: 파일 이름 길이 초과")
-// //        void createTemplateFailWithLongFileName() throws Exception {
-// //            String exceededTitle = "a" .repeat(MAX_LENGTH + 1);
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    "title",
-// //                    "description",
-// //                    List.of(new CreateSnippetRequest(exceededTitle, "content", 1)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
-// //        }
-// //
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 생성 실패: 파일 내용 길이 초과")
-// //        @CsvSource({"a, 65536", "ㄱ, 21846"})
-// //        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) throws Exception {
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    "title",
-// //                    "description",
-// //                    List.of(new CreateSnippetRequest("title", repeatTarget.repeat(exceededLength), 1)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
-// //        }
-// //
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
-// //        @CsvSource({"a, 65536", "ㄱ, 21846"})
-// //        void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) throws Exception {
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    "title",
-// //                    repeatTarget.repeat(exceededLength),
-// //                    List.of(new CreateSnippetRequest("title", "content", 1)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-// //        }
-// //
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 생성 실패: 잘못된 스니펫 순서 입력")
-// //        @CsvSource({"0, 1", "1, 3", "2, 1"})
-// //        void createTemplateFailWithWrongSnippetOrdinal(int firstIndex, int secondIndex) throws Exception {
-// //            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                    "title",
-// //                    "description",
-// //                    List.of(new CreateSnippetRequest("title", "content", firstIndex),
-// //                            new CreateSnippetRequest("title", "content", secondIndex)),
-// //                    1,
-// //                    1L,
-// //                    List.of("tag1", "tag2")
-// //            );
-// //
-// //            mvc.perform(post("/templates")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(templateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("스니펫 순서가 잘못되었습니다."));
-// //        }
-// //    }
-// //
-// //    @Test
-// //    @DisplayName("템플릿 전체 조회 성공")
-// //    void findAllTemplatesSuccess() throws Exception {
-// //        // given
-// //        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //        CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSnippets("title1");
-// //        CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSnippets("title2");
-// //        templateService.createTemplate(memberDto, templateRequest1);
-// //        templateService.createTemplate(memberDto, templateRequest2);
-// //
-// //        // when & then
-// //        mvc.perform(get("/templates")
-// //                        .cookie(cookie)
-// //                        .param("memberId", "1")
-// //                        .param("keyword", "")
-// //                        .accept(MediaType.APPLICATION_JSON)
-// //                        .contentType(MediaType.APPLICATION_JSON))
-// //                .andExpect(status().isOk())
-// //                .andExpect(jsonPath("$.templates.size()").value(2));
-// //
-// //    }
-// //
-// //    @Nested
-// //    @DisplayName("템플릿 상세 조회 테스트")
-// //    class findTemplateTest {
-// //
-// //        @Test
-// //        @DisplayName("템플릿 상세 조회 성공")
-// //        void findOneTemplateSuccess() throws Exception {
-// //            // given
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-// //            templateService.createTemplate(memberDto, templateRequest);
-// //
-// //            // when & then
-// //            mvc.perform(get("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON))
-// //                    .andExpect(status().isOk())
-// //                    .andExpect(jsonPath("$.title").value(templateRequest.title()))
-// //                    .andExpect(jsonPath("$.snippets.size()").value(2))
-// //                    .andExpect(jsonPath("$.category.id").value(1))
-// //                    .andExpect(jsonPath("$.category.name").value("카테고리 없음"))
-// //                    .andExpect(jsonPath("$.tags.size()").value(2));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 상세 조회 실패: 존재하지 않는 템플릿 조회")
-// //        void findOneTemplateFailWithNotFoundTemplate() throws Exception {
-// //            // when & then
-// //            mvc.perform(get("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON))
-// //                    .andExpect(status().isNotFound())
-// //                    .andExpect(jsonPath("$.detail").value("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 상세 조회 실패: 권한 없음")
-// //        void findOneTemplateFailWithUnauthorized() throws Exception {
-// //            // given
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-// //            templateService.createTemplate(memberDto, templateRequest);
-// //
-// //            // when
-// //            String basicAuth = HttpHeaders.encodeBasicAuth(secondMember.getEmail(), secondMember.getPassword(),
-// //                    StandardCharsets.UTF_8);
-// //            cookie = new Cookie("Authorization", basicAuth);
-// //
-// //            // then
-// //            mvc.perform(get("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON))
-// //                    .andExpect(status().isUnauthorized())
-// //                    .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-// //        }
-// //    }
-// //
-// //    @Nested
-// //    @DisplayName("템플릿 수정 테스트")
-// //    class updateTemplateTest {
-// //
-// //        @Test
-// //        @DisplayName("템플릿 수정 성공")
-// //        void updateTemplateSuccess() throws Exception {
-// //            // given
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    "updateTitle",
-// //                    "description",
-// //                    List.of(
-// //                            new CreateSnippetRequest("filename3", "content3", 2),
-// //                            new CreateSnippetRequest("filename4", "content4", 3)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-// //                    ),
-// //                    List.of(1L),
-// //                    1L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when & then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isOk());
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 수정 실패: 권한 없음")
-// //        void updateTemplateFailWithUnauthorized() throws Exception {
-// //            // given
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    "updateTitle",
-// //                    "description",
-// //                    List.of(
-// //                            new CreateSnippetRequest("filename3", "content3", 2),
-// //                            new CreateSnippetRequest("filename4", "content4", 3)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-// //                    ),
-// //                    List.of(1L),
-// //                    2L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when
-// //            String basicAuth = HttpHeaders.encodeBasicAuth(secondMember.getEmail(), secondMember.getPassword(),
-// //                    StandardCharsets.UTF_8);
-// //            cookie = new Cookie("Authorization", basicAuth);
-// //
-// //            // then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isUnauthorized())
-// //                    .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 수정 실패: 템플릿 이름 길이 초과")
-// //        void updateTemplateFailWithLongName() throws Exception {
-// //            // given
-// //            String exceededTitle = "a" .repeat(MAX_LENGTH + 1);
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    exceededTitle,
-// //                    "description",
-// //                    List.of(
-// //                            new CreateSnippetRequest("filename3", "content3", 2),
-// //                            new CreateSnippetRequest("filename4", "content4", 3)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-// //                    ),
-// //                    List.of(1L),
-// //                    2L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when & then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 수정 실패: 파일 이름 길이 초과")
-// //        void updateTemplateFailWithLongFileName() throws Exception {
-// //            // given
-// //            String exceededTitle = "a" .repeat(MAX_LENGTH + 1);
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    "title",
-// //                    "description",
-// //                    List.of(
-// //                            new CreateSnippetRequest(exceededTitle, "content3", 2),
-// //                            new CreateSnippetRequest("filename4", "content4", 3)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-// //                    ),
-// //                    List.of(1L),
-// //                    2L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when & then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
-// //        }
-// //
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 수정 실패: 파일 내용 길이 초과")
-// //        @CsvSource({"a, 65536", "ㄱ, 21846"})
-// //        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) throws Exception {
-// //            // given
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    "title",
-// //                    "description",
-// //                    List.of(
-// //                            new CreateSnippetRequest("filename3", repeatTarget.repeat(exceedLength), 2),
-// //                            new CreateSnippetRequest("filename4", "content4", 3)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-// //                    ),
-// //                    List.of(1L),
-// //                    2L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when & then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
-// //        }
-// //
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 수정 실패: 템플릿 설명 길이 초과")
-// //        @CsvSource({"a, 65536", "ㄱ, 21846"})
-// //        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) throws Exception {
-// //            // given
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    "title",
-// //                    repeatTarget.repeat(exceedLength),
-// //                    List.of(
-// //                            new CreateSnippetRequest("filename3", "content3", 2),
-// //                            new CreateSnippetRequest("filename4", "content4", 3)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", 1)
-// //                    ),
-// //                    List.of(1L),
-// //                    2L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when & then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-// //        }
-// //
-// //        // 정상 요청: 2, 3, 1
-// //        @ParameterizedTest
-// //        @DisplayName("템플릿 수정 실패: 잘못된 스니펫 순서 입력")
-// //        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
-// //        void updateTemplateFailWithWrongSnippetOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal)
-// //                throws Exception {
-// //            // given
-// //            createTemplateAndTwoCategories();
-// //            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-// //                    "updateTitle",
-// //                    "description",
-// //                    List.of(
-// //                            new CreateSnippetRequest("filename3", "content3", createOrdinal1),
-// //                            new CreateSnippetRequest("filename4", "content4", createOrdinal2)
-// //                    ),
-// //                    List.of(
-// //                            new UpdateSnippetRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
-// //                    ),
-// //                    List.of(1L),
-// //                    2L,
-// //                    List.of("tag1", "tag3")
-// //            );
-// //
-// //            // when & then
-// //            mvc.perform(post("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON)
-// //                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-// //                    .andExpect(status().isBadRequest())
-// //                    .andExpect(jsonPath("$.detail").value("스니펫 순서가 잘못되었습니다."));
-// //        }
-// //
-// //        private void createTemplateAndTwoCategories() {
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            categoryService.create(new CreateCategoryRequest("category1"), memberDto);
-// //            categoryService.create(new CreateCategoryRequest("category2"), memberDto);
-// //            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-// //            templateService.createTemplate(memberDto, templateRequest);
-// //        }
-// //    }
-// //
-// //    @Nested
-// //    @DisplayName("템플릿 삭제 테스트")
-// //    class deleteTemplateTest {
-// //
-// //        @Test
-// //        @DisplayName("템플릿 삭제 성공")
-// //        void deleteTemplateSuccess() throws Exception {
-// //            // given
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            categoryService.create(new CreateCategoryRequest("category"), memberDto);
-// //            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-// //            templateService.createTemplate(memberDto, templateRequest);
-// //
-// //            // when & then
-// //            mvc.perform(delete("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON))
-// //                    .andExpect(status().isNoContent());
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 삭제 실패: 권한 없음")
-// //        void deleteTemplateFailWithUnauthorized() throws Exception {
-// //            // given
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            categoryService.create(new CreateCategoryRequest("category"), memberDto);
-// //            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSnippets("title");
-// //            templateService.createTemplate(memberDto, templateRequest);
-// //
-// //            // when
-// //            String basicAuth = HttpHeaders.encodeBasicAuth(secondMember.getEmail(), secondMember.getPassword(),
-// //                    StandardCharsets.UTF_8);
-// //            cookie = new Cookie("Authorization", basicAuth);
-// //
-// //            // then
-// //            mvc.perform(delete("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON))
-// //                    .andExpect(status().isUnauthorized())
-// //                    .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("템플릿 삭제 실패: 존재하지 않는 템플릿 삭제")
-// //        void deleteTemplateFailWithNotFoundTemplate() throws Exception {
-// //            // when & then
-// //            mvc.perform(delete("/templates/1")
-// //                            .cookie(cookie)
-// //                            .accept(MediaType.APPLICATION_JSON)
-// //                            .contentType(MediaType.APPLICATION_JSON))
-// //                    .andExpect(status().isNotFound());
-// //        }
-// //    }
-// //
-// //    private static CreateTemplateRequest createTemplateRequestWithTwoSnippets(String title) {
-// //        CreateTemplateRequest templateRequest = new CreateTemplateRequest(
-// //                title,
-// //                "description",
-// //                List.of(
-// //                        new CreateSnippetRequest("filename1", "content1", 1),
-// //                        new CreateSnippetRequest("filename2", "content2", 2)
-// //                ),
-// //                1,
-// //                1L,
-// //                List.of("tag1", "tag2")
-// //        );
-// //        return templateRequest;
-// //    }
-// //}
-// >>>>>>> dev/be
+package codezap.template.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import jakarta.servlet.http.Cookie;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import codezap.auth.configuration.AuthArgumentResolver;
+import codezap.auth.manager.CookieCredentialManager;
+import codezap.auth.manager.CredentialManager;
+import codezap.auth.provider.CredentialProvider;
+import codezap.auth.provider.basic.BasicAuthCredentialProvider;
+import codezap.category.dto.request.CreateCategoryRequest;
+import codezap.category.repository.CategoryRepository;
+import codezap.category.repository.FakeCategoryRepository;
+import codezap.category.service.CategoryService;
+import codezap.fixture.CategoryFixture;
+import codezap.fixture.MemberDtoFixture;
+import codezap.fixture.MemberFixture;
+import codezap.global.exception.GlobalExceptionHandler;
+import codezap.member.domain.Member;
+import codezap.member.dto.MemberDto;
+import codezap.member.repository.FakeMemberRepository;
+import codezap.member.repository.MemberRepository;
+import codezap.member.service.MemberService;
+import codezap.template.dto.request.CreateSourceCodeRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
+import codezap.template.dto.request.UpdateSourceCodeRequest;
+import codezap.template.dto.request.UpdateTemplateRequest;
+import codezap.template.repository.FakeSourceCodeRepository;
+import codezap.template.repository.FakeTagRepository;
+import codezap.template.repository.FakeTemplateRepository;
+import codezap.template.repository.FakeTemplateTagRepository;
+import codezap.template.repository.FakeThumbnailRepository;
+import codezap.template.repository.SourceCodeRepository;
+import codezap.template.repository.TagRepository;
+import codezap.template.repository.TemplateRepository;
+import codezap.template.repository.TemplateTagRepository;
+import codezap.template.repository.ThumbnailRepository;
+import codezap.template.service.TemplateApplicationService;
+import codezap.template.service.TemplateService;
+
+class TemplateControllerTest {
+
+    private static final int MAX_LENGTH = 255;
+
+    private final TemplateRepository templateRepository = new FakeTemplateRepository();
+    private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
+    private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();
+    private final CategoryRepository categoryRepository = new FakeCategoryRepository(
+            List.of(CategoryFixture.getFirstCategory(), CategoryFixture.getSecondCategory())
+    );
+    private final TemplateTagRepository templateTagRepository = new FakeTemplateTagRepository();
+    private final TagRepository tagRepository = new FakeTagRepository();
+    private final MemberRepository memberRepository = new FakeMemberRepository(
+            List.of(MemberFixture.getFirstMember(), MemberFixture.getSecondMember())
+    );
+    private final TemplateService templateService = new TemplateService(
+            thumbnailRepository,
+            templateRepository,
+            sourceCodeRepository,
+            categoryRepository,
+            tagRepository,
+            templateTagRepository,
+            memberRepository);
+    private final CategoryService categoryService = new CategoryService(
+            categoryRepository, templateRepository, memberRepository
+    );
+
+    private final MemberService memberService = new MemberService(memberRepository, categoryRepository);
+
+    private final TemplateApplicationService applicationService = new TemplateApplicationService(
+            memberService, templateService
+    );
+
+    private final TemplateController templateController = new TemplateController(templateService, applicationService);
+
+    private final CredentialManager credentialManager = new CookieCredentialManager();
+    private final CredentialProvider credentialProvider = new BasicAuthCredentialProvider(memberRepository);
+
+    private final MockMvc mvc = MockMvcBuilders.standaloneSetup(templateController)
+            .setControllerAdvice(new GlobalExceptionHandler())
+            .setCustomArgumentResolvers(new AuthArgumentResolver(credentialManager, credentialProvider),
+                    new PageableHandlerMethodArgumentResolver())
+            .build();
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    Cookie cookie;
+
+    @BeforeEach
+    void setCookie() {
+        Member firstMember = MemberFixture.getFirstMember();
+        String basicAuth = HttpHeaders.encodeBasicAuth(
+                firstMember.getName(),
+                firstMember.getPassword(),
+                StandardCharsets.UTF_8);
+        cookie = new Cookie("credential", basicAuth);
+    }
+
+    @Nested
+    @DisplayName("템플릿 생성 테스트")
+    class createTemplateTest {
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 성공")
+        @CsvSource({"a, 65535", "ㄱ, 21845"})
+        void createTemplateSuccess(String repeatTarget, int maxLength) throws Exception {
+            String maxTitle = "a".repeat(MAX_LENGTH);
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    maxTitle,
+                    repeatTarget.repeat(maxLength),
+                    List.of(new CreateSourceCodeRequest("a".repeat(MAX_LENGTH), repeatTarget.repeat(maxLength), 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isCreated());
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 템플릿명 길이 초과")
+        void createTemplateFailWithLongTitle() throws Exception {
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    exceededTitle,
+                    "description",
+                    List.of(new CreateSourceCodeRequest("a", "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    repeatTarget.repeat(exceededLength),
+                    List.of(new CreateSourceCodeRequest("title", "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 파일명 길이 초과")
+        void createTemplateFailWithLongFileName() throws Exception {
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest(exceededTitle, "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 소스 코드 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("title", repeatTarget.repeat(exceededLength), 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 잘못된 소스 코드 순서 입력")
+        @CsvSource({"0, 1", "1, 3", "2, 1"})
+        void createTemplateFailWithWrongSourceCodeOrdinal(int firstIndex, int secondIndex) throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("title", "content", firstIndex),
+                            new CreateSourceCodeRequest("title", "content", secondIndex)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드 순서가 잘못되었습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 인증 정보가 없거나 잘못된 경우")
+        void createTemplateFailWithNotLogin() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("filename", "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 카테고리 권한이 없는 경우")
+        void createTemplateFailWithNoMatchCategory() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("filename", "content", 1)),
+                    1,
+                    2L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("해당 카테고리에 대한 권한이 없습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 카테고리가 없는 경우")
+        void createTemplateFailWithNotCategory() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("filename", "content", 1)),
+                    1,
+                    3L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.detail").value("식별자 3에 해당하는 카테고리가 존재하지 않습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 해당 순서인 소스 코드 없는 경우")
+        void createTemplateFailWithNotSourceCode() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("filename", "content", 1)),
+                    10,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.detail").value("템플릿에 10번째 소스 코드가 존재하지 않습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 검색 테스트")
+    class getTemplatesTest {
+
+        @Test
+        @DisplayName("템플릿 검색 성공")
+        void findAllTemplatesSuccess() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
+            CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSourceCodes("title2");
+            templateService.createTemplate(memberDto, templateRequest1);
+            templateService.createTemplate(memberDto, templateRequest2);
+
+            // when & then
+            mvc.perform(get("/templates")
+                            .cookie(cookie)
+                            .param("memberId", "1")
+                            .param("keyword", "")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.templates.size()").value(2));
+        }
+
+        @Test
+        @DisplayName("템플릿 검색 실패: 태그 ID가 0개인 경우")
+        void findAllTemplatesFailWithZeroTagIds() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
+            templateService.createTemplate(memberDto, templateRequest1);
+
+            // when & then
+            mvc.perform(get("/templates")
+                            .cookie(cookie)
+                            .param("memberId", "1")
+                            .param("keyword", "")
+                            .param("tagIds", "")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("태그 ID가 0개입니다. 필터링 하지 않을 경우 null로 전달해주세요."));
+        }
+
+        @Test
+        @DisplayName("템플릿 검색 실패: 인증 정보가 없거나 잘못된 경우")
+        void findAllTemplatesFailWithCookie() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
+            templateService.createTemplate(memberDto, templateRequest1);
+
+            // when & then
+            mvc.perform(get("/templates")
+                            .param("memberId", "1")
+                            .param("keyword", "")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."));
+        }
+
+        @Test
+        @DisplayName("템플릿 검색 실패: 인증 정보와 멤버 ID가 다른 경우")
+        void findAllTemplatesFailNonMatchMemberIdAndMemberDto() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
+            templateService.createTemplate(memberDto, templateRequest1);
+
+            // when & then
+            mvc.perform(get("/templates")
+                            .cookie(cookie)
+                            .param("memberId", "100")
+                            .param("keyword", "")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("인증 정보에 포함된 멤버 ID와 파라미터로 받은 멤버 ID가 다릅니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 검색 실패: 카테고리가 없는 경우")
+        void findAllTemplatesFailNotFoundCategory() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
+            templateService.createTemplate(memberDto, templateRequest1);
+
+            // when & then
+            mvc.perform(get("/templates")
+                            .cookie(cookie)
+                            .param("memberId", "1")
+                            .param("keyword", "")
+                            .param("categoryId", "100")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.detail").value("식별자 100에 해당하는 카테고리가 존재하지 않습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 검색 실패: 태그가 없는 경우")
+        void findAllTemplatesFailNotFoundTag() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title1");
+            templateService.createTemplate(memberDto, templateRequest1);
+
+            // when & then
+            mvc.perform(get("/templates")
+                            .cookie(cookie)
+                            .param("memberId", "1")
+                            .param("keyword", "")
+                            .param("tagIds", "100")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.detail").value("식별자 100에 해당하는 태그가 존재하지 않습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 단건 조회 테스트")
+    class findTemplateTest {
+        @Test
+        @DisplayName("템플릿 단건 조회 성공")
+        void findOneTemplateSuccess() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+
+            // when & then
+            mvc.perform(get("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isOk())
+                    .andExpect(jsonPath("$.title").value(templateRequest.title()))
+                    .andExpect(jsonPath("$.sourceCodes.size()").value(2))
+                    .andExpect(jsonPath("$.category.id").value(1))
+                    .andExpect(jsonPath("$.category.name").value("카테고리 없음"))
+                    .andExpect(jsonPath("$.tags.size()").value(2));
+        }
+
+        @Test
+        @DisplayName("템플릿 단건 조회 실패: 존재하지 않는 템플릿 조회")
+        void findOneTemplateFailWithNotFoundTemplate() throws Exception {
+            // when & then
+            mvc.perform(get("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.detail").value("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 단건 조회 실패: 자신의 템플릿이 아닐 경우")
+        void findOneTemplateFailWithUnauthorized() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+
+            // then
+            mvc.perform(get("/templates/1")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."));
+        }
+
+        @Test
+        @DisplayName("템플릿 단건 조회 실패: 자신의 템플릿이 아닐 경우")
+        void findOneTemplateFailWithNotMine() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+            Member secondMember = MemberFixture.getSecondMember();
+
+            // when
+            String basicAuth = HttpHeaders.encodeBasicAuth(
+                    secondMember.getName(),
+                    secondMember.getPassword(),
+                    StandardCharsets.UTF_8);
+            cookie = new Cookie("credential", basicAuth);
+
+            // then
+            mvc.perform(get("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 수정 테스트")
+    class updateTemplateTest {
+
+        @Test
+        @DisplayName("템플릿 수정 성공")
+        void updateTemplateSuccess() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    1L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isOk());
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 권한 없음")
+        void updateTemplateFailWithUnauthorized() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+            Member secondMember = MemberFixture.getSecondMember();
+
+            // when
+            String basicAuth = HttpHeaders.encodeBasicAuth(
+                    secondMember.getName(),
+                    secondMember.getPassword(),
+                    StandardCharsets.UTF_8);
+            cookie = new Cookie("credential", basicAuth);
+
+            // then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 템플릿명 길이 초과")
+        void updateTemplateFailWithLongName() throws Exception {
+            // given
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    exceededTitle,
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 파일 이름 길이 초과")
+        void updateTemplateFailWithLongFileName() throws Exception {
+            // given
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest(exceededTitle, "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 파일 내용 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", repeatTarget.repeat(exceedLength), 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 템플릿 설명 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    repeatTarget.repeat(exceedLength),
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        // 정상 요청: 2, 3, 1
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 잘못된 소스 코드 순서 입력")
+        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
+        void updateTemplateFailWithWrongSourceCodeOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal)
+                throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", createOrdinal1),
+                            new CreateSourceCodeRequest("filename4", "content4", createOrdinal2)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드 순서가 잘못되었습니다."));
+        }
+
+        private void createTemplateAndTwoCategories() {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(memberDto, new CreateCategoryRequest("category1"));
+            categoryService.create(memberDto, new CreateCategoryRequest("category2"));
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 삭제 테스트")
+    class deleteTemplateTest {
+
+        @Test
+        @DisplayName("템플릿 삭제 성공: 1개")
+        void deleteTemplateSuccess() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(memberDto, new CreateCategoryRequest("category"));
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+
+            // when & then
+            mvc.perform(delete("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("템플릿 삭제 성공: 여러개")
+        void deleteTemplatesSuccess() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(memberDto, new CreateCategoryRequest("category"));
+            CreateTemplateRequest templateRequest1 = createTemplateRequestWithTwoSourceCodes("title");
+            CreateTemplateRequest templateRequest2 = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest1);
+            templateService.createTemplate(memberDto, templateRequest2);
+
+            // when & then
+            mvc.perform(delete("/templates/1,2")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNoContent());
+        }
+
+        @Test
+        @DisplayName("템플릿 삭제 실패: 템플릿 ID가 중복된 경우")
+        void deleteTemplateFailWithDuplication() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(memberDto, new CreateCategoryRequest("category"));
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+
+            // when & then
+            mvc.perform(delete("/templates/1,1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("삭제하고자 하는 템플릿 ID가 중복되었습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 삭제 실패: 인증 정보가 없거나 잘못된 경우")
+        void deleteTemplateFailWithUnauthorized() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(memberDto, new CreateCategoryRequest("category"));
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+
+            // when & then
+            mvc.perform(delete("/templates/1")
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."));
+        }
+
+        @Test
+        @DisplayName("템플릿 삭제 실패: 자신의 템플릿이 아닐 경우")
+        void deleteTemplateFailNotMine() throws Exception {
+            // given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            categoryService.create(memberDto, new CreateCategoryRequest("category"));
+            CreateTemplateRequest templateRequest = createTemplateRequestWithTwoSourceCodes("title");
+            templateService.createTemplate(memberDto, templateRequest);
+            Member secondMember = MemberFixture.getSecondMember();
+
+            // when
+            String basicAuth = HttpHeaders.encodeBasicAuth(
+                    secondMember.getName(),
+                    secondMember.getPassword(),
+                    StandardCharsets.UTF_8);
+            cookie = new Cookie("credential", basicAuth);
+
+            // then
+            mvc.perform(delete("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isUnauthorized())
+                    .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 삭제 실패: 존재 하지 않는 템플릿 삭제")
+        void deleteTemplateFailWithNotFoundTemplate() throws Exception {
+            // when & then
+            mvc.perform(delete("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON))
+                    .andExpect(status().isNotFound())
+                    .andExpect(jsonPath("$.detail").value("식별자 1에 해당하는 템플릿이 존재하지 않습니다."));
+        }
+    }
+
+    private static CreateTemplateRequest createTemplateRequestWithTwoSourceCodes(String title) {
+        return new CreateTemplateRequest(
+                title,
+                "description",
+                List.of(
+                        new CreateSourceCodeRequest("filename1", "content1", 1),
+                        new CreateSourceCodeRequest("filename2", "content2", 2)
+                ),
+                1,
+                1L,
+                List.of("tag1", "tag2")
+        );
+    }
+}

--- a/backend/src/test/java/codezap/template/repository/FakeSourceCodeRepository.java
+++ b/backend/src/test/java/codezap/template/repository/FakeSourceCodeRepository.java
@@ -27,7 +27,8 @@ public class FakeSourceCodeRepository implements SourceCodeRepository {
         return sourceCodes.stream()
                 .filter(sourceCode -> Objects.equals(sourceCode.getId(), id))
                 .findFirst()
-                .orElseThrow(() -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 소스 코드가 존재하지 않습니다."));
+                .orElseThrow(
+                        () -> new CodeZapException(HttpStatus.NOT_FOUND, "식별자 " + id + "에 해당하는 소스 코드가 존재하지 않습니다."));
     }
 
     @Override

--- a/backend/src/test/java/codezap/template/service/TagSearchTest.java
+++ b/backend/src/test/java/codezap/template/service/TagSearchTest.java
@@ -38,10 +38,6 @@ import codezap.template.repository.ThumbnailRepository;
 
 public class TagSearchTest {
 
-    private Member firstMember = new Member(1L, "name1", "password1234");
-    private Member secondMember = new Member(2L, "name2", "password1234");
-    private Category firstCategory = new Category(1L, firstMember, "카테고리 없음", true);
-
     private final TemplateRepository templateRepository = new FakeTemplateRepository();
     private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
     private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();

--- a/backend/src/test/java/codezap/template/service/TemplateServiceSearchTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceSearchTest.java
@@ -1,404 +1,403 @@
-// package codezap.template.service;
+package codezap.template.service;
 
-// import static org.assertj.core.api.Assertions.assertThat;
-// import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
-// import java.util.List;
+import java.util.List;
 
-// import org.junit.jupiter.api.DisplayName;
-// import org.junit.jupiter.api.Nested;
-// import org.junit.jupiter.api.Test;
-// import org.springframework.data.domain.PageRequest;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.PageRequest;
 
-// import codezap.category.domain.Category;
-// import codezap.category.repository.CategoryRepository;
-// import codezap.category.repository.FakeCategoryRepository;
-// import codezap.fixture.MemberDtoFixture;
-// import codezap.fixture.MemberFixture;
-// import codezap.member.domain.Member;
-// import codezap.member.dto.MemberDto;
-// import codezap.member.repository.FakeMemberRepository;
-// import codezap.member.repository.MemberRepository;
-// import codezap.template.domain.SourceCode;
-// import codezap.template.domain.Template;
-// import codezap.template.domain.Thumbnail;
-// import codezap.template.dto.request.CreateSourceCodeRequest;
-// import codezap.template.dto.request.CreateTemplateRequest;
-// import codezap.template.dto.response.FindAllTemplatesResponse;
-// import codezap.template.dto.response.FindAllTemplatesResponse.ItemResponse;
-// import codezap.template.repository.FakeSourceCodeRepository;
-// import codezap.template.repository.FakeTagRepository;
-// import codezap.template.repository.FakeTemplateRepository;
-// import codezap.template.repository.FakeTemplateTagRepository;
-// import codezap.template.repository.FakeThumbnailRepository;
-// import codezap.template.repository.SourceCodeRepository;
-// import codezap.template.repository.TagRepository;
-// import codezap.template.repository.TemplateRepository;
-// import codezap.template.repository.TemplateTagRepository;
-// import codezap.template.repository.ThumbnailRepository;
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.category.repository.FakeCategoryRepository;
+import codezap.fixture.MemberDtoFixture;
+import codezap.fixture.MemberFixture;
+import codezap.member.domain.Member;
+import codezap.member.dto.MemberDto;
+import codezap.member.repository.FakeMemberRepository;
+import codezap.member.repository.MemberRepository;
+import codezap.template.domain.SourceCode;
+import codezap.template.domain.Template;
+import codezap.template.domain.Thumbnail;
+import codezap.template.dto.request.CreateSourceCodeRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
+import codezap.template.dto.response.FindAllTemplatesResponse;
+import codezap.template.dto.response.FindAllTemplatesResponse.ItemResponse;
+import codezap.template.repository.FakeSourceCodeRepository;
+import codezap.template.repository.FakeTagRepository;
+import codezap.template.repository.FakeTemplateRepository;
+import codezap.template.repository.FakeTemplateTagRepository;
+import codezap.template.repository.FakeThumbnailRepository;
+import codezap.template.repository.SourceCodeRepository;
+import codezap.template.repository.TagRepository;
+import codezap.template.repository.TemplateRepository;
+import codezap.template.repository.TemplateTagRepository;
+import codezap.template.repository.ThumbnailRepository;
 
-// class TemplateServiceSearchTest {
+class TemplateServiceSearchTest {
+    private final TemplateRepository templateRepository = new FakeTemplateRepository();
+    private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
+    private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();
+    private final CategoryRepository categoryRepository = new FakeCategoryRepository();
+    private final TemplateTagRepository templateTagRepository = new FakeTemplateTagRepository();
+    private final TagRepository tagRepository = new FakeTagRepository();
+    private final MemberRepository memberRepository = new FakeMemberRepository(List.of(
+            MemberFixture.getFirstMember(), MemberFixture.getSecondMember()
+    ));
+    private final TemplateService templateService = new TemplateService(
+            thumbnailRepository,
+            templateRepository,
+            sourceCodeRepository,
+            categoryRepository,
+            tagRepository,
+            templateTagRepository,
+            memberRepository);
 
-//     private Member firstMember = new Member(1L, "name1", "password1234");
-//     private Member secondMember = new Member(2L, "name2", "password1234");
+    private void saveDefault15Templates(Member member, Category category) {
+        saveTemplate(makeTemplateRequest("hello keyword 1"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 2"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 3"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 4"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 5"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 6"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 7"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 8"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 9"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 10"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 11"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 12"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 13"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 14"), member, category);
+        saveTemplate(makeTemplateRequest("hello keyword 15"), member, category);
+    }
 
-//     private final TemplateRepository templateRepository = new FakeTemplateRepository();
-//     private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
-//     private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();
-//     private final CategoryRepository categoryRepository = new FakeCategoryRepository();
-//     private final TemplateTagRepository templateTagRepository = new FakeTemplateTagRepository();
-//     private final TagRepository tagRepository = new FakeTagRepository();
-//     private final MemberRepository memberRepository = new FakeMemberRepository(List.of(
-//             MemberFixture.getFirstMember(), MemberFixture.getSecondMember()
-//     ));
-//     private final TemplateService templateService = new TemplateService(
-//             thumbnailRepository,
-//             templateRepository,
-//             sourceCodeRepository,
-//             categoryRepository,
-//             tagRepository,
-//             templateTagRepository,
-//             memberRepository);
+    private CreateTemplateRequest makeTemplateRequest(String title) {
+        return new CreateTemplateRequest(title, "description",
+                List.of(new CreateSourceCodeRequest("filename1", "content1", 1),
+                        new CreateSourceCodeRequest("filename2", "content2", 2)),
+                1,
+                1L,
+                List.of());
+    }
 
-//     private void saveDefault15Templates(Member member, Category category) {
-//         saveTemplate(makeTemplateRequest("hello keyword 1"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 2"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 3"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 4"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 5"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 6"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 7"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 8"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 9"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 10"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 11"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 12"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 13"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 14"), member, category);
-//         saveTemplate(makeTemplateRequest("hello keyword 15"), member, category);
-//     }
+    private Template saveTemplate(CreateTemplateRequest createTemplateRequest, Member member, Category category) {
+        Template savedTemplate = templateRepository.save(
+                new Template(member, createTemplateRequest.title(), createTemplateRequest.description(), category));
+        SourceCode savedFirstSourceCode = sourceCodeRepository.save(
+                new SourceCode(savedTemplate, "filename1", "content1", 1));
+        sourceCodeRepository.save(new SourceCode(savedTemplate, "filename2", "content2", 2));
+        savedTemplate.updateSourceCodes(List.of(savedFirstSourceCode));
+        thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
 
-//     private CreateTemplateRequest makeTemplateRequest(String title) {
-//         return new CreateTemplateRequest(title, "description",
-//                 List.of(new CreateSourceCodeRequest("filename1", "content1", 1),
-//                         new CreateSourceCodeRequest("filename2", "content2", 2)),
-//                 1,
-//                 1L,
-//                 List.of());
-//     }
+        return savedTemplate;
+    }
 
-//     private Template saveTemplate(CreateTemplateRequest createTemplateRequest, Member member, Category category) {
-//         Template savedTemplate = templateRepository.save(
-//                 new Template(member, createTemplateRequest.title(), createTemplateRequest.description(), category));
-//         SourceCode savedFirstSourceCode = sourceCodeRepository.save(
-//                 new SourceCode(savedTemplate, "filename1", "content1", 1));
-//         sourceCodeRepository.save(new SourceCode(savedTemplate, "filename2", "content2", 2));
-//         savedTemplate.updateSourceCodes(List.of(savedFirstSourceCode));
-//         thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
+    private void saveTemplateByFilename(String templateTitle, String firstFilename, String secondFilename,
+            Member member, Category category
+    ) {
+        Template savedTemplate = templateRepository.save(new Template(member, templateTitle, "설명", category));
+        SourceCode savedFirstSourceCode = sourceCodeRepository.save(
+                new SourceCode(savedTemplate, firstFilename, "content1", 1));
+        SourceCode savedSecondSourceCode = sourceCodeRepository.save(
+                new SourceCode(savedTemplate, secondFilename, "content2", 2));
+        savedTemplate.updateSourceCodes(List.of(savedFirstSourceCode, savedSecondSourceCode));
+        thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
+    }
 
-//         return savedTemplate;
-//     }
+    private void saveTemplateBySourceCode(String templateTitle, String firstContent, String secondContent,
+            Member member, Category category
+    ) {
+        Template savedTemplate = templateRepository.save(new Template(member, templateTitle, "설명", category));
+        SourceCode savedFirstSourceCode = sourceCodeRepository.save(
+                new SourceCode(savedTemplate, "filename1", firstContent, 1));
+        SourceCode savedSecondSourceCode = sourceCodeRepository.save(
+                new SourceCode(savedTemplate, "filename2", secondContent, 2));
+        savedTemplate.updateSourceCodes(List.of(savedFirstSourceCode, savedSecondSourceCode));
+        thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
+    }
 
-//     private void saveTemplateByFilename(String templateTitle, String firstFilename, String secondFilename,
-//             Member member, Category category
-//     ) {
-//         Template savedTemplate = templateRepository.save(new Template(member, templateTitle, "설명", category));
-//         SourceCode savedFirstSourceCode = sourceCodeRepository.save(
-//                 new SourceCode(savedTemplate, firstFilename, "content1", 1));
-//         SourceCode savedSecondSourceCode = sourceCodeRepository.save(
-//                 new SourceCode(savedTemplate, secondFilename, "content2", 2));
-//         savedTemplate.updateSourceCodes(List.of(savedFirstSourceCode, savedSecondSourceCode));
-//         thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
-//     }
+    @Nested
+    @DisplayName("템플릿 토픽 검색")
+    class searchContainKeyword {
+        @Test
+        @DisplayName("템플릿 토픽 검색 성공 : 템플릿 제목에 포함")
+        void findAllTemplatesTitleContainKeywordSuccess() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category = categoryRepository.save(new Category("category", member));
+            saveTemplate(makeTemplateRequest("hello"), member, category);
+            saveTemplate(makeTemplateRequest("hello keyword"), member, category);
+            saveTemplate(makeTemplateRequest("keyword hello"), member, category);
+            saveTemplate(makeTemplateRequest("hello keyword !"), member, category);
 
-//     private void saveTemplateBySourceCode(String templateTitle, String firstContent, String secondContent,
-//             Member member, Category category
-//     ) {
-//         Template savedTemplate = templateRepository.save(new Template(member, templateTitle, "설명", category));
-//         SourceCode savedFirstSourceCode = sourceCodeRepository.save(
-//                 new SourceCode(savedTemplate, "filename1", firstContent, 1));
-//         SourceCode savedSecondSourceCode = sourceCodeRepository.save(
-//                 new SourceCode(savedTemplate, "filename2", secondContent, 2));
-//         savedTemplate.updateSourceCodes(List.of(savedFirstSourceCode, savedSecondSourceCode));
-//         thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
-//     }
+            //when
+            FindAllTemplatesResponse templates = templateService.findAllBy(
+                    member.getId(), "keyword", null, null, PageRequest.of(1, 3)
+            );
 
-//     @Nested
-//     @DisplayName("템플릿 토픽 검색")
-//     class searchContainKeyword {
-//         @Test
-//         @DisplayName("템플릿 토픽 검색 성공 : 템플릿 제목에 포함")
-//         void findAllTemplatesTitleContainKeywordSuccess() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category = categoryRepository.save(new Category("category", member));
-//             saveTemplate(makeTemplateRequest("hello"), member, category);
-//             saveTemplate(makeTemplateRequest("hello keyword"), member, category);
-//             saveTemplate(makeTemplateRequest("keyword hello"), member, category);
-//             saveTemplate(makeTemplateRequest("hello keyword !"), member, category);
+            //then
+            assertThat(templates.templates()).hasSize(3);
+        }
 
-//             //when
-//             FindAllTemplatesResponse templates = templateService.findAllBy(
-//                     member.getId(), "keyword", null, null, PageRequest.of(1, 3)
-//             );
+        @Test
+        @DisplayName("템플릿 토픽 검색 성공 : 탬플릿 내에 파일명 중 하나라도 포함")
+        void findAllFilenameContainKeywordSuccess() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category = categoryRepository.save(new Category("category", member));
+            saveTemplateByFilename("tempate1", "login.js", "signup.js", member, category);
+            saveTemplateByFilename("tempate2", "login.java", "signup.java", member, category);
+            saveTemplateByFilename("tempate3", "login.js", "signup.java", member, category);
 
-//             //then
-//             assertThat(templates.templates()).hasSize(3);
-//         }
+            //when
+            FindAllTemplatesResponse templates = templateService.findAllBy(
+                    member.getId(), "java", null, null, PageRequest.of(1, 3)
+            );
 
-//         @Test
-//         @DisplayName("템플릿 토픽 검색 성공 : 탬플릿 내에 파일명 중 하나라도 포함")
-//         void findAllFilenameContainKeywordSuccess() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category = categoryRepository.save(new Category("category", member));
-//             saveTemplateByFilename("tempate1", "login.js", "signup.js", member, category);
-//             saveTemplateByFilename("tempate2", "login.java", "signup.java", member, category);
-//             saveTemplateByFilename("tempate3", "login.js", "signup.java", member, category);
+            //then
+            assertThat(templates.templates()).hasSize(2);
+        }
 
-//             //when
-//             FindAllTemplatesResponse templates = templateService.findAllBy(
-//                     member.getId(), "java", null, null, PageRequest.of(1, 3)
-//             );
+        @Test
+        @DisplayName("템플릿 토픽 검색 성공 : 탬플릿 내에 소스 코드 중 하나라도 포함")
+        void findAllSourceCodeContainKeywordSuccess() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category = categoryRepository.save(new Category("category", member));
+            saveTemplateBySourceCode("tempate1", "public Main {", "new Car();", member, category);
+            saveTemplateBySourceCode("tempate2", "private Car", "public Movement", member, category);
+            saveTemplateBySourceCode("tempate3", "console.log", "a+b=3", member, category);
 
-//             //then
-//             assertThat(templates.templates()).hasSize(2);
-//         }
+            //when
+            FindAllTemplatesResponse templates = templateService.findAllBy(
+                    member.getId(), "Car", null, null, PageRequest.of(1, 3)
+            );
 
-//         @Test
-//         @DisplayName("템플릿 토픽 검색 성공 : 탬플릿 내에 소스 코드 중 하나라도 포함")
-//         void findAllSourceCodeContainKeywordSuccess() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category = categoryRepository.save(new Category("category", member));
-//             saveTemplateBySourceCode("tempate1", "public Main {", "new Car();", member, category);
-//             saveTemplateBySourceCode("tempate2", "private Car", "public Movement", member, category);
-//             saveTemplateBySourceCode("tempate3", "console.log", "a+b=3", member, category);
+            //then
+            assertThat(templates.templates()).hasSize(2);
+        }
 
-//             //when
-//             FindAllTemplatesResponse templates = templateService.findAllBy(
-//                     member.getId(), "Car", null, null, PageRequest.of(1, 3)
-//             );
+        @Test
+        @DisplayName("템플릿 토픽 검색 성공 : 탬플릿 설명에 포함")
+        void findAllDescriptionContainKeywordSuccess() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category = categoryRepository.save(new Category("category", member));
+            CreateTemplateRequest request1 = new CreateTemplateRequest("타이틀", "Login 구현",
+                    List.of(new CreateSourceCodeRequest("filename1", "content1", 1),
+                            new CreateSourceCodeRequest("filename2", "content2", 2)),
+                    1,
+                    category.getId(),
+                    List.of("tag1", "tag2"));
+            saveTemplate(request1, member, category);
+            CreateTemplateRequest request2 = new CreateTemplateRequest("타이틀", "Signup 구현",
+                    List.of(new CreateSourceCodeRequest("filename1", "content1", 1),
+                            new CreateSourceCodeRequest("filename2", "content2", 2)),
+                    1,
+                    category.getId(),
+                    List.of("tag1", "tag2"));
+            saveTemplate(request2, member, category);
 
-//             //then
-//             assertThat(templates.templates()).hasSize(2);
-//         }
+            //when
+            FindAllTemplatesResponse templates = templateService.findAllBy(
+                    member.getId(), "Login", null, null, PageRequest.of(1, 3)
+            );
 
-//         @Test
-//         @DisplayName("템플릿 토픽 검색 성공 : 탬플릿 설명에 포함")
-//         void findAllDescriptionContainKeywordSuccess() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category = categoryRepository.save(new Category("category", member));
-//             CreateTemplateRequest request1 = new CreateTemplateRequest("타이틀", "Login 구현",
-//                     List.of(new CreateSourceCodeRequest("filename1", "content1", 1),
-//                             new CreateSourceCodeRequest("filename2", "content2", 2)),
-//                     1,
-//                     category.getId(),
-//                     List.of("tag1", "tag2"));
-//             saveTemplate(request1, member, category);
-//             CreateTemplateRequest request2 = new CreateTemplateRequest("타이틀", "Signup 구현",
-//                     List.of(new CreateSourceCodeRequest("filename1", "content1", 1),
-//                             new CreateSourceCodeRequest("filename2", "content2", 2)),
-//                     1,
-//                     category.getId(),
-//                     List.of("tag1", "tag2"));
-//             saveTemplate(request2, member, category);
+            //then
+            assertThat(templates.templates()).hasSize(1);
+        }
 
-//             //when
-//             FindAllTemplatesResponse templates = templateService.findAllBy(
-//                     member.getId(), "Login", null, null, PageRequest.of(1, 3)
-//             );
+        @Test
+        @DisplayName("전체 탐색 / 1페이지 성공")
+        void findAllFirstPageSuccess() {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category1 = categoryRepository.save(new Category("category1", member));
+            Category category2 = categoryRepository.save(new Category("category2", member));
+            saveDefault15Templates(member, category1);
+            saveDefault15Templates(member, category2);
+            FindAllTemplatesResponse allBy = templateService.findAllBy(
+                    member.getId(), "", null, null, PageRequest.of(1, 20)
+            );
 
-//             //then
-//             assertThat(templates.templates()).hasSize(1);
-//         }
+            assertAll(() -> assertThat(allBy.templates()).hasSize(20),
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20),
+                    () -> assertThat(allBy.totalElements()).isEqualTo(30));
+        }
 
-//         @Test
-//         @DisplayName("전체 탐색 / 1페이지 성공")
-//         void findAllFirstPageSuccess() {
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category1 = categoryRepository.save(new Category("category1", member));
-//             Category category2 = categoryRepository.save(new Category("category2", member));
-//             saveDefault15Templates(member, category1);
-//             saveDefault15Templates(member, category2);
-//             FindAllTemplatesResponse allBy = templateService.findAllBy(
-//                     member.getId(), "", null, null, PageRequest.of(1, 20)
-//             );
+        @Test
+        @DisplayName("템플릿 토픽 검색 성공 : 페이징 성공")
+        void findAllContainKeywordPaging() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category = categoryRepository.save(new Category("category", member));
+            saveDefault15Templates(member, category);
 
-//             assertAll(() -> assertThat(allBy.templates()).hasSize(20),
-//                     () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20),
-//                     () -> assertThat(allBy.totalElements()).isEqualTo(30));
-//         }
+            //when
+            FindAllTemplatesResponse templates = templateService.findAllBy(
+                    member.getId(), "keyword", null, null, PageRequest.of(2, 5)
+            );
 
-//         @Test
-//         @DisplayName("템플릿 토픽 검색 성공 : 페이징 성공")
-//         void findAllContainKeywordPaging() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category = categoryRepository.save(new Category("category", member));
-//             saveDefault15Templates(member, category);
+            //then
+            List<String> titles = templates.templates().stream().map(ItemResponse::title).toList();
+            assertThat(titles).containsExactly("hello keyword 6", "hello keyword 7", "hello keyword 8",
+                    "hello keyword 9",
+                    "hello keyword 10");
+        }
+    }
 
-//             //when
-//             FindAllTemplatesResponse templates = templateService.findAllBy(
-//                     member.getId(), "keyword", null, null, PageRequest.of(2, 5)
-//             );
+    @Nested
+    @DisplayName("조건에 따른 페이지 조회 메서드 동작 확인")
+    class FilteringPageTest {
 
-//             //then
-//             List<String> titles = templates.templates().stream().map(ItemResponse::title).toList();
-//             assertThat(titles).containsExactly("hello keyword 6", "hello keyword 7", "hello keyword 8",
-//                     "hello keyword 9",
-//                     "hello keyword 10");
-//         }
-//     }
+        private static final PageRequest DEFAULT_PAGING_REQUEST = PageRequest.of(1, 20);
 
-//     @Nested
-//     @DisplayName("조건에 따른 페이지 조회 메서드 동작 확인")
-//     class FilteringPageTest {
+        @Test
+        @DisplayName("전체 탐색 / 1페이지 성공")
+        void findAllFirstPageSuccess() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category1 = categoryRepository.save(new Category("category1", member));
+            Category category2 = categoryRepository.save(new Category("category2", member));
+            saveDefault15Templates(member, category1);
+            saveDefault15Templates(member, category2);
 
-//         private static final PageRequest DEFAULT_PAGING_REQUEST = PageRequest.of(1, 20);
+            FindAllTemplatesResponse allBy = templateService.findAllBy(
+                    member.getId(), "", null, null, PageRequest.of(1, 20)
+            );
 
-//         @Test
-//         @DisplayName("전체 탐색 / 1페이지 성공")
-//         void findAllFirstPageSuccess() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category1 = categoryRepository.save(new Category("category1", member));
-//             Category category2 = categoryRepository.save(new Category("category2", member));
-//             saveDefault15Templates(member, category1);
-//             saveDefault15Templates(member, category2);
+            //when & then
+            assertAll(() -> assertThat(allBy.templates()).hasSize(20),
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20),
+                    () -> assertThat(allBy.totalElements()).isEqualTo(30));
+        }
 
-//             FindAllTemplatesResponse allBy = templateService.findAllBy(
-//                     member.getId(), "", null, null, PageRequest.of(1, 20)
-//             );
+        @Test
+        @DisplayName("전체 탐색 / 2페이지 성공")
+        void findAllSecondPageSuccess() {
+            //given
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category1 = categoryRepository.save(new Category("category1", member));
+            Category category2 = categoryRepository.save(new Category("category2", member));
+            saveDefault15Templates(member, category1);
+            saveDefault15Templates(member, category2);
 
-//             //when & then
-//             assertAll(() -> assertThat(allBy.templates()).hasSize(20),
-//                     () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 20),
-//                     () -> assertThat(allBy.totalElements()).isEqualTo(30));
-//         }
+            FindAllTemplatesResponse allBy = templateService.findAllBy(
+                    member.getId(), "", null, null, PageRequest.of(2, 20)
+            );
 
-//         @Test
-//         @DisplayName("전체 탐색 / 2페이지 성공")
-//         void findAllSecondPageSuccess() {
-//             //given
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category1 = categoryRepository.save(new Category("category1", member));
-//             Category category2 = categoryRepository.save(new Category("category2", member));
-//             saveDefault15Templates(member, category1);
-//             saveDefault15Templates(member, category2);
+            assertAll(() -> assertThat(allBy.templates()).hasSize(10),
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() > 20),
+                    () -> assertThat(allBy.totalElements()).isEqualTo(30));
+        }
 
-//             FindAllTemplatesResponse allBy = templateService.findAllBy(
-//                     member.getId(), "", null, null, PageRequest.of(2, 20)
-//             );
+        @Test
+        @DisplayName("카테고리 탐색 성공")
+        void findByCategoryPageSuccess() {
+            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+            Member member = memberRepository.fetchById(memberDto.id());
+            Category category1 = categoryRepository.save(new Category("category1", member));
+            Category category2 = categoryRepository.save(new Category("category2", member));
+            saveDefault15Templates(member, category1);
+            saveDefault15Templates(member, category2);
 
-//             assertAll(() -> assertThat(allBy.templates()).hasSize(10),
-//                     () -> assertThat(allBy.templates()).allMatch(template -> template.id() > 20),
-//                     () -> assertThat(allBy.totalElements()).isEqualTo(30));
-//         }
+            FindAllTemplatesResponse allBy = templateService.findAllBy(
+                    member.getId(), "", category1.getId(), null, PageRequest.of(1, 20)
+            );
 
-//         @Test
-//         @DisplayName("카테고리 탐색 성공")
-//         void findByCategoryPageSuccess() {
-//             MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//             Member member = memberRepository.fetchById(memberDto.id());
-//             Category category1 = categoryRepository.save(new Category("category1", member));
-//             Category category2 = categoryRepository.save(new Category("category2", member));
-//             saveDefault15Templates(member, category1);
-//             saveDefault15Templates(member, category2);
+            assertAll(() -> assertThat(allBy.templates()).hasSize(15),
+                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 15),
+                    () -> assertThat(allBy.totalElements()).isEqualTo(15));
+        }
 
-//             FindAllTemplatesResponse allBy = templateService.findAllBy(
-//                     member.getId(), "", category1.getId(), null, PageRequest.of(1, 20)
-//             );
-
-//             assertAll(() -> assertThat(allBy.templates()).hasSize(15),
-//                     () -> assertThat(allBy.templates()).allMatch(template -> template.id() <= 15),
-//                     () -> assertThat(allBy.totalElements()).isEqualTo(15));
-//         }
-
-// //        @Test
-// //        @DisplayName("단일 태그 탐색 성공")
-// //        void findBySingleTagPageSuccess() {
-// //            Member member = memberRepository.fetchById(1L);
-// //            Category category1 = categoryRepository.save(new Category("category1", member));
-// //            tagRepository.save(new Tag("tag1"));
-// //            tagRepository.save(new Tag("tag2"));
-// //            saveDefault15Templates(member, category1);
-// //            saveDefault15Templates(member, category1);
-// //            for (long i = 1L; i <= 30L; i++) {
-// //                templateTagRepository.save(
-// //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) + 1)));
-// //            }
-// //            FindAllTemplatesResponse allBy = templateService.findAllBy(
-// //                    member.getId(), "", null, List.of(1L), DEFAULT_PAGING_REQUEST
-// //            );
-// //
-// //            assertAll(() -> assertThat(allBy.templates()).hasSize(15),
-// //                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 0), // 태그
-// //                    () -> assertThat(allBy.totalElements()).isEqualTo(15));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("복수 태그 탐색 성공")
-// //        void findByMultipleTagPageSuccess() {
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            Member member = memberRepository.fetchById(memberDto.id());
-// //            Category category1 = categoryRepository.save(new Category("category1", member));
-// //            Category category2 = categoryRepository.save(new Category("category2", member));
-// //            tagRepository.save(new Tag("tag1"));
-// //            tagRepository.save(new Tag("tag2"));
-// //            tagRepository.save(new Tag("tag3"));
-// //            saveDefault15Templates(member, category1);
-// //            saveDefault15Templates(member, category2);
-// //            for (long i = 1L; i <= 30L; i++) {
-// //                templateTagRepository.save(
-// //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) + 1)));
-// //            }
-// //
-// //            for (long i = 1L; i <= 30L; i++) {
-// //                templateTagRepository.save(
-// //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById(3L)));
-// //            }
-// //
-// //            FindAllTemplatesResponse allBy = templateService.findAllBy(
-// //                    member.getId(), "", null, List.of(1L, 3L), DEFAULT_PAGING_REQUEST
-// //            );
-// //
-// //            assertAll(() -> assertThat(allBy.templates()).hasSize(15),
-// //                    () -> assertThat(allBy.totalElements()).isEqualTo(15));
-// //        }
-// //
-// //        @Test
-// //        @DisplayName("카테고리 & 단일 태그 탐색 성공")
-// //        void findByCategoryAndSingleTagPageSuccess() {
-// //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-// //            Member member = memberRepository.fetchById(memberDto.id());
-// //            Category category1 = categoryRepository.save(new Category("category1", member));
-// //            Category category2 = categoryRepository.save(new Category("category2", member));
-// //            saveDefault15Templates(member, category1);
-// //            saveDefault15Templates(member, category2);
-// //            tagRepository.save(new Tag("tag1"));
-// //            tagRepository.save(new Tag("tag2"));
-// //            for (long i = 1L; i <= 30L; i++) {
-// //                templateTagRepository.save(
-// //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) + 1)));
-// //            }
-// //            FindAllTemplatesResponse allBy = templateService.findAllBy(
-// //                    member.getId(), "", category1.getId(), List.of(1L), DEFAULT_PAGING_REQUEST
-// //            );
-// //
-// //            assertAll(() -> assertThat(allBy.templates()).hasSize(7),
-// //                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16),
-// //                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 0),
-// //                    () -> assertThat(allBy.totalElements()).isEqualTo(7));
-// //        }
-//     }
-// }
+        //        @Test
+        //        @DisplayName("단일 태그 탐색 성공")
+        //        void findBySingleTagPageSuccess() {
+        //            Member member = memberRepository.fetchById(1L);
+        //            Category category1 = categoryRepository.save(new Category("category1", member));
+        //            tagRepository.save(new Tag("tag1"));
+        //            tagRepository.save(new Tag("tag2"));
+        //            saveDefault15Templates(member, category1);
+        //            saveDefault15Templates(member, category1);
+        //            for (long i = 1L; i <= 30L; i++) {
+        //                templateTagRepository.save(
+        //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) +
+        //                        1)));
+        //            }
+        //            FindAllTemplatesResponse allBy = templateService.findAllBy(
+        //                    member.getId(), "", null, List.of(1L), DEFAULT_PAGING_REQUEST
+        //            );
+        //
+        //            assertAll(() -> assertThat(allBy.templates()).hasSize(15),
+        //                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 0), // 태그
+        //                    () -> assertThat(allBy.totalElements()).isEqualTo(15));
+        //        }
+        //
+        //        @Test
+        //        @DisplayName("복수 태그 탐색 성공")
+        //        void findByMultipleTagPageSuccess() {
+        //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        //            Member member = memberRepository.fetchById(memberDto.id());
+        //            Category category1 = categoryRepository.save(new Category("category1", member));
+        //            Category category2 = categoryRepository.save(new Category("category2", member));
+        //            tagRepository.save(new Tag("tag1"));
+        //            tagRepository.save(new Tag("tag2"));
+        //            tagRepository.save(new Tag("tag3"));
+        //            saveDefault15Templates(member, category1);
+        //            saveDefault15Templates(member, category2);
+        //            for (long i = 1L; i <= 30L; i++) {
+        //                templateTagRepository.save(
+        //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) +
+        //                        1)));
+        //            }
+        //
+        //            for (long i = 1L; i <= 30L; i++) {
+        //                templateTagRepository.save(
+        //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById(3L)));
+        //            }
+        //
+        //            FindAllTemplatesResponse allBy = templateService.findAllBy(
+        //                    member.getId(), "", null, List.of(1L, 3L), DEFAULT_PAGING_REQUEST
+        //            );
+        //
+        //            assertAll(() -> assertThat(allBy.templates()).hasSize(15),
+        //                    () -> assertThat(allBy.totalElements()).isEqualTo(15));
+        //        }
+        //
+        //        @Test
+        //        @DisplayName("카테고리 & 단일 태그 탐색 성공")
+        //        void findByCategoryAndSingleTagPageSuccess() {
+        //            MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
+        //            Member member = memberRepository.fetchById(memberDto.id());
+        //            Category category1 = categoryRepository.save(new Category("category1", member));
+        //            Category category2 = categoryRepository.save(new Category("category2", member));
+        //            saveDefault15Templates(member, category1);
+        //            saveDefault15Templates(member, category2);
+        //            tagRepository.save(new Tag("tag1"));
+        //            tagRepository.save(new Tag("tag2"));
+        //            for (long i = 1L; i <= 30L; i++) {
+        //                templateTagRepository.save(
+        //                        new TemplateTag(templateRepository.fetchById(i), tagRepository.fetchById((i % 2) +
+        //                        1)));
+        //            }
+        //            FindAllTemplatesResponse allBy = templateService.findAllBy(
+        //                    member.getId(), "", category1.getId(), List.of(1L), DEFAULT_PAGING_REQUEST
+        //            );
+        //
+        //            assertAll(() -> assertThat(allBy.templates()).hasSize(7),
+        //                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() < 16),
+        //                    () -> assertThat(allBy.templates()).allMatch(template -> template.id() % 2 == 0),
+        //                    () -> assertThat(allBy.totalElements()).isEqualTo(7));
+        //        }
+    }
+}

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -45,11 +45,6 @@ import codezap.template.repository.ThumbnailRepository;
 
 class TemplateServiceTest {
 
-    private Member firstMember = new Member(1L, "name1", "password1234");
-    private Member secondMember = new Member(2L, "name2", "password1234");
-    private Category firstCategory = new Category(1L, firstMember, "카테고리 없음", true);
-    private Category secondCategory = new Category(2L, secondMember, "카테고리 없음", true);
-
     private final TemplateRepository templateRepository = new FakeTemplateRepository();
     private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
     private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -1,7 +1,6 @@
 package codezap.template.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
@@ -144,8 +143,7 @@ class TemplateServiceTest {
 
         // then
         Long templateId = template.getId();
-        assertThatThrownBy(() -> templateService.findByIdAndMember(otherMemberDto, templateId));
-        assertThatCode(() -> templateService.findByIdAndMember(otherMemberDto, template.getId()))
+        assertThatThrownBy(() -> templateService.findByIdAndMember(otherMemberDto, templateId))
                 .isInstanceOf(CodeZapException.class)
                 .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
     }


### PR DESCRIPTION
## 📍주요 변경사항
- 충돌한 테스트 코드 해결
- equals & hashcode 재정의
  - @EqualsAndHashCode 사용 시 프록시 객체 비교 안 됨
  - 재정의 방법
     - getClass() vs instanceOf 사용 -> getClass() 사용 (intanceOf는 상속한 객체 비교도 true 라서 안됨)
     - getter로 id 가져오기 (프록시 객체일 경우 값이 없을 수 있기 때문에 getter를 이용해 실제 값 가져오기)