### PR TITLE
CategoryRepositoryTest 구현

### DIFF
--- a/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
@@ -2,6 +2,7 @@ package codezap.category.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -30,7 +31,7 @@ public class CategoryRepositoryTest {
     class FetchById {
 
         @Test
-        @DisplayName("성공: id로 카테고리를 조회할 수 있다.")
+        @DisplayName("Id로 카테고리 조회 성공")
         void fetchByIdSuccess() {
             memberRepository.save(MemberFixture.getFirstMember());
             var category = sut.save(CategoryFixture.getFirstCategory());
@@ -41,7 +42,7 @@ public class CategoryRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패: 존재하지 않는 id로 조회할 경우 예외 발생")
+        @DisplayName("Id로 카테고리 조회 실패: 존재하지 않는 id")
         void fetchByIdFail() {
             var notExistId = 100L;
             assertThatThrownBy(() -> sut.fetchById(notExistId))
@@ -55,18 +56,27 @@ public class CategoryRepositoryTest {
     class FindAllByMemberOrderById {
 
         @Test
-        @DisplayName("성공: 회원의 모든 카테고리를 id 오름차순으로 조회할 수 있다.")
+        @DisplayName("회원의 모든 카테고리를 오름차순으로 조회 성공")
         void findAllByMemberOrderByIdSuccess() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = sut.save(new Category("category1", member));
-            var category2 = sut.save(new Category("category2", member));
-            var category3 = sut.save(new Category("category3", member));
-            var category4 = sut.save(new Category("category4", member));
-            var category5 = sut.save(new Category("category5", member));
+            // given
+            var member1 = memberRepository.save(MemberFixture.getFirstMember());
+            var category1 = sut.save(new Category("category1", member1));
+            var category3 = sut.save(new Category("category3", member1));
+            var category5 = sut.save(new Category("category5", member1));
 
-            var actual = sut.findAllByMemberOrderById(member);
+            var member2 = memberRepository.save(MemberFixture.getSecondMember());
+            var category2 = sut.save(new Category("category2", member2));
+            var category4 = sut.save(new Category("category4", member2));
 
-            assertThat(actual).containsExactly(category1, category2, category3, category4, category5);
+            // when
+            var actual1 = sut.findAllByMemberOrderById(member1);
+            var actual2 = sut.findAllByMemberOrderById(member2);
+
+            // then
+            assertAll(
+                    () -> assertThat(actual1).containsExactly(category1, category3, category5),
+                    () -> assertThat(actual2).containsExactly(category2, category4)
+            );
         }
     }
 
@@ -75,7 +85,7 @@ public class CategoryRepositoryTest {
     class ExistsByNameAndMember {
 
         @Test
-        @DisplayName("성공: 카테고리 이름과 회원으로 해당 카테고리가 존재하는지 조회")
+        @DisplayName("카테고리 이름과 회원으로 해당 카테고리가 존재하는지 조회 성공")
         void existsByNameAndMemberSuccess() {
             var member = new Member("Zappy", "password", "salt");
             memberRepository.save(member);
@@ -88,7 +98,7 @@ public class CategoryRepositoryTest {
         }
 
         @Test
-        @DisplayName("실패: 일치하는 카테고리가 없을 경우")
+        @DisplayName("카테고리 이름과 회원으로 해당 카테고리가 존재하는지 조회 성공: 일치하는 카테고리 없음")
         void existsByNameAndMemberFail() {
             var member = new Member("Zappy", "password", "salt");
             memberRepository.save(member);

--- a/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
@@ -9,6 +9,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import codezap.category.domain.Category;
+import codezap.fixture.CategoryFixture;
+import codezap.fixture.MemberFixture;
 import codezap.global.exception.CodeZapException;
 import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
@@ -30,10 +32,8 @@ public class CategoryRepositoryTest {
         @Test
         @DisplayName("성공: id로 카테고리를 조회할 수 있다.")
         void fetchByIdSuccess() {
-            var member = new Member("Zappy", "password", "salt");
-            memberRepository.save(member);
-            var category = new Category("category1", member);
-            sut.save(category);
+            memberRepository.save(MemberFixture.getFirstMember());
+            var category = sut.save(CategoryFixture.getFirstCategory());
 
             var actual = sut.fetchById(category.getId());
 

--- a/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import codezap.category.domain.Category;
+import codezap.global.exception.CodeZapException;
 import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
@@ -44,7 +45,7 @@ public class CategoryRepositoryTest {
         void fetchByIdFail() {
             var id = 100L;
             assertThatThrownBy(() -> sut.fetchById(id))
-                    .isInstanceOf(IllegalArgumentException.class)
+                    .isInstanceOf(CodeZapException.class)
                     .hasMessage("식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다.");
         }
     }

--- a/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
@@ -1,0 +1,104 @@
+package codezap.category.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import codezap.category.domain.Category;
+import codezap.global.repository.JpaRepositoryTest;
+import codezap.member.domain.Member;
+import codezap.member.repository.MemberRepository;
+
+@JpaRepositoryTest
+public class CategoryRepositoryTest {
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private CategoryRepository sut;
+
+    @Nested
+    @DisplayName("Id로 카테고리 조회")
+    class FetchById {
+
+        @Test
+        @DisplayName("성공: id로 카테고리를 조회할 수 있다.")
+        void fetchByIdSuccess() {
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category = new Category("category1", member);
+            sut.save(category);
+
+            var actual = sut.fetchById(category.getId());
+
+            assertThat(actual).isEqualTo(category);
+        }
+
+        @Test
+        @DisplayName("실패: 존재하지 않는 id로 조회할 경우 예외 발생")
+        void fetchByIdFail() {
+            var id = 100L;
+            assertThatThrownBy(() -> sut.fetchById(id))
+                    .isInstanceOf(IllegalArgumentException.class)
+                    .hasMessage("식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("회원의 모든 카테고리를 오름차순으로 조회")
+    class FindAllByMemberOrderById {
+
+        @Test
+        @DisplayName("성공: 회원의 모든 카테고리를 id 오름차순으로 조회할 수 있다.")
+        void findAllByMemberOrderByIdSuccess() {
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category1 = new Category("category1", member);
+            sut.save(category1);
+            var category2 = new Category("category2", member);
+            sut.save(category2);
+            var category3 = new Category("category3", member);
+            sut.save(category3);
+
+            var actual = sut.findAllByMemberOrderById(member);
+
+            assertThat(actual).containsExactly(category1, category2, category3);
+        }
+    }
+
+    @Nested
+    @DisplayName("카테고리 이름과 회원으로 해당 카테고리가 존재하는지 조회")
+    class ExistsByNameAndMember {
+
+        @Test
+        @DisplayName("성공: 카테고리 이름과 회원으로 해당 카테고리가 존재하는지 조회")
+        void existsByNameAndMemberSuccess() {
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category1 = new Category("category1", member);
+            sut.save(category1);
+
+            var actual = sut.existsByNameAndMember("category1", member);
+
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        @DisplayName("실패: 일치하는 카테고리가 없을 경우")
+        void existsByNameAndMemberFail() {
+            var member = new Member("Zappy", "password", "salt");
+            memberRepository.save(member);
+            var category1 = new Category("category1", member);
+            sut.save(category1);
+
+            var actual = sut.existsByNameAndMember("category2", member);
+
+            assertThat(actual).isFalse();
+        }
+    }
+}

--- a/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
@@ -43,10 +43,10 @@ public class CategoryRepositoryTest {
         @Test
         @DisplayName("실패: 존재하지 않는 id로 조회할 경우 예외 발생")
         void fetchByIdFail() {
-            var id = 100L;
-            assertThatThrownBy(() -> sut.fetchById(id))
+            var notExistId = 100L;
+            assertThatThrownBy(() -> sut.fetchById(notExistId))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("식별자 " + id + "에 해당하는 카테고리가 존재하지 않습니다.");
+                    .hasMessage("식별자 " + notExistId + "에 해당하는 카테고리가 존재하지 않습니다.");
         }
     }
 
@@ -57,18 +57,16 @@ public class CategoryRepositoryTest {
         @Test
         @DisplayName("성공: 회원의 모든 카테고리를 id 오름차순으로 조회할 수 있다.")
         void findAllByMemberOrderByIdSuccess() {
-            var member = new Member("Zappy", "password", "salt");
-            memberRepository.save(member);
-            var category1 = new Category("category1", member);
-            sut.save(category1);
-            var category2 = new Category("category2", member);
-            sut.save(category2);
-            var category3 = new Category("category3", member);
-            sut.save(category3);
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category1 = sut.save(new Category("category1", member));
+            var category2 = sut.save(new Category("category2", member));
+            var category3 = sut.save(new Category("category3", member));
+            var category4 = sut.save(new Category("category4", member));
+            var category5 = sut.save(new Category("category5", member));
 
             var actual = sut.findAllByMemberOrderById(member);
 
-            assertThat(actual).containsExactly(category1, category2, category3);
+            assertThat(actual).containsExactly(category1, category2, category3, category4, category5);
         }
     }
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
#620

## 변수명 `sut`
#627 에 해당 변수명을 사용한 이유를 명시했습니다. 

## 📍주요 변경 사항
- 기존에 Category 도메인에 대한 레포 테스트가 존재하지 않았습니다. 
- 이에 구현합니다. 
