### PR TITLE
MemberJpaRepository 테스트 구현

### DIFF
--- a/backend/src/main/java/codezap/member/repository/MemberJpaRepository.java
+++ b/backend/src/main/java/codezap/member/repository/MemberJpaRepository.java
@@ -4,6 +4,7 @@ import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.http.HttpStatus;
 
 import codezap.global.exception.CodeZapException;
@@ -28,7 +29,7 @@ public interface MemberJpaRepository extends MemberRepository, JpaRepository<Mem
     }
 
     @Query("SELECT t.member FROM Template t WHERE t.id = :templateId")
-    Optional<Member> findByTemplateId(Long templateId);
+    Optional<Member> findByTemplateId(@Param("templateId") Long templateId);
 
     Optional<Member> findByName(String name);
 

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -9,7 +9,6 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import codezap.category.domain.Category;
-import codezap.category.repository.CategoryJpaRepository;
 import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
@@ -17,26 +16,19 @@ import codezap.global.exception.CodeZapException;
 import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
-import codezap.template.repository.TemplateJpaRepository;
 import codezap.template.repository.TemplateRepository;
 
 @JpaRepositoryTest
 class MemberJpaRepositoryTest {
 
-    private final MemberRepository memberRepository;
-    private final TemplateRepository templateRepository;
-    private final CategoryRepository categoryRepository;
+    @Autowired
+    private MemberRepository memberRepository;
 
     @Autowired
-    MemberJpaRepositoryTest(
-            MemberJpaRepository memberRepository,
-            TemplateJpaRepository templateRepository,
-            CategoryJpaRepository categoryRepository
-    ) {
-        this.memberRepository = memberRepository;
-        this.templateRepository = templateRepository;
-        this.categoryRepository = categoryRepository;
-    }
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
 
     @Nested
     @DisplayName("id로 Member 조회")

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -34,7 +34,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("id로 Member 조회")
     class fetchById {
         @Test
-        @DisplayName("id로 Member 조회 성공 : id로 Member를 알아낼 수 있다.")
+        @DisplayName("성공 : id로 Member 조회 가능")
         void fetchByIdSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -44,7 +44,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("id로 Member 조회 실패 : 존재하지 않는 id인 경우 에러가 발생한다.")
+        @DisplayName("실패 : 존재하지 않는 id인 경우 예외 발생")
         void fetchByIdFailByNotExistsId() {
             long notExistId = 100;
 
@@ -58,7 +58,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("닉네임(아이디)로 Member 조회")
     class fetchByName {
         @Test
-        @DisplayName("닉네임으로 Member 조회 성공 : 닉네임으로 Member를 알아낼 수 있다.")
+        @DisplayName("성공 : 닉네임으로 Member 조회 가능")
         void fetchByNameSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -68,7 +68,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("닉네임으로 Member 조회 실패 : 존재하지 않는 닉네임인 경우 에러가 발생한다.")
+        @DisplayName("실패 : 존재하지 않는 닉네임인 경우 예외 발생")
         void fetchByNameFailByNotExistsId() {
             String notExistName = "켬미";
 
@@ -82,7 +82,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("템플릿 id로 Member 조회")
     class fetchByTemplateId {
         @Test
-        @DisplayName("템플릿 id로 Member 조회 성공 : 템플릿 id로 Member를 알아낼 수 있다.")
+        @DisplayName("성공 : 템플릿 id로 Member 조회 가능")
         void fetchByTemplateIdSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
             Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
@@ -94,7 +94,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("템플릿 id로 Member 조회 실패 : 존재하지 않는 템플릿 id인 경우 에러가 발생한다.")
+        @DisplayName("실패 : 존재하지 않는 템플릿 id인 경우 예외 발생")
         void fetchByTemplateIdFailByNotExistsId() {
             long notExistId = 100;
 
@@ -108,7 +108,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("닉네임(아이디) 존재 여부")
     class existsByName {
         @Test
-        @DisplayName("닉네임 존재 여부 성공 : 해당 닉네임이 존재하면 true를 반환한다.")
+        @DisplayName("성공 : 해당 닉네임이 존재하면 true를 반환")
         void existsByNameReturnTrue() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -118,7 +118,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("닉네임 존재 여부 성공 : 해당 닉네임이 존재하지 않으면 false를 반환한다.")
+        @DisplayName("성공 : 해당 닉네임이 존재하지 않으면 false를 반환")
         void existsByNameReturnFalse() {
             boolean actual = memberRepository.existsByName("notExist");
 

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -3,16 +3,14 @@ package codezap.member.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
-import java.util.Optional;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.jpa.repository.JpaRepository;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryJpaRepository;
+import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.global.exception.CodeZapException;
@@ -20,23 +18,24 @@ import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
 import codezap.template.repository.TemplateJpaRepository;
+import codezap.template.repository.TemplateRepository;
 
 @JpaRepositoryTest
 class MemberJpaRepositoryTest {
 
-    private final MemberJpaRepository memberJpaRepository;
-    private final TemplateJpaRepository templateJpaRepository;
-    private final CategoryJpaRepository categoryJpaRepository;
+    private final MemberRepository memberRepository;
+    private final TemplateRepository templateRepository;
+    private final CategoryRepository categoryRepository;
 
     @Autowired
     MemberJpaRepositoryTest(
-            MemberJpaRepository memberJpaRepository,
-            TemplateJpaRepository templateJpaRepository,
-            CategoryJpaRepository categoryJpaRepository
+            MemberJpaRepository memberRepository,
+            TemplateJpaRepository templateRepository,
+            CategoryJpaRepository categoryRepository
     ) {
-        this.memberJpaRepository = memberJpaRepository;
-        this.templateJpaRepository = templateJpaRepository;
-        this.categoryJpaRepository = categoryJpaRepository;
+        this.memberRepository = memberRepository;
+        this.templateRepository = templateRepository;
+        this.categoryRepository = categoryRepository;
     }
 
     @Nested
@@ -46,9 +45,9 @@ class MemberJpaRepositoryTest {
         @DisplayName("성공 : id로 Member를 알아낼 수 있다.")
         void fetchByIdSuccess() {
             Member member = MemberFixture.getFirstMember();
-            member = ((JpaRepository<Member, Long>) memberJpaRepository).save(member);
+            member = memberRepository.save(member);
 
-            Member actual = memberJpaRepository.fetchById(member.getId());
+            Member actual = memberRepository.fetchById(member.getId());
 
             assertThat(actual).isEqualTo(member);
         }
@@ -58,7 +57,7 @@ class MemberJpaRepositoryTest {
         void fetchByIdFailByNotExistsId() {
             long id = 100;
 
-            assertThatThrownBy(() -> memberJpaRepository.fetchById(id))
+            assertThatThrownBy(() -> memberRepository.fetchById(id))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("식별자 " + id + "에 해당하는 멤버가 존재하지 않습니다.");
         }
@@ -71,9 +70,9 @@ class MemberJpaRepositoryTest {
         @DisplayName("성공 : 아이디로 Member를 알아낼 수 있다.")
         void fetchByNameSuccess() {
             Member member = MemberFixture.getFirstMember();
-            member = ((JpaRepository<Member, Long>) memberJpaRepository).save(member);
+            member = memberRepository.save(member);
 
-            Member actual = memberJpaRepository.fetchByName(member.getName());
+            Member actual = memberRepository.fetchByName(member.getName());
 
             assertThat(actual).isEqualTo(member);
         }
@@ -83,32 +82,9 @@ class MemberJpaRepositoryTest {
         void fetchByNameFailByNotExistsId() {
             String name = "켬미";
 
-            assertThatThrownBy(() -> memberJpaRepository.fetchByName(name))
+            assertThatThrownBy(() -> memberRepository.fetchByName(name))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("존재하지 않는 아이디 " + name + " 입니다.");
-        }
-    }
-
-    @Nested
-    @DisplayName("아이디로 Member 조회")
-    class findByName {
-        @Test
-        @DisplayName("성공 : 아이디로 Member를 알아낼 수 있다.")
-        void findByNameSuccess() {
-            Member member = MemberFixture.getFirstMember();
-            member = ((JpaRepository<Member, Long>) memberJpaRepository).save(member);
-
-            Optional<Member> actual = memberJpaRepository.findByName(member.getName());
-
-            assertThat(actual).isEqualTo(Optional.of(member));
-        }
-
-        @Test
-        @DisplayName("실패 : 존재하지 않는 아이디인 경우 optional 값이 반환된다.")
-        void findByNameFailByNotExistsId() {
-            Optional<Member> actual = memberJpaRepository.findByName("kyummi");
-
-            assertThat(actual).isEmpty();
         }
     }
 
@@ -118,13 +94,12 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("성공 : 템플릿 id로 Member를 알아낼 수 있다.")
         void fetchByTemplateIdSuccess() {
-            Member member = ((JpaRepository<Member, Long>) memberJpaRepository).save(MemberFixture.getFirstMember());
-            Category category = ((JpaRepository<Category, Long>) categoryJpaRepository).save(
-                    CategoryFixture.getFirstCategory());
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
+            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
             Template template = new Template(member, "title", "description", category);
-            template = ((JpaRepository<Template, Long>) templateJpaRepository).save(template);
+            template = templateRepository.save(template);
 
-            Member actual = memberJpaRepository.fetchByTemplateId(template.getId());
+            Member actual = memberRepository.fetchByTemplateId(template.getId());
 
             assertThat(actual).isEqualTo(member);
         }
@@ -134,35 +109,9 @@ class MemberJpaRepositoryTest {
         void fetchByTemplateIdFailByNotExistsId() {
             long id = 100;
 
-            assertThatThrownBy(() -> memberJpaRepository.fetchByTemplateId(id))
+            assertThatThrownBy(() -> memberRepository.fetchByTemplateId(id))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("템플릿에 대한 멤버가 존재하지 않습니다.");
-        }
-    }
-
-    @Nested
-    @DisplayName("템플릿 id로 Member 조회")
-    class findByTemplateId {
-        @Test
-        @DisplayName("성공 : 템플릿 id로 Member를 알아낼 수 있다.")
-        void findByTemplateIdSuccess() {
-            Member member = ((JpaRepository<Member, Long>) memberJpaRepository).save(MemberFixture.getFirstMember());
-            Category category = ((JpaRepository<Category, Long>) categoryJpaRepository).save(
-                    CategoryFixture.getFirstCategory());
-            Template template = new Template(member, "title", "description", category);
-            template = ((JpaRepository<Template, Long>) templateJpaRepository).save(template);
-
-            Optional<Member> actual = memberJpaRepository.findByTemplateId(template.getId());
-
-            assertThat(actual).isEqualTo(Optional.of(member));
-        }
-
-        @Test
-        @DisplayName("실패 : 존재하지 않는 템플릿 id인 경우 optional 값이 반환된다.")
-        void findByTemplateIdFailByNotExistsId() {
-            Optional<Member> actual = memberJpaRepository.findByTemplateId(100L);
-
-            assertThat(actual).isEmpty();
         }
     }
 
@@ -172,9 +121,9 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("성공 : 해당 아이디가 존재하면 true를 반환한다.")
         void existsByNameReturnTrue() {
-            Member member = ((JpaRepository<Member, Long>) memberJpaRepository).save(MemberFixture.getFirstMember());
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
 
-            boolean actual = memberJpaRepository.existsByName(member.getName());
+            boolean actual = memberRepository.existsByName(member.getName());
 
             assertThat(actual).isTrue();
         }
@@ -182,7 +131,7 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("성공 : 해당 아이디가 존재하면 false를 반환한다.")
         void existsByNameReturnFalse() {
-            boolean actual = memberJpaRepository.existsByName("kkk");
+            boolean actual = memberRepository.existsByName("kkk");
 
             assertThat(actual).isFalse();
         }

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -44,8 +44,7 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("성공 : id로 Member를 알아낼 수 있다.")
         void fetchByIdSuccess() {
-            Member member = MemberFixture.getFirstMember();
-            member = memberRepository.save(member);
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
 
             Member actual = memberRepository.fetchById(member.getId());
 
@@ -55,11 +54,11 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("실패 : 존재하지 않는 id인 경우 에러가 발생한다.")
         void fetchByIdFailByNotExistsId() {
-            long id = 100;
+            long notExistId = 100;
 
-            assertThatThrownBy(() -> memberRepository.fetchById(id))
+            assertThatThrownBy(() -> memberRepository.fetchById(notExistId))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("식별자 " + id + "에 해당하는 멤버가 존재하지 않습니다.");
+                    .hasMessage("식별자 " + notExistId + "에 해당하는 멤버가 존재하지 않습니다.");
         }
     }
 
@@ -69,8 +68,7 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("성공 : 닉네임으로 Member를 알아낼 수 있다.")
         void fetchByNameSuccess() {
-            Member member = MemberFixture.getFirstMember();
-            member = memberRepository.save(member);
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
 
             Member actual = memberRepository.fetchByName(member.getName());
 
@@ -80,11 +78,11 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("실패 : 존재하지 않는 닉네임인 경우 에러가 발생한다.")
         void fetchByNameFailByNotExistsId() {
-            String name = "켬미";
+            String notExistName = "켬미";
 
-            assertThatThrownBy(() -> memberRepository.fetchByName(name))
+            assertThatThrownBy(() -> memberRepository.fetchByName(notExistName))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("존재하지 않는 아이디 " + name + " 입니다.");
+                    .hasMessage("존재하지 않는 아이디 " + notExistName + " 입니다.");
         }
     }
 
@@ -131,7 +129,7 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("성공 : 해당 닉네임이 존재하지 않으면 false를 반환한다.")
         void existsByNameReturnFalse() {
-            boolean actual = memberRepository.existsByName("kkk");
+            boolean actual = memberRepository.existsByName("notExist");
 
             assertThat(actual).isFalse();
         }

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -34,7 +34,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("id로 Member 조회")
     class fetchById {
         @Test
-        @DisplayName("성공 : id로 Member를 알아낼 수 있다.")
+        @DisplayName("id로 Member 조회 성공 : id로 Member를 알아낼 수 있다.")
         void fetchByIdSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -44,7 +44,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패 : 존재하지 않는 id인 경우 에러가 발생한다.")
+        @DisplayName("id로 Member 조회 실패 : 존재하지 않는 id인 경우 에러가 발생한다.")
         void fetchByIdFailByNotExistsId() {
             long notExistId = 100;
 
@@ -58,7 +58,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("닉네임(아이디)로 Member 조회")
     class fetchByName {
         @Test
-        @DisplayName("성공 : 닉네임으로 Member를 알아낼 수 있다.")
+        @DisplayName("닉네임으로 Member 조회 성공 : 닉네임으로 Member를 알아낼 수 있다.")
         void fetchByNameSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -68,7 +68,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패 : 존재하지 않는 닉네임인 경우 에러가 발생한다.")
+        @DisplayName("닉네임으로 Member 조회 실패 : 존재하지 않는 닉네임인 경우 에러가 발생한다.")
         void fetchByNameFailByNotExistsId() {
             String notExistName = "켬미";
 
@@ -82,12 +82,11 @@ class MemberJpaRepositoryTest {
     @DisplayName("템플릿 id로 Member 조회")
     class fetchByTemplateId {
         @Test
-        @DisplayName("성공 : 템플릿 id로 Member를 알아낼 수 있다.")
+        @DisplayName("템플릿 id로 Member 조회 성공 : 템플릿 id로 Member를 알아낼 수 있다.")
         void fetchByTemplateIdSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
             Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            Template template = new Template(member, "title", "description", category);
-            template = templateRepository.save(template);
+            Template template = templateRepository.save(new Template(member, "title", "description", category));
 
             Member actual = memberRepository.fetchByTemplateId(template.getId());
 
@@ -95,7 +94,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패 : 존재하지 않는 템플릿 id인 경우 에러가 발생한다.")
+        @DisplayName("템플릿 id로 Member 조회 실패 : 존재하지 않는 템플릿 id인 경우 에러가 발생한다.")
         void fetchByTemplateIdFailByNotExistsId() {
             long id = 100;
 
@@ -109,7 +108,7 @@ class MemberJpaRepositoryTest {
     @DisplayName("닉네임(아이디) 존재 여부")
     class existsByName {
         @Test
-        @DisplayName("성공 : 해당 닉네임이 존재하면 true를 반환한다.")
+        @DisplayName("닉네임 존재 여부 성공 : 해당 닉네임이 존재하면 true를 반환한다.")
         void existsByNameReturnTrue() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -119,7 +118,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("성공 : 해당 닉네임이 존재하지 않으면 false를 반환한다.")
+        @DisplayName("닉네임 존재 여부 성공 : 해당 닉네임이 존재하지 않으면 false를 반환한다.")
         void existsByNameReturnFalse() {
             boolean actual = memberRepository.existsByName("notExist");
 

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -1,8 +1,12 @@
 package codezap.member.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.Optional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -10,9 +14,10 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryJpaRepository;
 import codezap.fixture.CategoryFixture;
+import codezap.fixture.MemberFixture;
+import codezap.global.exception.CodeZapException;
 import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
-import codezap.member.fixture.MemberFixture;
 import codezap.template.domain.Template;
 import codezap.template.repository.TemplateJpaRepository;
 
@@ -24,7 +29,9 @@ class MemberJpaRepositoryTest {
     private final CategoryJpaRepository categoryJpaRepository;
 
     @Autowired
-    MemberJpaRepositoryTest(MemberJpaRepository memberJpaRepository, TemplateJpaRepository templateJpaRepository,
+    MemberJpaRepositoryTest(
+            MemberJpaRepository memberJpaRepository,
+            TemplateJpaRepository templateJpaRepository,
             CategoryJpaRepository categoryJpaRepository
     ) {
         this.memberJpaRepository = memberJpaRepository;
@@ -32,14 +39,152 @@ class MemberJpaRepositoryTest {
         this.categoryJpaRepository = categoryJpaRepository;
     }
 
-    @Test
-    void fetchByTemplateId() {
-        // Then
-        Member member = ((JpaRepository<Member, Long>)memberJpaRepository).save(MemberFixture.memberFixture());
-        Category category = ((JpaRepository<Category, Long>)categoryJpaRepository).save(CategoryFixture.getFirstCategory());
-        Template template = new Template(member, "title", "description", category);
-        Template savedTemplate = ((JpaRepository<Template, Long>)templateJpaRepository).save(template);
+    @Nested
+    @DisplayName("id로 Member 조회")
+    class fetchById {
+        @Test
+        @DisplayName("성공 : id로 Member를 알아낼 수 있다.")
+        void fetchByIdSuccess() {
+            Member member = MemberFixture.getFirstMember();
+            member = ((JpaRepository<Member, Long>) memberJpaRepository).save(member);
 
-        assertThat(memberJpaRepository.fetchByTemplateId(savedTemplate.getId())).isEqualTo(member);
+            Member actual = memberJpaRepository.fetchById(member.getId());
+
+            assertThat(actual).isEqualTo(member);
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 id인 경우 에러가 발생한다.")
+        void fetchByIdFailByNotExistsId() {
+            long id = 100;
+
+            assertThatThrownBy(() -> memberJpaRepository.fetchById(id))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("식별자 " + id + "에 해당하는 멤버가 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("아이디로 Member 조회")
+    class fetchByName {
+        @Test
+        @DisplayName("성공 : 아이디로 Member를 알아낼 수 있다.")
+        void fetchByNameSuccess() {
+            Member member = MemberFixture.getFirstMember();
+            member = ((JpaRepository<Member, Long>) memberJpaRepository).save(member);
+
+            Member actual = memberJpaRepository.fetchByName(member.getName());
+
+            assertThat(actual).isEqualTo(member);
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 아이디인 경우 에러가 발생한다.")
+        void fetchByNameFailByNotExistsId() {
+            String name = "켬미";
+
+            assertThatThrownBy(() -> memberJpaRepository.fetchByName(name))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("존재하지 않는 아이디 " + name + " 입니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("아이디로 Member 조회")
+    class findByName {
+        @Test
+        @DisplayName("성공 : 아이디로 Member를 알아낼 수 있다.")
+        void findByNameSuccess() {
+            Member member = MemberFixture.getFirstMember();
+            member = ((JpaRepository<Member, Long>) memberJpaRepository).save(member);
+
+            Optional<Member> actual = memberJpaRepository.findByName(member.getName());
+
+            assertThat(actual).isEqualTo(Optional.of(member));
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 아이디인 경우 optional 값이 반환된다.")
+        void findByNameFailByNotExistsId() {
+            Optional<Member> actual = memberJpaRepository.findByName("kyummi");
+
+            assertThat(actual).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 id로 Member 조회")
+    class fetchByTemplateId {
+        @Test
+        @DisplayName("성공 : 템플릿 id로 Member를 알아낼 수 있다.")
+        void fetchByTemplateIdSuccess() {
+            Member member = ((JpaRepository<Member, Long>) memberJpaRepository).save(MemberFixture.getFirstMember());
+            Category category = ((JpaRepository<Category, Long>) categoryJpaRepository).save(
+                    CategoryFixture.getFirstCategory());
+            Template template = new Template(member, "title", "description", category);
+            template = ((JpaRepository<Template, Long>) templateJpaRepository).save(template);
+
+            Member actual = memberJpaRepository.fetchByTemplateId(template.getId());
+
+            assertThat(actual).isEqualTo(member);
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 템플릿 id인 경우 에러가 발생한다.")
+        void fetchByTemplateIdFailByNotExistsId() {
+            long id = 100;
+
+            assertThatThrownBy(() -> memberJpaRepository.fetchByTemplateId(id))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("템플릿에 대한 멤버가 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 id로 Member 조회")
+    class findByTemplateId {
+        @Test
+        @DisplayName("성공 : 템플릿 id로 Member를 알아낼 수 있다.")
+        void findByTemplateIdSuccess() {
+            Member member = ((JpaRepository<Member, Long>) memberJpaRepository).save(MemberFixture.getFirstMember());
+            Category category = ((JpaRepository<Category, Long>) categoryJpaRepository).save(
+                    CategoryFixture.getFirstCategory());
+            Template template = new Template(member, "title", "description", category);
+            template = ((JpaRepository<Template, Long>) templateJpaRepository).save(template);
+
+            Optional<Member> actual = memberJpaRepository.findByTemplateId(template.getId());
+
+            assertThat(actual).isEqualTo(Optional.of(member));
+        }
+
+        @Test
+        @DisplayName("실패 : 존재하지 않는 템플릿 id인 경우 optional 값이 반환된다.")
+        void findByTemplateIdFailByNotExistsId() {
+            Optional<Member> actual = memberJpaRepository.findByTemplateId(100L);
+
+            assertThat(actual).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("아이디가 존재 여부")
+    class existsByName {
+        @Test
+        @DisplayName("성공 : 해당 아이디가 존재하면 true를 반환한다.")
+        void existsByNameReturnTrue() {
+            Member member = ((JpaRepository<Member, Long>) memberJpaRepository).save(MemberFixture.getFirstMember());
+
+            boolean actual = memberJpaRepository.existsByName(member.getName());
+
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공 : 해당 아이디가 존재하면 false를 반환한다.")
+        void existsByNameReturnFalse() {
+            boolean actual = memberJpaRepository.existsByName("kkk");
+
+            assertThat(actual).isFalse();
+        }
     }
 }

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -64,10 +64,10 @@ class MemberJpaRepositoryTest {
     }
 
     @Nested
-    @DisplayName("아이디로 Member 조회")
+    @DisplayName("닉네임(아이디)로 Member 조회")
     class fetchByName {
         @Test
-        @DisplayName("성공 : 아이디로 Member를 알아낼 수 있다.")
+        @DisplayName("성공 : 닉네임으로 Member를 알아낼 수 있다.")
         void fetchByNameSuccess() {
             Member member = MemberFixture.getFirstMember();
             member = memberRepository.save(member);
@@ -78,7 +78,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패 : 존재하지 않는 아이디인 경우 에러가 발생한다.")
+        @DisplayName("실패 : 존재하지 않는 닉네임인 경우 에러가 발생한다.")
         void fetchByNameFailByNotExistsId() {
             String name = "켬미";
 
@@ -116,10 +116,10 @@ class MemberJpaRepositoryTest {
     }
 
     @Nested
-    @DisplayName("아이디가 존재 여부")
+    @DisplayName("닉네임(아이디) 존재 여부")
     class existsByName {
         @Test
-        @DisplayName("성공 : 해당 아이디가 존재하면 true를 반환한다.")
+        @DisplayName("성공 : 해당 닉네임이 존재하면 true를 반환한다.")
         void existsByNameReturnTrue() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
 
@@ -129,7 +129,7 @@ class MemberJpaRepositoryTest {
         }
 
         @Test
-        @DisplayName("성공 : 해당 아이디가 존재하면 false를 반환한다.")
+        @DisplayName("성공 : 해당 닉네임이 존재하지 않으면 false를 반환한다.")
         void existsByNameReturnFalse() {
             boolean actual = memberRepository.existsByName("kkk");
 

--- a/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberJpaRepositoryTest.java
@@ -96,9 +96,9 @@ class MemberJpaRepositoryTest {
         @Test
         @DisplayName("템플릿 id로 Member 조회 실패 : 존재하지 않는 템플릿 id인 경우 에러가 발생한다.")
         void fetchByTemplateIdFailByNotExistsId() {
-            long id = 100;
+            long notExistId = 100;
 
-            assertThatThrownBy(() -> memberRepository.fetchByTemplateId(id))
+            assertThatThrownBy(() -> memberRepository.fetchByTemplateId(notExistId))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("템플릿에 대한 멤버가 존재하지 않습니다.");
         }


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #620 

## 📍주요 변경 사항
MemberJpaRepository 관련 테스트 구현
- 메서드 이름 및 쿼리를 직접 작성한 메서드에 대해 테스트를 작성

## 🎸기타

## 문제 있었음 -> 결론 제우스가 도와줌 내 yml 파일 설정 문제 !

### 테스트 처음 실행 시 정상 실행 (DB에 테이블 없는 상태에서)
![image](https://github.com/user-attachments/assets/27415cdb-fbc1-4af4-a45b-c74b600045bc)

### 두번 째 실행부터 Flyway 에러 발생 
![image](https://github.com/user-attachments/assets/9bdc3137-1533-4432-9e48-91f9fd05382f)

#### 문제 원인
- V1__init.sql 실행으로 문제 발생 -> 테이블이 이미 존재해서 에러

#### 의문점 - 왜 V1__init.sql 이 계속 실행되는가?  
  - Flyway는 각 마이그레이션 파일에 고유한 버전을 부여하며, 이 버전이 flyway_schema_history 테이블에 기록된 경우 동일한 버전의 스크립트는 재실행되지 않는다. 
  -  flyway_schema_history 확인하면 version 1 등록되어 있음
  - ![image](https://github.com/user-attachments/assets/dc0f60c1-e608-41d6-b5b9-51c13768831d)

#### 나만 그러면 도와줄 친구 찾음. applicaton-db.yml 파일을 dev 서버와 동일하게 변경해도 안됨

### 해결 

@zeus6768 가 도와줌

#### 1차 결론
결론 : applicatoin-db.yml 파일을 test 패키지에 구현하지 않았음. 
줄줄 이야기 해봐요 :
test 패키지에 yml 파일이 하나라도 구현했다면 사용하는 모든 yml 파일을 새롭게 구현해야 했음.
하지만 그걸 모르고 applicatoin-db.yml 파일을 test 패키지에 구현하지 않았음. 
application-db.yml 파일을 test 패키지에 추가하고 나니 해결

#### 2차 결론
1차 결론 후 또 안됨, create-drop 이 아닌 validate인 경우 안됨
초켬제 머리 합친 결과 : 몰리가 구현해준 test annotaiton이랑 충돌하나로 결론
1. 몰리가 구현해준 어노테이션 실행 시키면 모든 테이블 드랍하는 거와 flyway 충돌
2. 테스트에서는 creat-drop 으로 하기로 함 ~