### PR TITLE
cors를 허용하는 origin 지정

### DIFF
--- a/backend/src/main/java/codezap/global/cors/WebCorsConfiguration.java
+++ b/backend/src/main/java/codezap/global/cors/WebCorsConfiguration.java
@@ -10,7 +10,7 @@ public class WebCorsConfiguration implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowCredentials(true)
-                .allowedOriginPatterns("*")
+                .allowedOriginPatterns("https://*.codezap.com", "http://localhost:8080")
                 .allowedMethods("*")
                 .exposedHeaders("*");
     }

--- a/backend/src/main/java/codezap/global/cors/WebCorsConfiguration.java
+++ b/backend/src/main/java/codezap/global/cors/WebCorsConfiguration.java
@@ -10,7 +10,7 @@ public class WebCorsConfiguration implements WebMvcConfigurer {
     public void addCorsMappings(CorsRegistry registry) {
         registry.addMapping("/**")
                 .allowCredentials(true)
-                .allowedOriginPatterns("https://*.codezap.com", "http://localhost:8080")
+                .allowedOriginPatterns("https://*.code-zap.com")
                 .allowedMethods("*")
                 .exposedHeaders("*");
     }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #594

## 📍주요 변경 사항
1. cors를 허용하는 origin 을 와일드 카드에서 우리 클라이언트 도메인으로 지정

