### PR TITLE
Member 도메인에 salt 필드 추가

### DIFF
--- a/backend/src/main/java/codezap/member/domain/Member.java
+++ b/backend/src/main/java/codezap/member/domain/Member.java
@@ -30,8 +30,11 @@ public class Member extends BaseTimeEntity {
     @Column(nullable = false)
     private String password;
 
-    public Member(String name, String password) {
-        this(null, name, password);
+    @Column(nullable = false)
+    private String salt;
+
+    public Member(String name, String password, String salt) {
+        this(null, name, password, salt);
     }
 
     public boolean matchPassword(String password) {

--- a/backend/src/main/java/codezap/member/service/MemberService.java
+++ b/backend/src/main/java/codezap/member/service/MemberService.java
@@ -13,6 +13,7 @@ import codezap.member.dto.MemberDto;
 import codezap.member.dto.request.SignupRequest;
 import codezap.member.dto.response.FindMemberResponse;
 import codezap.member.repository.MemberRepository;
+import codezap.secure.SaltGenerator;
 import lombok.RequiredArgsConstructor;
 
 @Service
@@ -21,10 +22,11 @@ public class MemberService {
 
     private final MemberRepository memberRepository;
     private final CategoryRepository categoryRepository;
+    private final SaltGenerator saltGenerator;
 
     public Long signup(SignupRequest request) {
         assertUniqueName(request.name());
-        Member member = memberRepository.save(new Member(request.name(), request.password()));
+        Member member = memberRepository.save(new Member(request.name(), request.password(), saltGenerator.getSalt()));
         categoryRepository.save(Category.createDefaultCategory(member));
         return member.getId();
     }

--- a/backend/src/main/java/codezap/secure/RandomSaltGenerator.java
+++ b/backend/src/main/java/codezap/secure/RandomSaltGenerator.java
@@ -1,0 +1,18 @@
+package codezap.secure;
+
+import java.security.SecureRandom;
+import java.util.Base64;
+
+import org.springframework.stereotype.Component;
+
+@Component
+public class RandomSaltGenerator implements SaltGenerator {
+
+    @Override
+    public String getSalt() {
+        SecureRandom byteGenerator = new SecureRandom();
+        byte[] saltByte = new byte[32];
+        byteGenerator.nextBytes(saltByte);
+        return Base64.getEncoder().encodeToString(saltByte);
+    }
+}

--- a/backend/src/main/java/codezap/secure/SaltGenerator.java
+++ b/backend/src/main/java/codezap/secure/SaltGenerator.java
@@ -1,0 +1,5 @@
+package codezap.secure;
+
+public interface SaltGenerator {
+    String getSalt();
+}

--- a/backend/src/main/resources/db/migration/V2__add_salt.sql
+++ b/backend/src/main/resources/db/migration/V2__add_salt.sql
@@ -1,0 +1,1 @@
+ALTER TABLE member ADD COLUMN salt VARCHAR(255);

--- a/backend/src/test/java/codezap/fixture/MemberFixture.java
+++ b/backend/src/test/java/codezap/fixture/MemberFixture.java
@@ -7,7 +7,8 @@ public class MemberFixture {
         return new Member(
                 1L,
                 "몰리",
-                "password1234"
+                "password1234",
+                "salt1"
         );
     }
 
@@ -15,7 +16,8 @@ public class MemberFixture {
         return new Member(
                 2L,
                 "몰리2",
-                "password1234"
+                "password1234",
+                "salt2"
         );
     }
 }

--- a/backend/src/test/java/codezap/member/fixture/MemberFixture.java
+++ b/backend/src/test/java/codezap/member/fixture/MemberFixture.java
@@ -8,14 +8,16 @@ public class MemberFixture {
         return new Member(
                 1L,
                 "몰리",
-                "password1234"
+                "password1234",
+                "salt"
         );
     }
 
     public static Member createFixture(String name) {
         return new Member(
                 name,
-                "password1234"
+                "password1234",
+                "salt"
         );
     }
 }

--- a/backend/src/test/java/codezap/member/repository/FakeMemberRepository.java
+++ b/backend/src/test/java/codezap/member/repository/FakeMemberRepository.java
@@ -56,7 +56,8 @@ public class FakeMemberRepository implements MemberRepository {
         var saved = new Member(
                 getOrGenerateId(entity),
                 entity.getPassword(),
-                entity.getName()
+                entity.getName(),
+                entity.getSalt()
         );
         members.removeIf(member -> Objects.equals(member.getId(), entity.getId()));
         members.add(saved);

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -19,12 +19,15 @@ import codezap.member.dto.response.FindMemberResponse;
 import codezap.member.fixture.MemberFixture;
 import codezap.member.repository.FakeMemberRepository;
 import codezap.member.repository.MemberRepository;
+import codezap.secure.RandomSaltGenerator;
+import codezap.secure.SaltGenerator;
 
 public class MemberServiceTest {
 
     private final MemberRepository memberRepository = new FakeMemberRepository();
     private final CategoryRepository categoryRepository = new FakeCategoryRepository();
-    private final MemberService memberService = new MemberService(memberRepository, categoryRepository);
+    private final SaltGenerator saltGenerator = new RandomSaltGenerator();
+    private final MemberService memberService = new MemberService(memberRepository, categoryRepository, saltGenerator);
 
     @Nested
     @DisplayName("회원가입 테스트")

--- a/backend/src/test/java/codezap/secure/SaltGeneratorTest.java
+++ b/backend/src/test/java/codezap/secure/SaltGeneratorTest.java
@@ -1,0 +1,25 @@
+package codezap.secure;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.HashSet;
+import java.util.Set;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+class SaltGeneratorTest {
+
+    SaltGenerator saltGenerator = new RandomSaltGenerator();
+
+    @Test
+    @DisplayName("1,000,000번의 난수 생성에서 난수 충돌이 발생하지 않는다.")
+    void test() {
+        Set<String> salts = new HashSet<>();
+        for (int i = 0; i < 1_000_000; i++) {
+            salts.add(saltGenerator.getSalt());
+        }
+
+        assertThat(salts).hasSize(1_000_000);
+    }
+}

--- a/backend/src/test/java/codezap/secure/SaltGeneratorTest.java
+++ b/backend/src/test/java/codezap/secure/SaltGeneratorTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.util.HashSet;
 import java.util.Set;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -14,6 +15,7 @@ class SaltGeneratorTest {
 
     @Test
     @DisplayName("1,000,000번의 난수 생성에서 난수 충돌이 발생하지 않는다.")
+    @Disabled
     void test() {
         Set<String> salts = new HashSet<>();
         for (int i = 0; i < 1_000_000; i++) {

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -40,6 +40,8 @@ import codezap.member.dto.MemberDto;
 import codezap.member.repository.FakeMemberRepository;
 import codezap.member.repository.MemberRepository;
 import codezap.member.service.MemberService;
+import codezap.secure.RandomSaltGenerator;
+import codezap.secure.SaltGenerator;
 import codezap.tag.service.TemplateTagService;
 import codezap.template.dto.request.CreateSourceCodeRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
@@ -69,6 +71,8 @@ class TemplateControllerTest {
     private final MemberRepository memberRepository = new FakeMemberRepository(
             List.of(MemberFixture.getFirstMember(), MemberFixture.getSecondMember())
     );
+
+    private final SaltGenerator saltGenerator = new RandomSaltGenerator();
     private final TemplateService templateService = new TemplateService(templateRepository);
     private final CategoryService categoryService = new CategoryService(categoryRepository);
 
@@ -91,7 +95,7 @@ class TemplateControllerTest {
 
     private final MemberTemplateApplicationService memberTemplateApplicationService =
             new MemberTemplateApplicationService(
-                    new MemberService(memberRepository, categoryRepository),
+                    new MemberService(memberRepository, categoryRepository, saltGenerator),
                     categoryTemplateApplicationService,
                     templateApplicationService
             );

--- a/backend/src/test/java/codezap/template/repository/TemplateRepositoryFindAllTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateRepositoryFindAllTest.java
@@ -44,8 +44,8 @@ class TemplateRepositoryFindAllTest {
 
     @BeforeEach
     void setUp() {
-        member1 = memberRepository.save(new Member("user1@test.com", "pp"));
-        member2 = memberRepository.save(new Member("user2@test.com", "pp"));
+        member1 = memberRepository.save(new Member("user1@test.com", "pp", "salt1"));
+        member2 = memberRepository.save(new Member("user2@test.com", "pp", "salt2"));
 
         category1 = categoryRepository.save(new Category("Category 1", member1));
         category2 = categoryRepository.save(new Category("Category 2", member1));


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #584

## 📍주요 변경 사항
- salt 값을 생성하는 기능 구현
- Member 도메인에 salt 필드 추가
- flyway 스크립트 작성

## 🎸기타

- 난수 생성 테스트는 오래 걸리기 때문에 필요할 때 `@Disabled` 만 풀어서 확인할 수 있도록 남겨 두었습니다. 
  - (지우는 것이 나을 것 같으면 말해주세요! 지워도 상관 없습니다!)
- 나머지 테스트는 전부 도메인 변경으로 인해 터지는 테스트 보완입니다.