### PR TITLE
카테고리 편집 메뉴 및 모달 리팩토링 (2차 UT 및 QA 반영)

### DIFF
--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
@@ -1,7 +1,7 @@
 import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
-import { theme } from '../../style/theme';
+import { theme } from '@/style/theme';
 
 export const EditCategoryItemList = styled.div`
   display: flex;

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
@@ -1,6 +1,6 @@
 import styled from '@emotion/styled';
 
-import { theme } from '@/style/theme';
+import { theme } from '../../style/theme';
 
 export const EditCategoryItemList = styled.div`
   display: flex;
@@ -9,19 +9,39 @@ export const EditCategoryItemList = styled.div`
   width: 100%;
 `;
 
-export const EditCategoryItem = styled.div<{ hasError?: boolean }>`
+export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: boolean }>`
   display: flex;
   gap: 1rem;
   align-items: center;
 
-  padding: 0.25rem 1rem;
+  height: 3rem;
+  padding: ${({ isButton }) => (isButton ? '0' : '0 1rem')};
 
-  border: ${({ hasError }) => (hasError ? '1px solid red' : 'none')};
+  border: ${({ hasError }) => (hasError ? `1px solid red` : 'none')};
   border-radius: 8px;
+  box-shadow: 1px 1px 4px #00000030;
 
-  &:hover {
-    outline: 1px solid ${theme.color.light.secondary_500};
-    outline-offset: -2px;
+  transition: all 0.1s ease-out;
+
+  &:hover,
+  &:focus-within {
+    transform: scale(1.015);
+    box-shadow: 1px 1px 2px 1px #00000040;
+  }
+
+  &:hover span {
+    color: ${theme.color.light.secondary_700};
+  }
+
+  &:hover button,
+  &:focus-within button {
+    visibility: visible;
+  }
+
+  &:focus-within div {
+    padding: 0;
+    font-weight: bold;
+    color: ${theme.color.light.secondary_700};
   }
 `;
 
@@ -37,6 +57,7 @@ export const IconButtonWrapper = styled.button`
 
   padding: 0;
 
+  visibility: hidden;
   opacity: 0.7;
   background: none;
   border: none;

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { theme } from '../../style/theme';
@@ -9,7 +10,7 @@ export const EditCategoryItemList = styled.div`
   width: 100%;
 `;
 
-export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: boolean }>`
+export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: boolean; disabled?: boolean }>`
   display: flex;
   gap: 1rem;
   align-items: center;
@@ -23,11 +24,24 @@ export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: bool
 
   transition: all 0.1s ease-out;
 
-  &:hover,
-  &:focus-within {
-    transform: scale(1.015);
-    box-shadow: 1px 1px 2px 1px #00000040;
-  }
+  ${({ disabled }) =>
+    !disabled &&
+    css`
+      &:hover,
+      &:focus-within {
+        transform: scale(1.015);
+        box-shadow: 1px 1px 2px 1px #00000040;
+      }
+    `}
+
+  ${({ disabled }) =>
+    disabled &&
+    css`
+      button {
+        cursor: default;
+        opacity: 0.7;
+      }
+    `}
 
   &:hover span {
     color: ${theme.color.light.secondary_700};

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.style.ts
@@ -18,8 +18,8 @@ export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: bool
   height: 3rem;
   padding: ${({ isButton }) => (isButton ? '0' : '0 1rem')};
 
-  border: ${({ hasError }) => (hasError ? `1px solid red` : 'none')};
   border-radius: 8px;
+  outline: ${({ hasError }) => (hasError ? `1px solid red` : 'none')};
   box-shadow: 1px 1px 4px #00000030;
 
   transition: all 0.1s ease-out;
@@ -33,6 +33,10 @@ export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: bool
         box-shadow: 1px 1px 2px 1px #00000040;
       }
     `}
+
+  &:focus-within {
+    outline: ${({ hasError }) => !hasError && `1px solid ${theme.color.light.secondary_900}`};
+  }
 
   ${({ disabled }) =>
     disabled &&
@@ -54,8 +58,6 @@ export const EditCategoryItem = styled.div<{ hasError?: boolean; isButton?: bool
 
   &:focus-within div {
     padding: 0;
-    font-weight: bold;
-    color: ${theme.color.light.secondary_700};
   }
 `;
 

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -1,12 +1,12 @@
 import { css } from '@emotion/react';
 import { useState } from 'react';
 
+import { PencilIcon, SpinArrowIcon, TrashcanIcon } from '@/assets/images';
 import { Text, Modal, Input, Flex, Button } from '@/components';
 import { useCategoryNameValidation } from '@/hooks/category';
 import { useCategoryDeleteMutation, useCategoryEditMutation, useCategoryUploadMutation } from '@/queries/category';
+import { theme } from '@/style/theme';
 import type { Category, CustomError } from '@/types';
-import { PencilIcon, SpinArrowIcon, TrashcanIcon } from '../../assets/images/index';
-import { theme } from '../../style/theme';
 import * as S from './CategoryEditModal.style';
 
 interface CategoryEditModalProps {

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -132,12 +132,12 @@ const CategoryEditModal = ({ isOpen, toggleModal, categories, handleCancelEdit }
             onNameInputChange={handleNameInputChange}
             onNameInputBlur={handleNameInputBlur}
           />
+          <S.EditCategoryItem isButton={true}>
+            <Button fullWidth variant='text' hoverStyle='none' onClick={handleAddCategory} disabled={!isValid}>
+              {'+ 카테고리 추가'}
+            </Button>
+          </S.EditCategoryItem>
         </S.EditCategoryItemList>
-        <S.EditCategoryItem>
-          <Button fullWidth variant='text' onClick={handleAddCategory} disabled={!isValid}>
-            {'+ 카테고리 추가'}
-          </Button>
-        </S.EditCategoryItem>
       </Modal.Body>
       <Modal.Footer>
         <Flex direction='column' gap='0.75rem' width='100%' style={{ alignSelf: 'flex-end' }}>
@@ -191,6 +191,7 @@ const CategoryItems = ({
     {categories.map(({ id, name }) => (
       <S.EditCategoryItem key={id} hasError={invalidIds.includes(id)}>
         {categoriesToDelete.includes(id) ? (
+          // 기존 : 삭제 상태
           <>
             <Flex align='center' width='100%' height='2.5rem'>
               <Text.Medium color={theme.color.light.analogous_primary_400} textDecoration='line-through'>
@@ -203,7 +204,8 @@ const CategoryItems = ({
           <>
             <Flex align='center' width='100%' height='2.5rem'>
               {editingCategoryId === id ? (
-                <Input size='large' variant='outlined' style={{ width: '100%', height: '38px' }}>
+                // 기존 : 수정 상태
+                <Input size='large' variant='text' style={{ width: '100%', height: '38px' }}>
                   <Input.TextField
                     type='text'
                     value={editedCategories[id] ?? name}
@@ -218,7 +220,8 @@ const CategoryItems = ({
                   />
                 </Input>
               ) : (
-                <Text.Medium color={theme.color.light.secondary_700}>
+                // 기존 : 기본 상태
+                <Text.Medium color={theme.color.light.secondary_500} weight='bold'>
                   {editedCategories[id] !== undefined ? editedCategories[id] : name}
                 </Text.Medium>
               )}
@@ -233,7 +236,8 @@ const CategoryItems = ({
       <S.EditCategoryItem key={id} hasError={invalidIds.includes(id)}>
         <Flex align='center' width='100%' height='2.5rem'>
           {editingCategoryId === id ? (
-            <Input size='large' variant='outlined' style={{ width: '100%', height: '38px' }}>
+            // 생성 : 수정 상태
+            <Input size='large' variant='text' style={{ width: '100%', height: '38px' }}>
               <Input.TextField
                 type='text'
                 value={name}
@@ -245,10 +249,12 @@ const CategoryItems = ({
                   }
                 }}
                 autoFocus
+                style={{ fontWeight: 'bolder' }}
               />
             </Input>
           ) : (
-            <Text.Medium color={theme.color.light.secondary_700}>{name}</Text.Medium>
+            // 생성 : 기본 상태
+            <Text.Medium color={theme.color.light.secondary_500}>{name}</Text.Medium>
           )}
         </Flex>
         <IconButtons edit delete onEditClick={() => onEditClick(id)} onDeleteClick={() => onDeleteClick(id)} />

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -205,7 +205,7 @@ const CategoryItems = ({
             <Flex align='center' width='100%' height='2.5rem'>
               {editingCategoryId === id ? (
                 // 기존 : 수정 상태
-                <Input size='large' variant='text' style={{ width: '100%', height: '38px' }}>
+                <Input size='large' variant='text' style={{ width: '100%', height: '2.375rem' }}>
                   <Input.TextField
                     type='text'
                     value={editedCategories[id] ?? name}
@@ -245,7 +245,7 @@ const CategoryItems = ({
         <Flex align='center' width='100%' height='2.5rem'>
           {editingCategoryId === id ? (
             // 생성 : 수정 상태
-            <Input size='large' variant='text' style={{ width: '100%', height: '38px' }}>
+            <Input size='large' variant='text' style={{ width: '100%', height: '2.375rem' }}>
               <Input.TextField
                 type='text'
                 value={name}

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -1,3 +1,4 @@
+import { css } from '@emotion/react';
 import { useState } from 'react';
 
 import { Text, Modal, Input, Flex, Button } from '@/components';
@@ -208,6 +209,7 @@ const CategoryItems = ({
                   <Input.TextField
                     type='text'
                     value={editedCategories[id] ?? name}
+                    placeholder='카테고리 입력'
                     onChange={(e) => onNameInputChange(id, e.target.value)}
                     onBlur={() => onNameInputBlur(id)}
                     onKeyDown={(e) => {
@@ -216,6 +218,13 @@ const CategoryItems = ({
                       }
                     }}
                     autoFocus
+                    css={css`
+                      font-weight: bold;
+                      &::placeholder {
+                        font-weight: normal;
+                        color: ${theme.color.light.secondary_400};
+                      }
+                    `}
                   />
                 </Input>
               ) : (
@@ -240,6 +249,7 @@ const CategoryItems = ({
               <Input.TextField
                 type='text'
                 value={name}
+                placeholder='카테고리 입력'
                 onChange={(e) => onNameInputChange(id, e.target.value)}
                 onBlur={() => onNameInputBlur(id)}
                 onKeyDown={(e) => {
@@ -248,12 +258,20 @@ const CategoryItems = ({
                   }
                 }}
                 autoFocus
-                style={{ fontWeight: 'bolder' }}
+                css={css`
+                  font-weight: bold;
+                  &::placeholder {
+                    font-weight: normal;
+                    color: ${theme.color.light.secondary_400};
+                  }
+                `}
               />
             </Input>
           ) : (
             // 생성 : 기본 상태
-            <Text.Medium color={theme.color.light.secondary_500}>{name}</Text.Medium>
+            <Text.Medium color={theme.color.light.secondary_500} weight='bold'>
+              {name}
+            </Text.Medium>
           )}
         </Flex>
         <IconButtons edit delete onEditClick={() => onEditClick(id)} onDeleteClick={() => onDeleteClick(id)} />

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -74,10 +74,9 @@ const CategoryEditModal = ({ isOpen, toggleModal, categories, handleCancelEdit }
   };
 
   const handleAddCategory = () => {
-    const newCategoryId = categories.length + newCategories.length;
-    const newCategoryName = `카테고리 ${newCategoryId + 1}`;
+    const newCategoryId = categories[categories.length - 1].id + newCategories.length + 1;
 
-    setNewCategories((prev) => [...prev, { id: newCategoryId, name: newCategoryName }]);
+    setNewCategories((prev) => [...prev, { id: newCategoryId, name: '' }]);
     setEditingCategoryId(newCategoryId);
   };
 

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -131,7 +131,7 @@ const CategoryEditModal = ({ isOpen, toggleModal, categories, handleCancelEdit }
             onNameInputChange={handleNameInputChange}
             onNameInputBlur={handleNameInputBlur}
           />
-          <S.EditCategoryItem isButton={true}>
+          <S.EditCategoryItem isButton={true} disabled={!isValid}>
             <Button fullWidth variant='text' hoverStyle='none' onClick={handleAddCategory} disabled={!isValid}>
               {'+ 카테고리 추가'}
             </Button>

--- a/frontend/src/components/CategoryFilterMenu/CategoryFilterMenu.tsx
+++ b/frontend/src/components/CategoryFilterMenu/CategoryFilterMenu.tsx
@@ -3,8 +3,8 @@ import { useMemo, useState } from 'react';
 import { SettingIcon } from '@/assets/images';
 import { Text, CategoryEditModal } from '@/components';
 import { useToggle } from '@/hooks/utils';
+import { theme } from '@/style/theme';
 import type { Category } from '@/types';
-import { theme } from '../../style/theme';
 import * as S from './CategoryFilterMenu.style';
 
 interface CategoryMenuProps {

--- a/frontend/src/components/Modal/Modal.style.ts
+++ b/frontend/src/components/Modal/Modal.style.ts
@@ -37,12 +37,13 @@ export const HeaderWrapper = styled.div`
   display: flex;
   flex-shrink: 0;
   align-items: center;
-  padding-bottom: 1rem;
+  padding: 1rem;
 `;
 
 export const BodyContainer = styled.div`
   overflow-y: auto;
   flex-grow: 1;
+  padding: 1rem;
   font-size: 1rem;
 `;
 
@@ -52,7 +53,7 @@ export const FooterContainer = styled.div`
   gap: 1rem;
   justify-content: space-between;
 
-  padding-top: 1rem;
+  padding: 1rem;
 `;
 
 export const ModalContainer = styled.div<{ size: ModalSize }>`
@@ -64,7 +65,7 @@ export const ModalContainer = styled.div<{ size: ModalSize }>`
   gap: 1rem;
 
   max-height: 90vh;
-  padding: 1.5rem;
+  padding: 1rem;
 
   background-color: white;
   border-radius: 24px;

--- a/frontend/src/hooks/category/useCategoryNameValidation.ts
+++ b/frontend/src/hooks/category/useCategoryNameValidation.ts
@@ -12,32 +12,46 @@ export const useCategoryNameValidation = (
   const [invalidIds, setInvalidIds] = useState<number[]>([]);
 
   useEffect(() => {
-    const allNames = new Set<string>();
+    const allNames = new Map<string, number[]>();
     const invalidNames = new Set<number>();
 
+    const addNameToMap = (id: number, name: string) => {
+      if (!allNames.has(name)) {
+        allNames.set(name, []);
+      }
+
+      allNames.get(name)!.push(id);
+    };
+
     categories.forEach(({ id, name }) => {
-      if (INVALID_NAMES.includes(name) || allNames.has(name)) {
+      if (INVALID_NAMES.includes(name)) {
         invalidNames.add(id);
       } else {
-        allNames.add(name);
+        addNameToMap(id, name);
       }
     });
 
     newCategories.forEach(({ id, name }) => {
-      if (INVALID_NAMES.includes(name) || allNames.has(name)) {
+      if (INVALID_NAMES.includes(name)) {
         invalidNames.add(id);
       } else {
-        allNames.add(name);
+        addNameToMap(id, name);
       }
     });
 
     Object.entries(editedCategories).forEach(([id, name]) => {
       const originalName = categories.find((category) => category.id === Number(id))?.name;
 
-      if (INVALID_NAMES.includes(name) || (name !== originalName && allNames.has(name))) {
+      if (INVALID_NAMES.includes(name)) {
         invalidNames.add(Number(id));
       } else if (name !== originalName) {
-        allNames.add(name);
+        addNameToMap(Number(id), name);
+      }
+    });
+
+    allNames.forEach((ids) => {
+      if (ids.length > 1) {
+        ids.forEach((id) => invalidNames.add(id));
       }
     });
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -161,7 +161,7 @@ const categoryHandlers = [
 
     return HttpResponse.json({ status: 400, message: 'Invalid category data' });
   }),
-  http.post(`${CATEGORY_API_URL}/:id`, async (req) => {
+  http.put(`${CATEGORY_API_URL}/:id`, async (req) => {
     const { id } = req.params;
     const updatedCategory = await req.request.json();
     const categoryIndex = mockCategoryList.categories.findIndex((cat) => cat.id.toString() === id);
@@ -181,7 +181,9 @@ const categoryHandlers = [
     if (categoryIndex !== -1) {
       mockCategoryList.categories.splice(categoryIndex, 1);
 
-      return HttpResponse.json({ status: 204 });
+      return new HttpResponse(null, {
+        status: 204,
+      });
     } else {
       return HttpResponse.json({ status: 404, message: 'Category not found' });
     }

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -64,7 +64,6 @@ const MyTemplatePage = () => {
   const { mutateAsync: deleteTemplates } = useTemplateDeleteMutation(selectedList);
 
   const handleCategoryMenuClick = useCallback((selectedCategoryId: number) => {
-    scroll.top();
     setSelectedCategoryId(selectedCategoryId);
     setPage(1);
   }, []);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #510

## 📍주요 변경 사항
- 🚀 메뉴 > 카테고리 버튼 클릭 시, 스크롤 이벤트 제거
- 🚀 모달 > 카테고리 아이템의 Hover/Error/Edit 상태 스타일링
- 🐛 모달 > 임시 카테고리 아이디 부여 방식 수정
- 🚀 모달 > 카테고리 이름 에러 시, 카테고리 추가 버튼 비활성화 스타일링
- 🚀 모달 > 카테고리 추가 시, 기본 카테고리명 제거 및 Placeholder 추가
