### PR TITLE
서버 환경에 맞게 Swagger try it out 버튼 비활성화

### DIFF
--- a/backend/src/main/resources/application-swagger.yml
+++ b/backend/src/main/resources/application-swagger.yml
@@ -1,4 +1,18 @@
+spring:
+  config:
+    activate:
+      on-profile: dev
 springdoc:
   swagger-ui:
     supportedSubmitMethods: get, post, delete
     display-request-duration: true
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+springdoc:
+  swagger-ui:
+    supportedSubmitMethods: get
+    display-request-duration: false

--- a/backend/src/main/resources/application-swagger.yml
+++ b/backend/src/main/resources/application-swagger.yml
@@ -1,0 +1,4 @@
+springdoc:
+  swagger-ui:
+    supportedSubmitMethods: get, post, delete
+    display-request-duration: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -3,3 +3,4 @@ spring:
     active:
       - local
       - db
+      - swagger


### PR DESCRIPTION
## ⚡️ 관련 이슈
#580

## 📍주요 변경 사항
- 개발 서버 Swagger는 현재와 동일하게 모든 요청을 try it out을 할 수 있다
- 배포 서버 Swagger에서 post , delete 요청일 경우 try it out을 제한한다

## 🎸기타
swagger 페이지 접근 시 비밀번호를 통해 관리자 권한을 확인하는 방안으로 업데이트 예정
