### PR TITLE
템플릿 삭제 시 다른 리소스 삭제 순서 변경

### DIFF
--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -87,9 +87,9 @@ public class TemplateApplicationService {
 
     @Transactional
     public void deleteByMemberAndIds(Member member, List<Long> ids) {
-        templateService.deleteByMemberAndIds(member, ids);
-        templateTagService.deleteByIds(ids);
-        sourceCodeService.deleteByIds(ids);
         thumbnailService.deleteByTemplateIds(ids);
+        sourceCodeService.deleteByIds(ids);
+        templateTagService.deleteByIds(ids);
+        templateService.deleteByMemberAndIds(member, ids);
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #551

## 📍주요 변경 사항
1. 템플릿 삭제 시 템플릿 연관관계의 친구들을 먼저 삭제하고 템플릿을 마지막에 삭제해야 하는데, 순서가 변경되어 있었습니다.

## 🎸기타
### 1. 이런걸 더 고려해봐야 할 것 같습니다.
### - 이런 것도 해야해요.
