### PR TITLE
CategoryTemplateApplicationTest 추가

### DIFF
--- a/backend/src/test/java/codezap/global/ServiceTest.java
+++ b/backend/src/test/java/codezap/global/ServiceTest.java
@@ -1,0 +1,38 @@
+package codezap.global;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import codezap.category.repository.CategoryRepository;
+import codezap.member.repository.MemberRepository;
+import codezap.tag.repository.TagRepository;
+import codezap.tag.repository.TemplateTagRepository;
+import codezap.template.repository.SourceCodeRepository;
+import codezap.template.repository.TemplateRepository;
+import codezap.template.repository.ThumbnailRepository;
+
+@SpringBootTest
+@DatabaseIsolation
+public class ServiceTest {
+
+    @Autowired
+    protected MemberRepository memberRepository;
+
+    @Autowired
+    protected CategoryRepository categoryRepository;
+
+    @Autowired
+    protected TemplateRepository templateRepository;
+
+    @Autowired
+    protected TagRepository tagRepository;
+
+    @Autowired
+    protected TemplateTagRepository templateTagRepository;
+
+    @Autowired
+    protected SourceCodeRepository sourceCodeRepository;
+
+    @Autowired
+    protected ThumbnailRepository thumbnailRepository;
+}

--- a/backend/src/test/java/codezap/template/service/facade/CategoryTemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/CategoryTemplateApplicationServiceTest.java
@@ -1,0 +1,131 @@
+package codezap.template.service.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+
+import jakarta.transaction.Transactional;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import codezap.category.domain.Category;
+import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
+import codezap.global.ServiceTest;
+import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+import codezap.template.domain.SourceCode;
+import codezap.template.domain.Template;
+import codezap.template.domain.Thumbnail;
+import codezap.template.dto.request.CreateSourceCodeRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
+import codezap.template.dto.request.UpdateSourceCodeRequest;
+import codezap.template.dto.request.UpdateTemplateRequest;
+
+@Transactional
+class CategoryTemplateApplicationServiceTest extends ServiceTest {
+
+    @Autowired
+    private CategoryTemplateApplicationService categoryTemplateApplicationService;
+
+    @Nested
+    @DisplayName("템플릿 생성")
+    class CreateTemplate {
+
+        @Test
+        @DisplayName("성공: 작성자의 권한 확인 후 템플릿 생성")
+        void createTemplate_Success() {
+            // given
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
+            Category membersCategory = categoryRepository.save(new Category("Members", member));
+            List<CreateSourceCodeRequest> sourceCodeRequests = List.of(
+                    new CreateSourceCodeRequest("filename", "content", 1));
+            CreateTemplateRequest request = new CreateTemplateRequest(
+                    "Template", "Description", sourceCodeRequests, 1, membersCategory.getId(), List.of("태그"));
+
+            // when
+            Long result = categoryTemplateApplicationService.createTemplate(member, request);
+
+            // then
+            assertThat(result).isEqualTo(1L);
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리에 대한 권한이 없는 경우")
+        void createTemplate_Fail_NoAuthorization() {
+            // given
+            Member ownerMember = memberRepository.save(MemberFixture.getFirstMember());
+            Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
+            Category category = categoryRepository.save(new Category("Members", ownerMember));
+            List<CreateSourceCodeRequest> sourceCodeRequests = List.of(
+                    new CreateSourceCodeRequest("filename", "content", 1));
+            CreateTemplateRequest request = new CreateTemplateRequest(
+                    "Template", "Description", sourceCodeRequests, 1, category.getId(), List.of("태그"));
+
+            // when & then
+            assertThatThrownBy(() -> categoryTemplateApplicationService.createTemplate(otherMember, request))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("해당 카테고리에 대한 권한이 없습니다.");
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 수정")
+    class UpdateTemplate {
+
+        @Test
+        @DisplayName("성공")
+        void updateTemplate_Success() {
+            // given
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
+            Category category = categoryRepository.save(new Category("Members", member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
+            SourceCode sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename", "content", 1));
+            thumbnailRepository.save(new Thumbnail(template, sourceCode));
+            UpdateSourceCodeRequest updateSourceCodeRequest = new UpdateSourceCodeRequest(
+                    sourceCode.getId(), "Updated filename", "Updated content", 1);
+            UpdateTemplateRequest request = new UpdateTemplateRequest("Updated Template", "Updated Description", Collections.emptyList(),
+                    List.of(updateSourceCodeRequest), Collections.emptyList(), category.getId(), Collections.emptyList());
+
+            // when
+            categoryTemplateApplicationService.update(member, template.getId(), request);
+
+            // then
+            Template updatedTemplate = templateRepository.fetchById(template.getId());
+            assertAll(
+                    () -> assertEquals("Updated Template", updatedTemplate.getTitle()),
+                    () -> assertEquals("Updated Description", updatedTemplate.getDescription())
+            );
+        }
+
+        @Test
+        @DisplayName("실패: 카테고리에 대한 권한이 없는 경우")
+        void updateTemplate_WhenNoAuthorization() {
+            // given
+            Member otherMember = memberRepository.save(MemberFixture.getFirstMember());
+            Category othersCategory = categoryRepository.save(new Category("Members", otherMember));
+
+            Member member = memberRepository.save(MemberFixture.getSecondMember());
+            Category category = categoryRepository.save(new Category("Members", member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
+            SourceCode sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename", "content", 1));
+            thumbnailRepository.save(new Thumbnail(template, sourceCode));
+            UpdateSourceCodeRequest updateSourceCodeRequest = new UpdateSourceCodeRequest(
+                    sourceCode.getId(), "Updated filename", "Updated content", 1);
+            UpdateTemplateRequest request = new UpdateTemplateRequest("Updated Template", "Updated Description", Collections.emptyList(),
+                    List.of(updateSourceCodeRequest), Collections.emptyList(), othersCategory.getId(), Collections.emptyList());
+
+            // when & then
+            assertThatThrownBy(() -> categoryTemplateApplicationService.update(otherMember, template.getId(), request))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
+        }
+    }
+}

--- a/backend/src/test/java/codezap/template/service/facade/CategoryTemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/CategoryTemplateApplicationServiceTest.java
@@ -87,12 +87,14 @@ class CategoryTemplateApplicationServiceTest extends ServiceTest {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
             Category category = categoryRepository.save(new Category("Members", member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
+
             SourceCode sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename", "content", 1));
             thumbnailRepository.save(new Thumbnail(template, sourceCode));
-            UpdateSourceCodeRequest updateSourceCodeRequest = new UpdateSourceCodeRequest(
-                    sourceCode.getId(), "Updated filename", "Updated content", 1);
-            UpdateTemplateRequest request = new UpdateTemplateRequest("Updated Template", "Updated Description", Collections.emptyList(),
-                    List.of(updateSourceCodeRequest), Collections.emptyList(), category.getId(), Collections.emptyList());
+            UpdateSourceCodeRequest updateSourceCodeRequest = getUpdateSourceCodeRequest(sourceCode);
+            UpdateTemplateRequest request = new UpdateTemplateRequest("Updated Template", "Updated Description",
+                    Collections.emptyList(),
+                    List.of(updateSourceCodeRequest), Collections.emptyList(), category.getId(),
+                    Collections.emptyList());
 
             // when
             categoryTemplateApplicationService.update(member, template.getId(), request);
@@ -115,17 +117,28 @@ class CategoryTemplateApplicationServiceTest extends ServiceTest {
             Member member = memberRepository.save(MemberFixture.getSecondMember());
             Category category = categoryRepository.save(new Category("Members", member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
+
             SourceCode sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename", "content", 1));
             thumbnailRepository.save(new Thumbnail(template, sourceCode));
-            UpdateSourceCodeRequest updateSourceCodeRequest = new UpdateSourceCodeRequest(
-                    sourceCode.getId(), "Updated filename", "Updated content", 1);
-            UpdateTemplateRequest request = new UpdateTemplateRequest("Updated Template", "Updated Description", Collections.emptyList(),
-                    List.of(updateSourceCodeRequest), Collections.emptyList(), othersCategory.getId(), Collections.emptyList());
+            UpdateSourceCodeRequest updateSourceCodeRequest = getUpdateSourceCodeRequest(sourceCode);
+
+            UpdateTemplateRequest request = new UpdateTemplateRequest(
+                    "Updated Template",
+                    "Updated Description",
+                    Collections.emptyList(),
+                    List.of(updateSourceCodeRequest),
+                    Collections.emptyList(),
+                    othersCategory.getId(),
+                    Collections.emptyList());
 
             // when & then
             assertThatThrownBy(() -> categoryTemplateApplicationService.update(otherMember, template.getId(), request))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
+        }
+
+        private UpdateSourceCodeRequest getUpdateSourceCodeRequest(SourceCode sourceCode) {
+            return new UpdateSourceCodeRequest(sourceCode.getId(), "Updated filename", "Updated content", 1);
         }
     }
 }

--- a/backend/src/test/java/codezap/template/service/facade/CategoryTemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/CategoryTemplateApplicationServiceTest.java
@@ -41,7 +41,7 @@ class CategoryTemplateApplicationServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("성공: 작성자의 권한 확인 후 템플릿 생성")
-        void createTemplate_Success() {
+        void createTemplate() {
             // given
             Member member = memberRepository.save(MemberFixture.getFirstMember());
             Category membersCategory = categoryRepository.save(new Category("Members", member));
@@ -54,7 +54,7 @@ class CategoryTemplateApplicationServiceTest extends ServiceTest {
             Long result = categoryTemplateApplicationService.createTemplate(member, request);
 
             // then
-            assertThat(result).isEqualTo(1L);
+            assertThat(categoryRepository.existsById(result)).isTrue();
         }
 
         @Test


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #645

## 📍주요 변경 사항
1. CategoryTemplateApplicationService 테스트를 작성하였습니다.
2. ServiceTest가 SourceCodeService pr 과 중복됩니다. pr 머지 시 충돌이 발생할 수 있으나 필요하다고 생각하여 추가했습니다~

## 🎸기타
1. 리팩토링이 필요한 부분이 있는 듯합니다. 의견을 이슈에 작성해놓았으니 https://github.com/woowacourse-teams/2024-code-zap/issues/650#issuecomment-2355273823 참고해주세요.
2. 테스트를 하기 위해 해당 서비스의 역할을 생각해보았습니다. 관련 의문과 제안을 이슈 https://github.com/woowacourse-teams/2024-code-zap/issues/650#issuecomment-2356004453 에 작성해두었으니 참고해주세요.
3. https://github.com/woowacourse-teams/2024-code-zap/issues/650#issuecomment-2355576069 짱수와 동일한 프록시 객체 접근 문제가 발생합니다~ @Transactional 어노테이션을 통해 트랜잭션을 생성하는 방식으로 처리했습니다.