### PR TITLE
아이디, 비밀번호 글자수 상한선 제한

### DIFF
--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -25,7 +25,7 @@ const LoginPage = () => {
             style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', gap: '1rem' }}
           >
             <Input variant='outlined' size='medium' isValid={!errors.name}>
-              <Input.Label>아이디</Input.Label>
+              <Input.Label>아이디 (닉네임)</Input.Label>
               <Input.TextField type='text' value={name} onChange={handleNameChange} autoComplete='username' />
               <Input.HelperText>{errors.name}</Input.HelperText>
             </Input>

--- a/frontend/src/pages/SignupPage/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage/SignupPage.tsx
@@ -37,7 +37,7 @@ const SignupPage = () => {
             style={{ display: 'flex', flexDirection: 'column', width: '100%', height: '100%', gap: '1rem' }}
           >
             <Input variant='outlined' size='medium' isValid={!errors.name}>
-              <Input.Label>아이디</Input.Label>
+              <Input.Label>아이디 (닉네임)</Input.Label>
               <Input.TextField
                 type='text'
                 value={name}

--- a/frontend/src/service/validates.ts
+++ b/frontend/src/service/validates.ts
@@ -3,18 +3,20 @@ import { getByteSize } from '../utils/getByteSize';
 export const validateName = (name: string) => {
   const regex = /^[a-zA-Z0-9가-힣-_]+$/;
 
-  return regex.test(name) && name.length > 0 ? '' : '1자 이상의 아이디를 입력해주세요.';
+  return regex.test(name) && name.length >= 1 && name.length <= 255
+    ? ''
+    : '1자 이상의 올바른 문자를 입력해주세요. (ex. 코드잽)';
 };
 
 export const validatePassword = (password: string) => {
   const hasLetters = /[a-zA-Z]/.test(password);
   const hasNumbers = /[0-9]/.test(password);
   const hasNoSpaces = !/\s/.test(password);
-  const isValidLength = password.length >= 8;
+  const isValidLength = password.length >= 8 && password.length <= 16;
 
   return hasLetters && hasNumbers && isValidLength && hasNoSpaces
     ? ''
-    : '영문자, 숫자를 포함한 8자 이상의 비밀번호를 입력해주세요.';
+    : '영문자, 숫자를 포함한 8 ~ 16자의 비밀번호를 입력해주세요.';
 };
 
 export const validateConfirmPassword = (password: string, confirmPassword: string) =>

--- a/frontend/src/service/validates.ts
+++ b/frontend/src/service/validates.ts
@@ -1,22 +1,26 @@
 import { getByteSize } from '../utils/getByteSize';
 
 export const validateName = (name: string) => {
+  const MAX_LENGTH = 255;
+  const MIN_LENGTH = 1;
   const regex = /^[a-zA-Z0-9가-힣-_]+$/;
 
-  return regex.test(name) && name.length >= 1 && name.length <= 255
+  return regex.test(name) && name.length >= MIN_LENGTH && name.length <= MAX_LENGTH
     ? ''
-    : '1자 이상의 올바른 문자를 입력해주세요. (ex. 코드잽)';
+    : `${MIN_LENGTH}자 이상의 올바른 문자를 입력해주세요. (ex. 코드잽)`;
 };
 
 export const validatePassword = (password: string) => {
+  const MAX_LENGTH = 16;
+  const MIN_LENGTH = 8;
   const hasLetters = /[a-zA-Z]/.test(password);
   const hasNumbers = /[0-9]/.test(password);
   const hasNoSpaces = !/\s/.test(password);
-  const isValidLength = password.length >= 8 && password.length <= 16;
+  const isValidLength = password.length >= MIN_LENGTH && password.length <= MAX_LENGTH;
 
   return hasLetters && hasNumbers && isValidLength && hasNoSpaces
     ? ''
-    : '영문자, 숫자를 포함한 8 ~ 16자의 비밀번호를 입력해주세요.';
+    : `영문자, 숫자를 포함한 ${MIN_LENGTH} ~ ${MAX_LENGTH}자의 비밀번호를 입력해주세요.`;
 };
 
 export const validateConfirmPassword = (password: string, confirmPassword: string) =>

--- a/frontend/src/service/validates.ts
+++ b/frontend/src/service/validates.ts
@@ -7,7 +7,7 @@ export const validateName = (name: string) => {
 
   return regex.test(name) && name.length >= MIN_LENGTH && name.length <= MAX_LENGTH
     ? ''
-    : `${MIN_LENGTH}자 이상의 올바른 문자를 입력해주세요. (ex. 코드잽)`;
+    : `${MIN_LENGTH} ~ ${MAX_LENGTH}자의 올바른 문자를 입력해주세요. (ex. 코드잽)`;
 };
 
 export const validatePassword = (password: string) => {


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #602 

## 📍주요 변경 사항
1. 아이디, 비밀번호 글자수를 각각 255자, 16자의 상한선 제한을 둔다
2. 아이디 에러 메시지를 변경한다
3. 비밀번호 에러 메시지를 변경한다
4. 로그인, 회원가입 페이지에서 아이디 라는 인풋 라벨을 아이디(닉네임)으로 변경한다
