### PR TITLE
ThumbnailRepositoryTest 구현

### DIFF
--- a/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
@@ -38,11 +38,11 @@ public class ThumbnailRepositoryTest {
     private ThumbnailRepository sut;
 
     @Nested
-    @DisplayName("id로 썸네일 조회")
+    @DisplayName("썸네일 id로 썸네일 조회")
     class FetchById {
 
         @Test
-        @DisplayName("성공: id로 썸네일 조회")
+        @DisplayName("썸네일 id로 썸네일 조회 성공")
         void fetchByIdSuccess() {
             // given
             var member = memberRepository.save(MemberFixture.getFirstMember());
@@ -59,7 +59,7 @@ public class ThumbnailRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패: 존재하지 않는 id로 썸네일 조회")
+        @DisplayName("썸네일 id로 썸네일 조회 실패: 존재하지 않는 id")
         void fetchByIdFail() {
             var notExistId = 100L;
 
@@ -74,7 +74,7 @@ public class ThumbnailRepositoryTest {
     class FetchByTemplate {
 
         @Test
-        @DisplayName("성공: 템플릿으로 썸네일 조회")
+        @DisplayName("템플릿으로 썸네일 조회 성공")
         void fetchByTemplateSuccess() {
             // given
             var member = memberRepository.save(MemberFixture.getFirstMember());
@@ -96,7 +96,7 @@ public class ThumbnailRepositoryTest {
     class DeleteByTemplateId {
 
         @Test
-        @DisplayName("성공: 템플릿 id로 썸네일 삭제")
+        @DisplayName("템플릿 id로 썸네일 삭제 성공")
         void deleteByTemplateIdSuccess() {
             // given
             var member = memberRepository.save(MemberFixture.getFirstMember());
@@ -115,7 +115,7 @@ public class ThumbnailRepositoryTest {
         }
 
         @Test
-        @DisplayName("성공: 존재하지 않는 템플릿의 id로 삭제해도 예외로 처리하지 않는다.")
+        @DisplayName("템플릿 id로 썸네일 삭제 성공: 존재하지 않는 템플릿의 id로 삭제해도 예외로 처리하지 않는다.")
         void deleteByNotExistTemplateId() {
             assertThatCode(() -> sut.deleteByTemplateId(100L))
                     .doesNotThrowAnyException();

--- a/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
@@ -1,0 +1,131 @@
+package codezap.template.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.global.exception.CodeZapException;
+import codezap.global.repository.JpaRepositoryTest;
+import codezap.member.domain.Member;
+import codezap.member.repository.MemberRepository;
+import codezap.template.domain.SourceCode;
+import codezap.template.domain.Template;
+import codezap.template.domain.Thumbnail;
+
+@JpaRepositoryTest
+public class ThumbnailRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private SourceCodeRepository sourceCodeRepository;
+
+    @Autowired
+    private ThumbnailRepository sut;
+
+    @Nested
+    @DisplayName("id로 썸네일 조회")
+    class FetchById {
+
+        @Test
+        @DisplayName("성공: id로 썸네일 조회")
+        void fetchByIdSuccess() {
+            // given
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category = Category.createDefaultCategory(member);
+            categoryRepository.save(category);
+            var template = new Template(member, "Template Title", "Description", category);
+            templateRepository.save(template);
+            var sourceCode = new SourceCode(template, "filename", "content", 1);
+            sourceCodeRepository.save(sourceCode);
+            var thumbnail = new Thumbnail(template, sourceCode);
+            sut.save(thumbnail);
+
+            // when
+            var actual = sut.fetchById(thumbnail.getId());
+
+            // then
+            assertThat(actual).isEqualTo(thumbnail);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 id로 썸네일 조회")
+        void fetchByIdFail() {
+            var id = 100L;
+
+            assertThatThrownBy(() -> sut.fetchById(id))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("식별자 " + id + "에 해당하는 썸네일이 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿으로 썸네일 조회")
+    class FetchByTemplate {
+
+        @Test
+        @DisplayName("성공: 템플릿으로 썸네일 조회")
+        void fetchByTemplateSuccess() {
+            // given
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category = Category.createDefaultCategory(member);
+            categoryRepository.save(category);
+            var template = new Template(member, "Template Title", "Description", category);
+            templateRepository.save(template);
+            var sourceCode = new SourceCode(template, "filename", "content", 1);
+            sourceCodeRepository.save(sourceCode);
+            var thumbnail = new Thumbnail(template, sourceCode);
+
+            // when
+            sut.save(thumbnail);
+
+            // then
+            var actual = sut.fetchByTemplate(template);
+            assertThat(actual).isEqualTo(thumbnail);
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 id로 썸네일 삭제")
+    class DeleteByTemplateId {
+
+        @Test
+        @DisplayName("성공: 템플릿 id로 썸네일 삭제")
+        void deleteByTemplateIdSuccess() {
+            // given
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category = Category.createDefaultCategory(member);
+            categoryRepository.save(category);
+            var template = new Template(member, "Template Title", "Description", category);
+            templateRepository.save(template);
+            var sourceCode = new SourceCode(template, "filename", "content", 1);
+            sourceCodeRepository.save(sourceCode);
+            var thumbnail = new Thumbnail(template, sourceCode);
+            sut.save(thumbnail);
+
+            // when
+            sut.deleteByTemplateId(template.getId());
+
+            // then
+            assertThatThrownBy(() -> sut.fetchById(template.getId()))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("식별자 " + 1 + "에 해당하는 썸네일이 존재하지 않습니다.");
+        }
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
#620

## 변수명 `sut`
- `ThumbnailRepository` 객체는 `sut`로 변수명을 선언했습니다. SUT는 'System Under Test'의 약자로, 테스트의 대상이 되는 객체를 의미합니다. 
- 테스트에서 선언된 변수명이 많을 때 테스트 대상을 빠르게 찾기 위해 일관된 변수명을 사용합니다. 
- 출처: [단위 테스트](https://m.yes24.com/Goods/Detail/104084175) 56p, 87p.

## 📍주요 변경 사항
- 기존에 Thumbnail 도메인에 대한 레포 테스트가 존재하지 않았습니다. 
- 이에 구현합니다. 
