### PR TITLE
템플릿 조회에서 동적 쿼리 생성을 위한 Specification 구현

### DIFF
--- a/backend/src/main/java/codezap/template/repository/TemplateJpaRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateJpaRepository.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
@@ -13,7 +15,8 @@ import codezap.global.exception.CodeZapException;
 import codezap.template.domain.Template;
 
 @SuppressWarnings("unused")
-public interface TemplateJpaRepository extends TemplateRepository, JpaRepository<Template, Long> {
+public interface TemplateJpaRepository extends TemplateRepository, JpaRepository<Template, Long>,
+        JpaSpecificationExecutor<Template> {
 
     default Template fetchById(Long id) {
         return findById(id).orElseThrow(
@@ -21,6 +24,8 @@ public interface TemplateJpaRepository extends TemplateRepository, JpaRepository
     }
 
     List<Template> findByMemberId(Long id);
+
+    Page<Template> findAll(Specification<Template> specification, Pageable pageable);
 
     @Query("""
             SELECT DISTINCT t

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 
 import codezap.template.domain.Template;
 
@@ -14,6 +15,8 @@ public interface TemplateRepository {
     List<Template> findAll();
 
     List<Template> findByMemberId(Long id);
+
+    Page<Template> findAll(Specification<Template> specification, Pageable pageable);
 
     Page<Template> searchBy(Long memberId, String keyword, Pageable pageable);
 

--- a/backend/src/main/java/codezap/template/repository/TemplateSpecification.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateSpecification.java
@@ -1,0 +1,84 @@
+package codezap.template.repository;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import jakarta.persistence.criteria.Subquery;
+
+import org.springframework.data.jpa.domain.Specification;
+
+import codezap.template.domain.Template;
+import codezap.template.domain.TemplateTag;
+
+public class TemplateSpecification implements Specification<Template> {
+    private final Long memberId;
+    private final String keyword;
+    private final Long categoryId;
+    private final List<Long> tagIds;
+
+    private TemplateSpecification(Long memberId, String keyword, Long categoryId, List<Long> tagIds) {
+        this.memberId = memberId;
+        this.keyword = keyword;
+        this.categoryId = categoryId;
+        this.tagIds = tagIds;
+    }
+
+    public static Specification<Template> withDynamicQuery(
+            Long memberId, String keyword, Long categoryId, List<Long> tagIds
+    ) {
+        return new TemplateSpecification(memberId, keyword, categoryId, tagIds);
+    }
+
+    @Override
+    public Predicate toPredicate(Root<Template> root, CriteriaQuery<?> query, CriteriaBuilder criteriaBuilder) {
+        List<Predicate> predicates = new ArrayList<>();
+
+        addMemberPredicate(predicates, criteriaBuilder, root);
+        addCategoryPredicate(predicates, criteriaBuilder, root);
+        addTagPredicate(predicates, criteriaBuilder, root, query);
+        addKeywordPredicate(predicates, criteriaBuilder, root);
+
+        return criteriaBuilder.and(predicates.toArray(new Predicate[0]));
+    }
+
+    private void addMemberPredicate(List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<Template> root) {
+        if (memberId != null) {
+            predicates.add(criteriaBuilder.equal(root.get("member").get("id"), memberId));
+        }
+    }
+
+    private void addKeywordPredicate(List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<Template> root) {
+        if (keyword != null && !keyword.trim().isEmpty()) {
+            String likeKeyword = "%" + keyword.trim() + "%";
+            predicates.add(criteriaBuilder.or(criteriaBuilder.like(root.get("title"), likeKeyword),
+                    criteriaBuilder.like(root.get("description"), likeKeyword)));
+        }
+    }
+
+    private void addCategoryPredicate(List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<Template> root
+    ) {
+        if (categoryId != null) {
+            predicates.add(criteriaBuilder.equal(root.get("category").get("id"), categoryId));
+        }
+    }
+
+    private void addTagPredicate(
+            List<Predicate> predicates, CriteriaBuilder criteriaBuilder, Root<Template> root, CriteriaQuery<?> query
+    ) {
+        if (tagIds == null || tagIds.isEmpty()) {
+            return;
+        }
+        Subquery<Long> subquery = query.subquery(Long.class);
+        Root<TemplateTag> subRoot = subquery.from(TemplateTag.class);
+        subquery.select(subRoot.get("template").get("id")).where(subRoot.get("tag").get("id").in(tagIds))
+                .groupBy(subRoot.get("template").get("id"))
+                .having(criteriaBuilder.equal(criteriaBuilder.countDistinct(subRoot.get("tag").get("id")),
+                        tagIds.size()));
+
+        predicates.add(root.get("id").in(subquery));
+    }
+}

--- a/backend/src/test/java/codezap/template/repository/FakeTemplateRepository.java
+++ b/backend/src/test/java/codezap/template/repository/FakeTemplateRepository.java
@@ -9,6 +9,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specification;
 import org.springframework.http.HttpStatus;
 
 import codezap.global.exception.CodeZapException;
@@ -37,7 +38,6 @@ public class FakeTemplateRepository implements TemplateRepository {
         return templates.stream().anyMatch(template -> Objects.equals(template.getCategory().getId(), categoryId));
     }
 
-    @Override
     public Page<Template> searchBy(Long memberId, String keyword, Pageable pageable) {
         List<Template> searchedTemplates = templates.stream()
                 .filter(template -> Objects.equals(template.getMember().getId(), memberId))
@@ -47,7 +47,6 @@ public class FakeTemplateRepository implements TemplateRepository {
         return pageTemplates(pageable, searchedTemplates);
     }
 
-    @Override
     public Page<Template> searchBy(Long memberId, String keyword, List<Long> templateIds, Pageable pageable) {
         List<Template> searchedTemplates = templates.stream()
                 .filter(template -> Objects.equals(template.getMember().getId(), memberId))
@@ -58,7 +57,6 @@ public class FakeTemplateRepository implements TemplateRepository {
         return pageTemplates(pageable, searchedTemplates);
     }
 
-    @Override
     public Page<Template> searchBy(Long memberId, String keyword, Long categoryId, Pageable pageable) {
         List<Template> searchedTemplates = templates.stream()
                 .filter(template -> Objects.equals(template.getMember().getId(), memberId))
@@ -69,7 +67,6 @@ public class FakeTemplateRepository implements TemplateRepository {
         return pageTemplates(pageable, searchedTemplates);
     }
 
-    @Override
     public Page<Template> searchBy(Long memberId, String keyword, Long categoryId, List<Long> templateIds,
             Pageable pageable
     ) {
@@ -111,6 +108,11 @@ public class FakeTemplateRepository implements TemplateRepository {
         return templates.stream()
                 .filter(template -> Objects.equals(template.getMember().getId(), id))
                 .toList();
+    }
+
+    @Override
+    public Page<Template> findAll(Specification<Template> specification, Pageable pageable) {
+        return null;
     }
 
     @Override

--- a/backend/src/test/java/codezap/template/repository/TemplateRepositoryFindAllTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateRepositoryFindAllTest.java
@@ -1,0 +1,194 @@
+package codezap.template.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.global.repository.JpaRepositoryTest;
+import codezap.member.domain.Member;
+import codezap.member.repository.MemberRepository;
+import codezap.tag.domain.Tag;
+import codezap.tag.repository.TagRepository;
+import codezap.tag.repository.TemplateTagRepository;
+import codezap.template.domain.Template;
+import codezap.template.domain.TemplateTag;
+
+@JpaRepositoryTest
+class TemplateRepositoryFindAllTest {
+
+    @Autowired
+    private TemplateRepository templateRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private TemplateTagRepository templateTagRepository;
+
+    private Member member1, member2;
+    private Category category1, category2;
+    private Tag tag1, tag2;
+
+    @BeforeEach
+    void setUp() {
+        member1 = memberRepository.save(new Member("user1@test.com", "pp"));
+        member2 = memberRepository.save(new Member("user2@test.com", "pp"));
+
+        category1 = categoryRepository.save(new Category("Category 1", member1));
+        category2 = categoryRepository.save(new Category("Category 2", member1));
+
+        tag1 = tagRepository.save(new Tag("Tag 1"));
+        tag2 = tagRepository.save(new Tag("Tag 2"));
+
+        Template template1 = new Template(member1, "Template 1", "Description 1", category1);
+        TemplateTag templateTag11 = new TemplateTag(template1, tag1);
+        TemplateTag templateTag12 = new TemplateTag(template1, tag2);
+        templateRepository.save(template1);
+        templateTagRepository.save(templateTag11);
+        templateTagRepository.save(templateTag12);
+
+        Template template2 = new Template(member1, "Template 2", "Description 2", category2);
+        TemplateTag templateTag21 = new TemplateTag(template2, tag1);
+        TemplateTag templateTag22 = new TemplateTag(template2, tag2);
+        templateRepository.save(template2);
+        templateTagRepository.save(templateTag21);
+        templateTagRepository.save(templateTag22);
+
+        Template template3 = new Template(member2, "Another Template", "Another Description", category1);
+        TemplateTag templateTag31 = new TemplateTag(template3, tag2);
+        templateRepository.save(template3);
+        templateTagRepository.save(templateTag31);
+    }
+
+    @Test
+    @DisplayName("회원 ID로 템플릿 조회")
+    void testFindByMemberId() {
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(member1.getId(), null, null, null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).allMatch(template -> template.getMember().getId().equals(member1.getId()));
+    }
+
+    @Test
+    @DisplayName("키워드로 템플릿 조회")
+    void testFindByKeyword() {
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(null, "Template", null, null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent()).allMatch(template ->
+                template.getTitle().contains("Template") || template.getDescription().contains("Template"));
+    }
+
+    @Test
+    @DisplayName("카테고리 ID로 템플릿 조회")
+    void testFindByCategoryId() {
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(null, null, category1.getId(),
+                null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).allMatch(template -> template.getCategory().getId().equals(category1.getId()));
+    }
+
+    @Test
+    @DisplayName("태그 ID 목록으로 템플릿 조회: 모든 태그를 가진 템플릿만 조회")
+    void testFindByTagIds() {
+        List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
+
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(null, null, null, tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
+                templateRepository.fetchById(2L));
+    }
+
+    @Test
+    @DisplayName("단일 태그 ID로 템플릿 조회")
+    void testFindBySingleTagId() {
+        List<Long> tagIds = Arrays.asList(tag2.getId());
+
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(null, null, null, tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(3);
+        assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
+                templateRepository.fetchById(2L), templateRepository.fetchById(3L));
+    }
+
+    @Test
+    @DisplayName("회원 ID와 키워드로 템플릿 조회")
+    void testFindByMemberIdAndKeyword() {
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(member1.getId(), "Template", null,
+                null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).allMatch(template ->
+                template.getMember().getId().equals(member1.getId()) &&
+                        (template.getTitle().contains("Template") || template.getDescription().contains("Template"))
+        );
+    }
+
+    @Test
+    @DisplayName("회원 ID와 카테고리 ID로 템플릿 조회")
+    void testFindByMemberIdAndCategoryId() {
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(member1.getId(), null, category1.getId(),
+                null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent().get(0).getMember().getId()).isEqualTo(member1.getId());
+        assertThat(result.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId());
+    }
+
+    @Test
+    @DisplayName("회원 ID와 태그 ID 목록으로 템플릿 조회")
+    void testFindByMemberIdAndTagIds() {
+        List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(member1.getId(), null, null,
+                tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(2);
+        assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
+                templateRepository.fetchById(2L));
+    }
+
+    @Test
+    @DisplayName("모든 검색 기준으로 템플릿 조회")
+    void testFindWithAllCriteria() {
+        List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(member1.getId(), "Template",
+                category1.getId(), tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).hasSize(1);
+        assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L));
+    }
+
+    @Test
+    @DisplayName("검색 결과가 없는 경우 테스트")
+    void testFindWithNoResults() {
+        Specification<Template> spec = TemplateSpecification.withDynamicQuery(member1.getId(), "NonexistentKeyword",
+                null, null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #495

## 📍주요 변경 사항
- 동적 쿼리 생성을 위한 Specification 구현체 생성
- Specification 실행을 위해 TemplateJpaRepository가 JpaSpecificationExecutor를 상속받도록 변경
- Specification를 인자로 전달하는 템플릿 조회 쿼리 메서드 생성
- 동적 쿼리 적용 테스트 작성

## 🎸기타
- 기존 분기처리된 조회 쿼리문들을 대처하는 로직은 다음 pr에 올라갑니당
- FakeTemplateRepository에서 null 반환하는 이유
  - Specification을 어떻게 할 수가 없음...........아는 사람 알려주세요............ Fake 슬프다.........
> 문서화 나중에 해놓을게요 ㅠㅠㅠㅠㅠㅠ
일단은 [JPA의 동적 쿼리](https://tecoble.techcourse.co.kr/post/2022-10-11-jpa-dynamic-query/) 글 먼저 봐줘요.....

+) 코멘트에 설명 추가했습니다