### PR TITLE
페이지네이션 시에 페이지의 시작 인덱스를 1로 지정해주는 옵션 제거

### DIFF
--- a/backend/src/main/resources/application-local.yml
+++ b/backend/src/main/resources/application-local.yml
@@ -2,8 +2,3 @@ spring:
   output:
     ansi:
       enabled: always
-
-  data:
-    web:
-      pageable:
-        one-indexed-parameters: true


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #495

## 📍주요 변경 사항
1. 페이지네이션 시에 페이지의 시작 인덱스를 1로 지정해주는 옵션 문법이 틀려서 제거합니다.

## 🎸기타

인프라팀
🔥 application-db.yml에 아래 꼭 추가해주세요!!!!!!!! 🔥

```
spring:
  data.web.pageable.one-indexed-parameters: true
```

🔥 자기 로컬 application-db.yml에도 꼭 추가해주세요!!!!!!!! 🔥