### PR TITLE
테스트 시 DB 격리 및 레포지토리 테스트를 위한 베이스 어노테이션 생성

### DIFF
--- a/backend/src/test/java/codezap/global/DatabaseCleaner.java
+++ b/backend/src/test/java/codezap/global/DatabaseCleaner.java
@@ -1,0 +1,32 @@
+package codezap.global;
+
+import java.util.List;
+
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestContext;
+import org.springframework.test.context.support.AbstractTestExecutionListener;
+
+public class DatabaseCleaner extends AbstractTestExecutionListener {
+
+    @Override
+    public void beforeTestMethod(TestContext testContext) {
+        JdbcTemplate jdbcTemplate = testContext.getApplicationContext().getBean(JdbcTemplate.class);
+        List<String> queries = getTruncateQueries(jdbcTemplate);
+        truncate(queries, jdbcTemplate);
+    }
+
+    private List<String> getTruncateQueries(final JdbcTemplate jdbcTemplate) {
+        return jdbcTemplate.queryForList(
+                "SELECT CONCAT('TRUNCATE TABLE ', TABLE_NAME, ';') " +
+                        "FROM INFORMATION_SCHEMA.TABLES " +
+                        "WHERE TABLE_SCHEMA = DATABASE();",
+                String.class
+        );
+    }
+
+    private void truncate(List<String> queries, JdbcTemplate jdbcTemplate) {
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0;");
+        queries.forEach(jdbcTemplate::execute);
+        jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1;");
+    }
+}

--- a/backend/src/test/java/codezap/global/DatabaseIsolation.java
+++ b/backend/src/test/java/codezap/global/DatabaseIsolation.java
@@ -1,0 +1,11 @@
+package codezap.global;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import org.springframework.test.context.TestExecutionListeners;
+
+@Retention(RetentionPolicy.RUNTIME)
+@TestExecutionListeners(value = DatabaseCleaner.class, mergeMode = TestExecutionListeners.MergeMode.MERGE_WITH_DEFAULTS)
+public @interface DatabaseIsolation {
+}

--- a/backend/src/test/java/codezap/global/repository/JpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/global/repository/JpaRepositoryTest.java
@@ -1,0 +1,23 @@
+package codezap.global.repository;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+import codezap.global.DatabaseIsolation;
+import codezap.global.auditing.JpaAuditingConfiguration;
+
+@Target({ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+@DataJpaTest
+@DatabaseIsolation
+@Import(JpaAuditingConfiguration.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+public @interface JpaRepositoryTest {
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #469

## 📍주요 변경 사항
1. 테스트 시 각 메서드 격리를 위한 DatabaseCleaner 클래스 생성
  - AbstractTestExecutionListener의 beforeTestMethod를 재정의히여 매 테스트 메소드 실행 전 데이터베이스를 클린업하는 로직이 수행되도록 함
  - 클린업하는 로직
    - 모든 테이블을 비우고 외래 키 제약 조건을 일시적으로 비활성화하여 **TRUNCATE 작업 수행**합니당
2. `@DatabaseIsolation` 생성
  - 1번에서 만든 DatabaseCleaner를 테스트 실행 리스너로 추가하고, 기존 리스너들과 병합
  - 쉽게 말해 `@DatabaseIsolation` 어노테이션을 부착하게 되면 매 테스트 시 DatabaseCleaner가 동작합니다.
3. DataJpaTest에서 공통적으로 사용될 어노테이션들을 묶은 베이스 어노테이션 `@JpaRepositoryTest` 생성
  - @DataJpaTest, @DatabaseIsolation 등 레포지토리 단위 테스트 시 필요한 여러 어노테이션을 조합
  - JPA Auditing 기능 사용을 위한 JPA Auditing 설정 파일 import

## 🎸기타
1. 테스트 시 데이터베이스 격리를 위해 여러 방법 중 AbstractTestExecutionListener 재정의를 선택한 이유는 아래 블로그 글을 참고하시면 좋을 것 같습니다
  - [TestExecutionListener을 활용한 테스트 격리](https://velog.io/@appti/TestExecutionListener%EC%9D%84-%ED%99%9C%EC%9A%A9%ED%95%9C-%ED%85%8C%EC%8A%A4%ED%8A%B8-%EA%B2%A9%EB%A6%AC)에 다른 방법들의 문제점 참고

앞으로 매 레포지토리 테스트 시 해당 어노테이션을 사용하면 편하실 듯~