### PR TITLE
Member Service 테스트 

### DIFF
--- a/backend/src/test/java/codezap/global/cors/CorsPropertiesTest.java
+++ b/backend/src/test/java/codezap/global/cors/CorsPropertiesTest.java
@@ -1,18 +1,11 @@
 package codezap.global.cors;
 
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.*;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.properties.EnableConfigurationProperties;
-import org.springframework.boot.test.context.ConfigDataApplicationContextInitializer;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.ContextConfiguration;
-import org.springframework.test.context.TestPropertySource;
-import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 @SpringBootTest
 class CorsPropertiesTest {
@@ -29,6 +22,6 @@ class CorsPropertiesTest {
     @Test
     @DisplayName("yml 파일로부터 allowed-origins-patterns 값을 가져오는지 확인")
     void getAllowedOriginsPatterns() {
-        assertThat(corsProperties.getAllowedOriginsPatterns()).isEqualTo(new String[]{"*"});
+        assertThat(corsProperties.getAllowedOriginsPatterns()).isEqualTo(new String[]{""});
     }
 }

--- a/backend/src/test/java/codezap/global/cors/CorsPropertiesTest.java
+++ b/backend/src/test/java/codezap/global/cors/CorsPropertiesTest.java
@@ -29,6 +29,6 @@ class CorsPropertiesTest {
     @Test
     @DisplayName("yml 파일로부터 allowed-origins-patterns 값을 가져오는지 확인")
     void getAllowedOriginsPatterns() {
-        assertThat(corsProperties.getAllowedOriginsPatterns()).isEqualTo(new String[]{""});
+        assertThat(corsProperties.getAllowedOriginsPatterns()).isEqualTo(new String[]{"*"});
     }
 }

--- a/backend/src/test/java/codezap/global/repository/JpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/global/repository/JpaRepositoryTest.java
@@ -8,7 +8,6 @@ import java.lang.annotation.Target;
 import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
-import org.springframework.test.context.ActiveProfiles;
 
 import codezap.global.DatabaseIsolation;
 import codezap.global.auditing.JpaAuditingConfiguration;

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -75,11 +75,11 @@ class MemberServiceTest {
 
     @Nested
     @DisplayName("아이디 중복 검사 테스트")
-    class AssertUniquename {
+    class AssertUniqueName {
 
         @Test
         @DisplayName("아이디 중복 검사 통과: 사용가능한 아이디")
-        void assertUniquename() {
+        void assertUniqueName() {
             String name = "code";
 
             assertThatCode(() -> memberService.assertUniqueName(name))
@@ -88,7 +88,7 @@ class MemberServiceTest {
 
         @Test
         @DisplayName("아이디 중복 검사 실패: 중복된 아이디")
-        void assertUniquename_fail_duplicate() {
+        void assertUniqueName_fail_duplicate() {
             Member member = memberRepository.save(MemberFixture.memberFixture());
             String memberName = member.getName();
 
@@ -100,7 +100,7 @@ class MemberServiceTest {
 
     @Nested
     @DisplayName("회원 조회 테스트")
-    class findMember {
+    class FindMember {
 
         @Test
         @DisplayName("회원 정보 조회 성공")
@@ -139,7 +139,7 @@ class MemberServiceTest {
 
     @Nested
     @DisplayName("템플릿을 소유한 멤버 조회")
-    class getByTemplateId {
+    class GetByTemplateId {
         @Test
         @DisplayName("템플릿을 소유한 멤버 조회 성공")
         void getByTemplateId() {
@@ -163,7 +163,7 @@ class MemberServiceTest {
 
     @Nested
     @DisplayName("아이디로 멤버 조회")
-    class getById {
+    class GetById {
         @Test
         @DisplayName("아이디로 멤버 조회 성공")
         void getById() {

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import codezap.category.domain.Category;
@@ -28,6 +29,7 @@ import codezap.template.repository.TemplateRepository;
 
 @SpringBootTest
 @DatabaseIsolation
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberServiceTest {
 
     @Autowired

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -9,8 +9,8 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
@@ -27,9 +27,8 @@ import codezap.member.repository.MemberRepository;
 import codezap.template.domain.Template;
 import codezap.template.repository.TemplateRepository;
 
-@SpringBootTest
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DatabaseIsolation
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberServiceTest {
 
     @Autowired

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -10,9 +10,12 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
 import org.springframework.boot.test.web.server.LocalServerPort;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.annotation.DirtiesContext.MethodMode;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
@@ -32,6 +35,7 @@ import io.restassured.RestAssured;
 
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
 @DatabaseIsolation
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberServiceTest {
 
     @Autowired
@@ -184,7 +188,7 @@ class MemberServiceTest {
         }
 
         @Test
-        @DisplayName("아이디로 멤버 조회 실패 : ")
+        @DisplayName("아이디로 멤버 조회 실패 : 존재하지 않는 아이디")
         void getById_Fail() {
             Long notExitsId = 100L;
 

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -5,17 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
-import org.springframework.boot.test.web.server.LocalServerPort;
-import org.springframework.test.annotation.DirtiesContext;
-import org.springframework.test.annotation.DirtiesContext.MethodMode;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
@@ -31,11 +25,9 @@ import codezap.member.fixture.MemberFixture;
 import codezap.member.repository.MemberRepository;
 import codezap.template.domain.Template;
 import codezap.template.repository.TemplateRepository;
-import io.restassured.RestAssured;
 
-@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@SpringBootTest
 @DatabaseIsolation
-@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 class MemberServiceTest {
 
     @Autowired
@@ -50,14 +42,6 @@ class MemberServiceTest {
     @Autowired
     private MemberService memberService;
 
-    @LocalServerPort
-    int port;
-
-    @BeforeEach
-    void setUp() {
-        RestAssured.port = port;
-    }
-
     @Nested
     @DisplayName("회원가입 테스트")
     class SignupTest {
@@ -68,9 +52,12 @@ class MemberServiceTest {
             Member member = MemberFixture.memberFixture();
             SignupRequest signupRequest = new SignupRequest(member.getName(), member.getPassword());
 
+            Long savedId = memberService.signup(signupRequest);
+
+            boolean isDefaultCategory = categoryRepository.existsByNameAndMember("카테고리 없음", member);
             assertAll(
-                    () -> assertThat(memberService.signup(signupRequest)).isEqualTo(member.getId()),
-                    () -> assertThat(categoryRepository.existsByNameAndMember("카테고리 없음", member)).isTrue()
+                    () -> assertThat(savedId).isEqualTo(member.getId()),
+                    () -> assertThat(isDefaultCategory).isTrue()
             );
         }
 

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -156,7 +156,9 @@ class MemberServiceTest {
         @Test
         @DisplayName("템플릿을 소유한 멤버 조회 실패 : DB에 없는 템플릿인 경우")
         void getByTemplateId_Fail() {
-            assertThatCode(() -> memberService.getByTemplateId(100L))
+            Long notExistsId = 100L;
+
+            assertThatCode(() -> memberService.getByTemplateId(notExistsId))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("템플릿에 대한 멤버가 존재하지 않습니다.");
         }

--- a/backend/src/test/resources/application-local.yml
+++ b/backend/src/test/resources/application-local.yml
@@ -3,4 +3,6 @@ spring:
     ansi:
       enabled: always
 cors:
-  allowed-origins: http://localhost:3000
+  allowed-origins:
+    - http://localhost:3000
+  allowed-origins-patterns: http://*

--- a/backend/src/test/resources/application-local.yml
+++ b/backend/src/test/resources/application-local.yml
@@ -3,6 +3,4 @@ spring:
     ansi:
       enabled: always
 cors:
-  allowed-origins:
-    - http://localhost:3000
-  allowed-origins-patterns: http://*
+  allowed-origins: http://localhost:3000


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #645 

## 📍주요 변경 사항
MemberService Test 보충 및 MemberServiceTest 실제 DB 사용으로 변경

## 🎸기타
### 테스트 고민
Repository 단에서 나는 에러 처리도 서비스 테스트에서 확인하는게 맞을지 의문이 들긴합니다.
일단 추가하긴했는데 함께 고민하면 좋을 것 같아요 여러분들의 의견은 어떤가요?

### CI 문제

> **요약 정리**
> `@SpringBootTest` 환경 설정 MOCK으로 하고 `@AutoConfigureTestDatabase` 설정 안하면 문제 해결
> BUT, 이게 맞을까 싶음

#### 문제 해결 방법 찾음, BUT 이게 맞을까? -> 동일하게 바꾸면 CI 통과함
몰리 PR을 보니 CI 문제가 발생 안함.
그래서 뭐가 다른지 확인해보니 몰리는 기본 설정인 MOCK 사용하고, `@AutoConfigureTestDatabase` 설정이 없음

##### 1. `@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)` 랜덤 포트 문제

그래서 바꿔보니 해결 되네..? 왜 RANDOM_PORT 에서 문제가 발생할까요? 실제 환경이랑 동일하게 테스트하고 싶은 저희 욕구에 맞추려면 RANDOM_PORT를 사용하는게 좋을 것같은데 문제가 발생해서 애매하네요.. ㅜ

##### ~~2. `@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)` 설정 추가하면 문제~~

~~실제 DB를 사용하려면 해당 어노테이션 추가해야하지 않나요? 그런데 추가하면 에러 발생함~~
~~제가 해당 어노테이션에 대해 다음과 같이 이해했는데 잘못된 정보가 있거나 해당 어노테이션이 없어도 DB를 잘 사용한다는 게 보장된다면 지우겠습니다~~

~~- 없을 때: Spring Boot는 테스트 실행 시 기본적으로 임베디드 데이터베이스를 사용하며, 빠르게 실행되지만 실제 DB 환경과 차이가 있을 수 있음.~~
~~- 있을 때: 실제 데이터베이스를 그대로 사용하여 운영 환경과 더 유사한 테스트가 가능하지만, 속도가 느릴 수 있음.~~

실제로 찾아보니 해당 어노테이션은 없어도 될 것 같아요 !

위에 실제 DB를 사용하지 않는다는 조건은 `@DataJpaTest` 테스트 시에만 유효하네요 ! 그래서 `@DataJpaTest` 이 아니라면 db.yml 설정에 맞게 실제 DB를 사용한다고 합니다 ! 

#### 둘 다 추가했을 때 나는 에러는 뭘까?

flyway 설정 문제가 발생 문제 인가?
CI 작동 시 나는 에러를 chatGPT한테 물어보니 flyway 문제라고 진단하네요.
로컬에서는 잘 작동해서 문제가 무엇인지 의문..

로컬에서 CI 에러를 똑같이 만드는 법은 db.yml 파일에서 flyway 로직을 제거하면 동일한 에러 발생
![image](https://github.com/user-attachments/assets/c697bca4-0b51-4907-915a-12a955e2241e)

그래서 CI의 db.yml 파일을 flyway 설정을 포함하도록 변경해봄
그래도 해결되지 않음..!