### PR TITLE
태그 API 요청 엔드포인트 변경 / 태그가 0개 일 때, 태그박스 자리에 0이 렌더링 되는 문제 해결

### DIFF
--- a/frontend/src/api/tags.ts
+++ b/frontend/src/api/tags.ts
@@ -4,7 +4,7 @@ import { customFetch } from './customFetch';
 
 const API_URL = process.env.REACT_APP_API_URL;
 
-export const TAG_API_URL = `${API_URL}/templates/tags`;
+export const TAG_API_URL = `${API_URL}/tags`;
 
 export const getTagList = async ({ memberId }: Pick<MemberInfo, 'memberId'>) => {
   const url = `${TAG_API_URL}?memberId=${memberId}`;

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -151,7 +151,7 @@ const MyTemplatePage = () => {
               getOptionLabel={(option) => option.value}
             />
           </Flex>
-          {tags.length && (
+          {tags.length !== 0 && (
             <TagFilterMenu tags={tags} selectedTagIds={selectedTagIds} onSelectTags={handleTagMenuClick} />
           )}
           {templates.length ? (


### PR DESCRIPTION
## ⚡️ 관련 이슈
#510

## 📍주요 변경 사항
- 🐛 API 요청 엔드포인트 변경 (/templates/tags > /tags)
- 🐛 '내 템플릿' 페이지에서 태그가 0개일 때, '0'이 렌더링 되는 문제 
