### PR TITLE
템플릿 생성 실패한 경우, 토스트로 알림 및 라우터 유지하도록 변경

### DIFF
--- a/frontend/src/api/customFetch.ts
+++ b/frontend/src/api/customFetch.ts
@@ -34,10 +34,10 @@ export const customFetch = async <T>({ url, headers, method = 'GET', body }: Pro
 
     if (!response.ok) {
       const error: CustomError = {
-        type: responseBody.type || 'UnknownError',
-        title: responseBody.title || 'Error',
+        type: responseBody?.type || 'UnknownError',
+        title: responseBody?.title || 'Error',
         status: response.status,
-        detail: responseBody.detail || 'An error occurred',
+        detail: responseBody?.detail || 'An error occurred',
         instance: url,
       };
 

--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -5,6 +5,7 @@ import type {
   TemplateListResponse,
   TemplateUploadRequest,
   TemplateListRequest,
+  CustomError,
 } from '@/types';
 import { SortingOption } from '@/types';
 import { customFetch } from './customFetch';
@@ -102,15 +103,12 @@ export const getTemplate = async (id: number) => {
   throw new Error(response.detail);
 };
 
-export const postTemplate = async (newTemplate: TemplateUploadRequest) => {
-  const response = await customFetch({
+export const postTemplate = async (newTemplate: TemplateUploadRequest): Promise<void | CustomError> =>
+  await customFetch({
     method: 'POST',
     url: `${TEMPLATE_API_URL}`,
     body: JSON.stringify(newTemplate),
   });
-
-  return response;
-};
 
 export const editTemplate = async ({ id, template }: { id: number; template: TemplateEditRequest }): Promise<void> => {
   await customFetch({

--- a/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
+++ b/frontend/src/components/CategoryEditModal/CategoryEditModal.tsx
@@ -5,6 +5,7 @@ import { PencilIcon, SpinArrowIcon, TrashcanIcon } from '@/assets/images';
 import { Text, Modal, Input, Flex, Button } from '@/components';
 import { useCategoryNameValidation } from '@/hooks/category';
 import { useCategoryDeleteMutation, useCategoryEditMutation, useCategoryUploadMutation } from '@/queries/category';
+import { validateCategoryName } from '@/service/validates';
 import { theme } from '@/style/theme';
 import type { Category, CustomError } from '@/types';
 import * as S from './CategoryEditModal.style';
@@ -38,6 +39,12 @@ const CategoryEditModal = ({ isOpen, toggleModal, categories, handleCancelEdit }
   const isCategoryNew = (id: number) => newCategories.some((category) => category.id === id);
 
   const handleNameInputChange = (id: number, name: string) => {
+    const errorMessage = validateCategoryName(name);
+
+    if (errorMessage && name.length > 0) {
+      return;
+    }
+
     if (isCategoryNew(id)) {
       setNewCategories((prev) => prev.map((category) => (category.id === id ? { ...category, name } : category)));
     } else {

--- a/frontend/src/components/TemplateEdit/TemplateEdit.tsx
+++ b/frontend/src/components/TemplateEdit/TemplateEdit.tsx
@@ -147,7 +147,11 @@ const TemplateEdit = ({
           </S.UnderlineInputWrapper>
 
           <Input size='large' variant='text'>
-            <Input.TextField placeholder='설명을 입력해주세요' value={description} onChange={handleDescriptionChange} />
+            <Input.TextField
+              placeholder='이 템플릿을 언제 다시 쓸 것 같나요?'
+              value={description}
+              onChange={handleDescriptionChange}
+            />
           </Input>
 
           {sourceCodes.map((sourceCode, index) => (

--- a/frontend/src/hooks/template/useTemplateUpload.ts
+++ b/frontend/src/hooks/template/useTemplateUpload.ts
@@ -85,8 +85,10 @@ export const useTemplateUpload = () => {
   };
 
   const handleSaveButtonClick = async () => {
-    if (validateTemplate()) {
-      failAlert(validateTemplate());
+    const errorMessage = validateTemplate();
+
+    if (errorMessage) {
+      failAlert(errorMessage);
 
       return;
     }

--- a/frontend/src/hooks/template/useTemplateUpload.ts
+++ b/frontend/src/hooks/template/useTemplateUpload.ts
@@ -101,7 +101,13 @@ export const useTemplateUpload = () => {
     };
 
     await uploadTemplate(newTemplate, {
-      onSuccess: () => {
+      onSuccess: (res) => {
+        if (res?.status === 400 || res?.status === 404) {
+          failAlert('템플릿 생성에 실패했습니다. 다시 한 번 시도해주세요');
+
+          return;
+        }
+
         navigate(END_POINTS.MY_TEMPLATES);
       },
     });


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #581 

## 📍주요 변경 사항
- 템플릿 생성 실패할 경우, 라우터 이동 없이 생성 화면단 유지하기
- 템플릿 생성 실패할 경우, 토스트로 실패하였다고 알림하기
- 템플릿 생성 description input placeholder 문구 변경

https://github.com/user-attachments/assets/1baacec4-eddf-4033-985c-d8621c46962e


## 🎸기타
- 현재 템플릿 생성, 수정 요청에서 응답으로 올 수 있는 에러 코드
  - 401
  - 400
  - 404
  - 여기서 401 은 유저 인증에 대한 부분이므로 전체에서 핸들링 되어야 한다고 판단 => 나머지 400, 404에 대해서만 에러처리하였습니다.
- 에러핸들링 및 customFetch 의 리팩토링 필요합니다.