### PR TITLE
카테고리 편집 모달에서  카테고리를 추가하면 동일한 카테고리 아이템이 추가되고, 타입에러가 발생하는 문제

### DIFF
--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -13,7 +13,6 @@ interface CategoryEditModalProps {
   isOpen: boolean;
   toggleModal: () => void;
   categories: Category[];
-  defaultCategory: Category;
   handleCancelEdit: () => void;
 }
 
@@ -75,7 +74,10 @@ const CategoryEditModal = ({ isOpen, toggleModal, categories, handleCancelEdit }
   };
 
   const handleAddCategory = () => {
-    const newCategoryId = categories[categories.length - 1].id + newCategories.length + 1;
+    const newCategoryId =
+      categories.length > 0
+        ? categories[categories.length - 1].id + newCategories.length + 1
+        : newCategories.length + 1;
 
     setNewCategories((prev) => [...prev, { id: newCategoryId, name: '' }]);
     setEditingCategoryId(newCategoryId);

--- a/frontend/src/components/CategoryFilterMenu/CategoryFilterMenu.tsx
+++ b/frontend/src/components/CategoryFilterMenu/CategoryFilterMenu.tsx
@@ -68,7 +68,6 @@ const CategoryFilterMenu = ({ categories, onSelectCategory }: CategoryMenuProps)
         isOpen={isEditModalOpen}
         toggleModal={toggleEditModal}
         categories={userCategories}
-        defaultCategory={defaultCategory}
         handleCancelEdit={toggleEditModal}
       />
     </S.CategoryContainer>

--- a/frontend/src/queries/category/useCategoryUploadMutation.ts
+++ b/frontend/src/queries/category/useCategoryUploadMutation.ts
@@ -10,8 +10,9 @@ export const useCategoryUploadMutation = (handleCurrentCategory: (newValue: Cate
     mutationFn: postCategory,
     onSuccess: (res) => {
       queryClient.invalidateQueries({ queryKey: [QUERY_KEY.CATEGORY_LIST] });
-      if ('name' in res) {
-        handleCurrentCategory(res);
+
+      if (res !== null && 'name' in res) {
+        handleCurrentCategory(res as Category);
       }
     },
   });


### PR DESCRIPTION
## ⚡️ 관련 이슈
#510 

## 📍주요 변경 사항
- useCategoryUploadMutation에서 null 응답에 대해 'in' 연산자를 사용하는 문제 해결