### PR TITLE
fix(service): 썸네일 소스코드 삭제 안되는 문제 해결

### DIFF
--- a/backend/src/main/java/codezap/template/service/SourceCodeService.java
+++ b/backend/src/main/java/codezap/template/service/SourceCodeService.java
@@ -54,7 +54,8 @@ public class SourceCodeService {
     }
 
     private void updateThumbnail(UpdateTemplateRequest updateTemplateRequest, Template template, Thumbnail thumbnail) {
-        boolean isThumbnailDeleted = updateTemplateRequest.deleteSourceCodeIds().contains(thumbnail.getId());
+        boolean isThumbnailDeleted = updateTemplateRequest.deleteSourceCodeIds()
+                .contains(thumbnail.getSourceCode().getId());
         if (isThumbnailDeleted) {
             refreshThumbnail(template, thumbnail);
         }


### PR DESCRIPTION
## ⚡️ 관련 이슈


## 📍주요 변경 사항
수정 시 썸네일 삭제 안되는 문제 해결
- 원인 : thumbnail 비교 시 thumbnail.sourceCode.id 비교가 아닌 thumbnail.id 비교

## 🎸기타