### PR TITLE
파일명, 소스코드 길이 제한

### DIFF
--- a/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
+++ b/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
@@ -59,12 +59,9 @@ const SourceCodeEditor = ({ index, fileName, content, onChangeContent, onChangeF
   const handleContentChange = (value: string, viewUpdate: ViewUpdate) => {
     const currentByteSize = getByteSize(value);
 
-    console.log(currentByteSize);
-
     if (currentByteSize > MAX_CONTENT_SIZE) {
       failAlert(`소스코드는 최대 ${MAX_CONTENT_SIZE} 바이트를 초과할 수 없습니다.`);
 
-      // 이전 상태로 롤백
       const previousContent = previousContentRef.current;
       const transaction = viewUpdate.state.update({
         changes: { from: 0, to: value.length, insert: previousContent },

--- a/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
+++ b/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
@@ -10,7 +10,6 @@ import { validateFileName } from '@/service';
 import { getByteSize, getLanguageByFilename } from '@/utils';
 import * as S from './SourceCodeEditor.style';
 
-const MAX_FILENAME_LENGTH = 255;
 const MAX_CONTENT_SIZE = 65535;
 
 interface Props {
@@ -38,12 +37,6 @@ const SourceCodeEditor = ({ index, fileName, content, onChangeContent, onChangeF
 
   const handleFileNameChange = (event: ChangeEvent<HTMLInputElement>) => {
     const newFileName = event.target.value;
-
-    if (newFileName.length > MAX_FILENAME_LENGTH) {
-      failAlert(`파일명은 최대 ${MAX_FILENAME_LENGTH}자까지 가능합니다.`);
-
-      return;
-    }
 
     const errorMessage = validateFileName(newFileName);
 

--- a/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
+++ b/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
@@ -9,6 +9,8 @@ import { validateFileName } from '@/service';
 import { getLanguageByFilename } from '@/utils';
 import * as S from './SourceCodeEditor.style';
 
+const MAX_FILENAME_LENGTH = 255;
+
 interface Props {
   index: number;
   fileName: string;
@@ -32,7 +34,15 @@ const SourceCodeEditor = ({ index, fileName, content, onChangeContent, onChangeF
   };
 
   const handleFileNameChange = (event: ChangeEvent<HTMLInputElement>) => {
-    const errorMessage = validateFileName(event.target.value);
+    const newFileName = event.target.value;
+
+    if (newFileName.length > MAX_FILENAME_LENGTH) {
+      failAlert(`파일명은 최대 ${MAX_FILENAME_LENGTH}자까지 가능합니다.`);
+
+      return;
+    }
+
+    const errorMessage = validateFileName(newFileName);
 
     if (errorMessage) {
       failAlert(errorMessage);
@@ -40,7 +50,7 @@ const SourceCodeEditor = ({ index, fileName, content, onChangeContent, onChangeF
       return;
     }
 
-    onChangeFileName(event.target.value);
+    onChangeFileName(newFileName);
   };
 
   const handleContentChange = (value: string) => {

--- a/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
+++ b/frontend/src/components/SourceCodeEditor/SourceCodeEditor.tsx
@@ -6,11 +6,9 @@ import { ChangeEvent, useRef } from 'react';
 
 import { ToastContext } from '@/contexts';
 import { useCustomContext } from '@/hooks/utils';
-import { validateFileName } from '@/service';
-import { getByteSize, getLanguageByFilename } from '@/utils';
+import { validateFileName, validateSourceCode } from '@/service';
+import { getLanguageByFilename } from '@/utils';
 import * as S from './SourceCodeEditor.style';
-
-const MAX_CONTENT_SIZE = 65535;
 
 interface Props {
   index: number;
@@ -50,10 +48,10 @@ const SourceCodeEditor = ({ index, fileName, content, onChangeContent, onChangeF
   };
 
   const handleContentChange = (value: string, viewUpdate: ViewUpdate) => {
-    const currentByteSize = getByteSize(value);
+    const errorMessage = validateSourceCode(value);
 
-    if (currentByteSize > MAX_CONTENT_SIZE) {
-      failAlert(`소스코드는 최대 ${MAX_CONTENT_SIZE} 바이트를 초과할 수 없습니다.`);
+    if (errorMessage) {
+      failAlert(errorMessage);
 
       const previousContent = previousContentRef.current;
       const transaction = viewUpdate.state.update({

--- a/frontend/src/service/index.ts
+++ b/frontend/src/service/index.ts
@@ -1,1 +1,7 @@
-export { validateName, validatePassword, validateConfirmPassword, validateFileName } from './validates';
+export {
+  validateName,
+  validatePassword,
+  validateConfirmPassword,
+  validateFileName,
+  validateSourceCode,
+} from './validates';

--- a/frontend/src/service/validates.ts
+++ b/frontend/src/service/validates.ts
@@ -39,8 +39,6 @@ export const validateSourceCode = (sourceCode: string) => {
   const MAX_CONTENT_SIZE = 65535;
   const currentByteSize = getByteSize(sourceCode);
 
-  console.log(currentByteSize);
-
   if (currentByteSize > MAX_CONTENT_SIZE) {
     return `소스코드는 최대 ${MAX_CONTENT_SIZE} 바이트까지 입력할 수 있습니다!.`;
   }

--- a/frontend/src/service/validates.ts
+++ b/frontend/src/service/validates.ts
@@ -1,3 +1,5 @@
+import { getByteSize } from '../utils/getByteSize';
+
 export const validateName = (name: string) => {
   const regex = /^[a-zA-Z0-9가-힣-_]+$/;
 
@@ -28,6 +30,19 @@ export const validateFileName = (fileName: string) => {
 
   if (invalidChars.test(fileName)) {
     return '특수 문자 (<, >, :, ", /, , |, ?, *)는 사용할 수 없습니다!';
+  }
+
+  return '';
+};
+
+export const validateSourceCode = (sourceCode: string) => {
+  const MAX_CONTENT_SIZE = 65535;
+  const currentByteSize = getByteSize(sourceCode);
+
+  console.log(currentByteSize);
+
+  if (currentByteSize > MAX_CONTENT_SIZE) {
+    return `소스코드는 최대 ${MAX_CONTENT_SIZE} 바이트까지 입력할 수 있습니다!.`;
   }
 
   return '';

--- a/frontend/src/utils/getByteSize.ts
+++ b/frontend/src/utils/getByteSize.ts
@@ -1,0 +1,1 @@
+export const getByteSize = (str: string) => new TextEncoder().encode(str).length;

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -1,4 +1,5 @@
 export { formatRelativeTime } from './formatRelativeTime';
+export { getByteSize } from './getByteSize';
 export { getLanguageByFilename } from './getLanguageByFileName';
 export { removeAllWhitespace } from './removeAllWhitespace';
 export { remToPx } from './remToPx';


### PR DESCRIPTION
## ⚡️ 관련 이슈
#581

## 📍주요 변경 사항
### 1. 파일명 255자 제한
### 2. 소스코드 65,535 Byte 제한

## 🎸기타
### 1. 개선사항
- Validation 코드 분리
### 2. 문제점
- 최대 글자수에서 한글(3Byte)를 입력하여 글자수를 초과하면 3회 시도부터 에러 발생
- 에디터의 글자를 통째로 덮어씌우기 때문에, 커서의 위치가 에디터의 처음으로 초기화