### PR TITLE
HTTP 요청과 응답의 Thread UUID가 출력되지 않는 버그 해결

### DIFF
--- a/backend/src/main/java/codezap/global/logger/MDCFilter.java
+++ b/backend/src/main/java/codezap/global/logger/MDCFilter.java
@@ -10,13 +10,16 @@ import jakarta.servlet.ServletRequest;
 import jakarta.servlet.ServletResponse;
 
 import org.slf4j.MDC;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@Order(1)
 public class MDCFilter implements Filter {
+
     private final String CORRELATION_ID = "correlationId";
 
     @Override

--- a/backend/src/main/java/codezap/global/logger/RequestResponseLogger.java
+++ b/backend/src/main/java/codezap/global/logger/RequestResponseLogger.java
@@ -9,6 +9,7 @@ import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 import org.springframework.web.util.ContentCachingRequestWrapper;
@@ -18,6 +19,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @Component
+@Order(2)
 public class RequestResponseLogger extends OncePerRequestFilter {
 
     @Override

--- a/backend/src/main/resources/logger/file/error-appender.xml
+++ b/backend/src/main/resources/logger/file/error-appender.xml
@@ -3,7 +3,7 @@
 <included>
     <appender name="error-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/error/error.log</file>
+        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/error.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>

--- a/backend/src/main/resources/logger/file/info-appender.xml
+++ b/backend/src/main/resources/logger/file/info-appender.xml
@@ -3,7 +3,7 @@
 <included>
     <appender name="info-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/info/info.log</file>
+        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/info.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>

--- a/backend/src/main/resources/logger/file/warn-appender.xml
+++ b/backend/src/main/resources/logger/file/warn-appender.xml
@@ -3,7 +3,7 @@
 <included>
     <appender name="warn-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/warn/warn.log</file>
+        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/warn.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #420 

- Spring Filter의 순서 설정에 관련된 문제이므로 개발서버뿐 아니라 운영서버에도 적용되는 내용입니다. 

## 📍주요 변경 사항
1. 로그에 `correlationId`를 부여하는 MDC 필터의 순서를 1로 설정합니다. 
2. HTTP 요청과 응답 로그를 출력하는 `RequestResponseLogger`의 순서를 2로 설정합니다. 

## 🎸기타
- 추후 Filter 작업 시 순서를 고려해야 합니다. 

## 참고 문서

[요청, 응답 로그에 correlationId 를 추가하자!](https://github.com/woowacourse-teams/2024-code-zap/wiki/%EC%9A%94%EC%B2%AD%2C-%EC%9D%91%EB%8B%B5-%EB%A1%9C%EA%B7%B8%EC%97%90-correlationId-%EB%A5%BC-%EC%B6%94%EA%B0%80%ED%95%98%EC%9E%90%21)
