### PR TITLE
TemplateServiceTest 추가

### DIFF
--- a/backend/src/test/java/codezap/template/repository/TemplateJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateJpaRepositoryTest.java
@@ -150,9 +150,8 @@ class TemplateJpaRepositoryTest {
 
             assertAll(
                     () -> assertThat(result.getContent())
-                            .allMatch(template ->
-                                    template.getTitle().contains(keyword) || template.getDescription()
-                                            .contains(keyword)),
+                            .allMatch(template -> template.getTitle().contains(keyword)
+                                    || template.getDescription().contains(keyword)),
                     () -> assertThat(result.getContent()).hasSize(3)
             );
         }
@@ -213,10 +212,11 @@ class TemplateJpaRepositoryTest {
             Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
 
             assertAll(
-                    () -> assertThat(result.getContent()).containsExactlyInAnyOrder(
-                            templateRepository.fetchById(1L),
-                            templateRepository.fetchById(2L),
-                            templateRepository.fetchById(3L)),
+                    () -> assertThat(result.getContent())
+                            .containsExactlyInAnyOrder(
+                                    templateRepository.fetchById(1L),
+                                    templateRepository.fetchById(2L),
+                                    templateRepository.fetchById(3L)),
                     () -> assertThat(result.getContent()).hasSize(3)
             );
         }
@@ -238,10 +238,9 @@ class TemplateJpaRepositoryTest {
             assertAll(
                     () -> assertThat(result.getContent()).hasSize(2),
                     () -> assertThat(result.getContent())
-                            .allMatch(template ->
-                                    template.getMember().getId().equals(member1.getId())
-                                            && (template.getTitle().contains(keyword) || template.getDescription()
-                                            .contains(keyword)))
+                            .allMatch(template -> template.getMember().getId().equals(member1.getId())
+                                    && (template.getTitle().contains(keyword)
+                                    || template.getDescription().contains(keyword)))
             );
         }
 

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -132,10 +132,11 @@ class TemplateServiceTest {
         void getByMemberIdSuccess() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
             var member2 = memberRepository.save(MemberFixture.getSecondMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(TemplateFixture.get(member1, category));
-            var template2 = templateRepository.save(TemplateFixture.get(member1, category));
-            var template3 = templateRepository.save(TemplateFixture.get(member2, category));
+            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category2 = categoryRepository.save(CategoryFixture.getSecondCategory());
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template3 = templateRepository.save(TemplateFixture.get(member2, category2));
 
             var actual = sut.getByMemberId(member1.getId());
 

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -6,6 +6,7 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -181,6 +182,22 @@ class TemplateServiceTest {
                     () -> assertThat(actual.getContent())
                             .allMatch(template -> template.getMember().getId().equals(member1.getId()))
             );
+        }
+
+        @Test
+        @Disabled("Pageable에 대한 null 검증이 필요함")
+        @DisplayName("검색 기능 실패: Pageable을 전달하지 않은 경우")
+        void findAllFailureWithNullPageable() {
+            saveInitialData();
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = null;
+
+            assertThatThrownBy(() ->sut.findAll(memberId, keyword, categoryId, tagIds, pageable))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("Pageable을 필수로 작성해야 합니다.");
         }
 
         @Test

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -194,9 +194,6 @@ class TemplateServiceTest {
             Pageable pageable = PageRequest.of(0, 10);
 
             Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
-            for (Template template : actual.getContent()) {
-                System.out.println(template.getTitle());
-            }
 
             assertAll(
                     () -> assertThat(actual.getContent())

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -75,7 +75,7 @@ class TemplateServiceTest {
                             new CreateSourceCodeRequest("filename2", "content2", 2)
                     ),
                     1,
-                    1L,
+                    category.getId(),
                     List.of("tag1", "tag2")
             );
 
@@ -84,7 +84,8 @@ class TemplateServiceTest {
             assertAll(
                     () -> assertThat(actual.getTitle()).isEqualTo(templateRequest.title()),
                     () -> assertThat(actual.getMember()).isEqualTo(member),
-                    () -> assertThat(actual.getCategory()).isEqualTo(category)
+                    () -> assertThat(actual.getCategory()).isEqualTo(category),
+                    () -> assertThat(actual.getDescription()).isEqualTo(templateRequest.description())
             );
 
         }
@@ -106,7 +107,8 @@ class TemplateServiceTest {
             assertAll(
                     () -> assertThat(actual.getTitle()).isEqualTo(template.getTitle()),
                     () -> assertThat(actual.getMember()).isEqualTo(member),
-                    () -> assertThat(actual.getCategory()).isEqualTo(category)
+                    () -> assertThat(actual.getCategory()).isEqualTo(category),
+                    () -> assertThat(actual.getDescription()).isEqualTo(template.getDescription())
             );
         }
 

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -7,272 +7,566 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.transaction.annotation.Transactional;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
-import codezap.category.repository.FakeCategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
+import codezap.global.DatabaseIsolation;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
-import codezap.member.repository.FakeMemberRepository;
 import codezap.member.repository.MemberRepository;
 import codezap.tag.domain.Tag;
 import codezap.tag.repository.TagRepository;
 import codezap.tag.repository.TemplateTagRepository;
-import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.TemplateTag;
-import codezap.template.domain.Thumbnail;
 import codezap.template.dto.request.CreateSourceCodeRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
-import codezap.template.dto.request.UpdateSourceCodeRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
-import codezap.template.repository.FakeSourceCodeRepository;
-import codezap.template.repository.FakeTagRepository;
-import codezap.template.repository.FakeTemplateRepository;
-import codezap.template.repository.FakeTemplateTagRepository;
-import codezap.template.repository.FakeThumbnailRepository;
-import codezap.template.repository.SourceCodeRepository;
 import codezap.template.repository.TemplateRepository;
-import codezap.template.repository.ThumbnailRepository;
 
+@SpringBootTest
+@DatabaseIsolation
+@Transactional
 class TemplateServiceTest {
 
-    private final TemplateRepository templateRepository = new FakeTemplateRepository();
-    private final SourceCodeRepository sourceCodeRepository = new FakeSourceCodeRepository();
-    private final ThumbnailRepository thumbnailRepository = new FakeThumbnailRepository();
-    private final CategoryRepository categoryRepository = new FakeCategoryRepository(
-            List.of(CategoryFixture.getFirstCategory(), CategoryFixture.getSecondCategory())
-    );
-    private final TemplateTagRepository templateTagRepository = new FakeTemplateTagRepository();
+    @Autowired
+    private TemplateRepository templateRepository;
 
-    private final TagRepository tagRepository = new FakeTagRepository();
+    @Autowired
+    private CategoryRepository categoryRepository;
 
-    private final MemberRepository memberRepository = new FakeMemberRepository(
-            List.of(MemberFixture.getFirstMember(), MemberFixture.getSecondMember())
-    );
-    private final TemplateService templateService = new TemplateService(templateRepository);
+    @Autowired
+    private TemplateTagRepository templateTagRepository;
 
-    private CreateTemplateRequest makeTemplateRequest(String title) {
-        return new CreateTemplateRequest(
-                title,
-                "description",
-                List.of(
-                        new CreateSourceCodeRequest("filename1", "content1", 1),
-                        new CreateSourceCodeRequest("filename2", "content2", 2)
-                ),
-                1,
-                1L,
-                List.of("tag1", "tag2")
-        );
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private TemplateService sut;
+
+    @Nested
+    @DisplayName("템플릿 생성")
+    class CreateTemplate {
+
+        @Test
+        @DisplayName("템플릿 생성 성공")
+        void createTemplateSuccess() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename1", "content1", 1),
+                            new CreateSourceCodeRequest("filename2", "content2", 2)
+                    ),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            var actual = sut.createTemplate(member, templateRequest, category);
+
+            assertAll(
+                    () -> assertThat(actual.getTitle()).isEqualTo(templateRequest.title()),
+                    () -> assertThat(actual.getMember()).isEqualTo(member),
+                    () -> assertThat(actual.getCategory()).isEqualTo(category)
+            );
+
+        }
     }
 
-    private UpdateTemplateRequest makeUpdateTemplateRequest(Long categoryId) {
-        return new UpdateTemplateRequest(
-                "updateTitle",
-                "description",
-                List.of(
-                        new CreateSourceCodeRequest("filename3", "content3", 2),
-                        new CreateSourceCodeRequest("filename4", "content4", 3)
-                ),
-                List.of(
-                        new UpdateSourceCodeRequest(2L, "filename2", "content2", 1)
-                ),
-                List.of(1L),
-                categoryId,
-                List.of("tag1", "tag3")
-        );
+    @Nested
+    @DisplayName("ID로 템플릿 단건 조회")
+    class GetById {
+
+        @Test
+        @DisplayName("템플릿 단건 조회 성공")
+        void getByIdSuccess() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template = templateRepository.save(TemplateFixture.get(member, category));
+
+            var actual = sut.getById(template.getId());
+
+            assertAll(
+                    () -> assertThat(actual.getTitle()).isEqualTo(template.getTitle()),
+                    () -> assertThat(actual.getMember()).isEqualTo(member),
+                    () -> assertThat(actual.getCategory()).isEqualTo(category)
+            );
+        }
+
+        @Test
+        @DisplayName("템플릿 단건 조회 실패: 해당하는 ID의 템플릿이 없는 경우")
+        void getByIdFailWithWrongId() {
+            var nonExistentID = 100L;
+
+            assertThatThrownBy(() -> sut.getById(nonExistentID))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("식별자 " + nonExistentID + "에 해당하는 템플릿이 존재하지 않습니다.");
+        }
     }
 
-    private Template saveTemplate(CreateTemplateRequest createTemplateRequest, Category category, Member member) {
-        Category savedCategory = categoryRepository.save(category);
-        Template savedTemplate = templateRepository.save(
-                new Template(
-                        member,
-                        createTemplateRequest.title(),
-                        createTemplateRequest.description(),
-                        savedCategory
-                )
-        );
-        SourceCode savedFirstSourceCode = sourceCodeRepository.save(
-                new SourceCode(savedTemplate, "filename1", "content1", 1));
-        sourceCodeRepository.save(new SourceCode(savedTemplate, "filename2", "content2", 2));
-        thumbnailRepository.save(new Thumbnail(savedTemplate, savedFirstSourceCode));
-        createTemplateRequest.tags().stream()
-                .map(Tag::new)
-                .map(tagRepository::save)
-                .forEach(tag -> templateTagRepository.save(new TemplateTag(savedTemplate, tag)));
+    @Nested
+    @DisplayName("멤버 ID로 템플릿 조회")
+    class GetByMemberId {
 
-        return savedTemplate;
+        @Test
+        @DisplayName("멤버 id로 템플릿 조회 성공")
+        void getByMemberIdSuccess() {
+            var member1 = memberRepository.save(MemberFixture.getFirstMember());
+            var member2 = memberRepository.save(MemberFixture.getSecondMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category));
+            var template3 = templateRepository.save(TemplateFixture.get(member2, category));
+
+            var actual = sut.getByMemberId(member1.getId());
+
+            assertThat(actual).hasSize(2)
+                    .containsExactly(template1, template2);
+        }
+
+        @Test
+        @DisplayName("멤버 ID로 템플릿 조회 성공: 해당하는 템플릿이 없는 경우")
+        void getByMemberIdSuccessWithEmptyList() {
+            var memberId = 100L;
+
+            var actual = sut.getByMemberId(memberId);
+
+            assertThat(actual).isEmpty();
+        }
     }
 
-//    @Test
-//    @DisplayName("템플릿 전체 조회 성공")
-//    void findAllTemplatesSuccess() {
-//        // given
-//        MemberDto memberDto = MemberDtoFixture.getFirstMemberDto();
-//        Member member = memberRepository.fetchById(memberDto.id());
-//        saveTemplate(makeTemplateRequest("title1"), new Category("category1", member), member);
-//        saveTemplate(makeTemplateRequest("title2"), new Category("category2", member), member);
-//
-//        // when
-//        Page<Template> allTemplates = templateService.findAll(null, null, null, null, PageRequest.of(1, 10));
-//
-//        // then
-//        assertThat(allTemplates).hasSize(2);
-//    }
+    @Nested
+    @DisplayName("검색 기능")
+    class FindAll {
 
-    @Test
-    @DisplayName("템플릿 단건 조회 성공")
-    void findOneTemplateSuccess() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        Template template = saveTemplate(createdTemplate, new Category("category1", member), member);
+        private Member member1, member2;
+        private Category category1, category2;
+        private Tag tag1, tag2;
+        private Template template1, template2, template3;
 
-        // when
-        Template foundTemplate = templateService.getById(template.getId());
+        @Test
+        @DisplayName("검색 기능: 회원 ID로 템플릿 조회 성공")
+        void findAllSuccessByMemberId() {
+            saveInitialData();
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
 
-        // then
-        assertAll(
-                () -> assertThat(foundTemplate.getTitle()).isEqualTo(template.getTitle()),
-                () -> assertThat(foundTemplate.getCategory().getId()).isEqualTo(template.getCategory().getId())
-        );
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template -> template.getMember().getId().equals(member1.getId()))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 키워드로 템플릿 조회 성공")
+        void findAllSuccessByKeyword() {
+            saveInitialData();
+            Long memberId = null;
+            String keyword = "Template";
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+            for (Template template : actual.getContent()) {
+                System.out.println(template.getTitle());
+            }
+
+            assertAll(
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template ->
+                                    template.getTitle().contains(keyword) || template.getDescription()
+                                            .contains(keyword)),
+                    () -> assertThat(actual.getContent()).hasSize(3)
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 카테고리 ID로 템플릿 조회 성공")
+        void findAllSuccessByCategoryId() {
+            saveInitialData();
+            Long memberId = null;
+            String keyword = null;
+            Long categoryId = category1.getId();
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template -> template.getCategory().getId().equals(category1.getId()))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 태그 ID 목록으로 템플릿 조회, 모든 태그를 가진 템플릿만 조회 성공")
+        void findAllSuccessByTagIds() {
+            saveInitialData();
+            Long memberId = null;
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent())
+                            .containsExactlyInAnyOrder(
+                                    templateRepository.fetchById(1L),
+                                    templateRepository.fetchById(2L)),
+                    () -> assertThat(actual.getContent()).hasSize(2)
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 단일 태그 ID로 템플릿 조회 성공")
+        void findAllSuccessBySingleTagId() {
+            saveInitialData();
+            Long memberId = null;
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = List.of(tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(
+                            templateRepository.fetchById(1L),
+                            templateRepository.fetchById(2L),
+                            templateRepository.fetchById(3L)),
+                    () -> assertThat(actual.getContent()).hasSize(3)
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID와 키워드로 템플릿 조회 성공")
+        void findAllSuccessByMemberIdAndKeyword() {
+            saveInitialData();
+            Long memberId = member1.getId();
+            String keyword = "Template";
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template ->
+                                    template.getMember().getId().equals(member1.getId())
+                                            && (template.getTitle().contains(keyword) || template.getDescription()
+                                            .contains(keyword)))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID와 카테고리 ID로 템플릿 조회 성공")
+        void findAllSuccessByMemberIdAndCategoryId() {
+            saveInitialData();
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = category1.getId();
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(1),
+                    () -> assertThat(actual.getContent().get(0).getMember().getId()).isEqualTo(member1.getId()),
+                    () -> assertThat(actual.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId())
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID와 태그 ID 목록으로 템플릿 조회 성공")
+        void findAllSuccessByMemberIdAndTagIds() {
+            saveInitialData();
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
+                            templateRepository.fetchById(2L))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 모든 검색 기준으로 템플릿 조회 성공")
+        void findAllSuccessWithAllCriteria() {
+            saveInitialData();
+            Long memberId = member1.getId();
+            String keyword = "Template";
+            Long categoryId = category1.getId();
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(1),
+                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 검색 결과가 없는 경우 빈 리스트 반환 성공")
+        void findAllSuccessWithNoResults() {
+            saveInitialData();
+            Long memberId = null;
+            String keyword = "NonExistentKeyword";
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertThat(actual.getContent()).isEmpty();
+        }
+
+        @Test
+        @DisplayName("검색 기능: 두 번째 페이지 조회 성공")
+        void findAllSuccessWithSecondPage() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            for (int i = 0; i < 15; i++) {
+                templateRepository.save(TemplateFixture.get(member, category));
+            }
+            Long memberId = member.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(1, 10);
+
+            Page<Template> actual = sut.findAll(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(5),
+                    () -> assertThat(actual.getContent().get(0).getId()).isEqualTo(11L)
+            );
+        }
+
+        private void saveInitialData() {
+            saveTwoMembers();
+            saveTwoCategory();
+            saveTwoTags();
+            saveThreeTemplates();
+            saveTemplateTags();
+        }
+
+        private void saveTwoMembers() {
+            member1 = memberRepository.save(MemberFixture.getFirstMember());
+            member2 = memberRepository.save(MemberFixture.getSecondMember());
+        }
+
+        private void saveTwoCategory() {
+            category1 = categoryRepository.save(new Category("Category 1", member1));
+            category2 = categoryRepository.save(new Category("Category 2", member1));
+        }
+
+        private void saveTwoTags() {
+            tag1 = tagRepository.save(new Tag("Tag 1"));
+            tag2 = tagRepository.save(new Tag("Tag 2"));
+        }
+
+        private void saveThreeTemplates() {
+            template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            template2 = templateRepository.save(TemplateFixture.get(member1, category2));
+            template3 = templateRepository.save(TemplateFixture.get(member2, category1));
+        }
+
+        private void saveTemplateTags() {
+            templateTagRepository.save(new TemplateTag(template1, tag1));
+            templateTagRepository.save(new TemplateTag(template1, tag2));
+
+            templateTagRepository.save(new TemplateTag(template2, tag1));
+            templateTagRepository.save(new TemplateTag(template2, tag2));
+
+            templateTagRepository.save(new TemplateTag(template3, tag2));
+        }
     }
 
-    @Test
-    @DisplayName("템플릿 생성 성공")
-    void createTemplateSuccess() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        Category category = CategoryFixture.getFirstCategory();
-        CreateTemplateRequest createTemplateRequest = makeTemplateRequest("title");
+    @Nested
+    @DisplayName("템플릿 수정")
+    class UpdateTemplate {
 
-        // when
-        Template template = templateService.createTemplate(member, createTemplateRequest, category);
+        @Test
+        @DisplayName("템플릿 수정 성공")
+        void updateTemplateSuccess() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template = templateRepository.save(TemplateFixture.get(member, category));
+            var updateTemplateRequest = new UpdateTemplateRequest(
+                    "Update Title",
+                    "Update Description",
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    category.getId(),
+                    List.of()
+            );
 
-        // then
-        assertAll(
-                () -> assertThat(templateRepository.findAll()).hasSize(1),
-                () -> assertThat(template.getTitle()).isEqualTo(createTemplateRequest.title()),
-                () -> assertThat(template.getCategory().getName()).isEqualTo("카테고리 없음")
-        );
+            sut.updateTemplate(member, template.getId(), updateTemplateRequest, category);
+
+            assertAll(
+                    () -> assertThat(template.getTitle()).isEqualTo(updateTemplateRequest.title()),
+                    () -> assertThat(template.getDescription()).isEqualTo(updateTemplateRequest.description())
+            );
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 해당하는 ID의 템플릿이 존재하지 않는 경우")
+        void updateTemplateFailWithWrongID() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var updateTemplateRequest = new UpdateTemplateRequest(
+                    "Update Title",
+                    "Update Description",
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    category.getId(),
+                    List.of()
+            );
+            var nonExistentID = 100L;
+
+            assertThatThrownBy(() -> sut.updateTemplate(member, nonExistentID, updateTemplateRequest, category))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("식별자 " + nonExistentID + "에 해당하는 템플릿이 존재하지 않습니다.");
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 템플릿을 수정할 권한이 없는 경우")
+        void updateTemplateFailWithWrongMember() {
+            var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
+            var otherMember = memberRepository.save(MemberFixture.getSecondMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template = templateRepository.save(TemplateFixture.get(ownerMember, category));
+            var updateTemplateRequest = new UpdateTemplateRequest(
+                    "Update Title",
+                    "Update Description",
+                    List.of(),
+                    List.of(),
+                    List.of(),
+                    category.getId(),
+                    List.of()
+            );
+
+            assertThatThrownBy(() -> sut.updateTemplate(otherMember, template.getId(), updateTemplateRequest, category))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
+        }
     }
 
-    @Test
-    @DisplayName("템플릿 수정 성공")
-    void updateTemplateSuccess() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        Category category = CategoryFixture.getFirstCategory();
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        Template template = saveTemplate(createdTemplate, category, member);
-        categoryRepository.save(category);
+    @Nested
+    @DisplayName("템플릿 삭제")
+    class DeleteTemplate {
 
-        // when
-        UpdateTemplateRequest updateTemplateRequest = makeUpdateTemplateRequest(1L);
-        templateService.updateTemplate(member, template.getId(), updateTemplateRequest, category);
-        Template updateTemplate = templateRepository.fetchById(template.getId());
-        List<Tag> tags = templateTagRepository.findAllByTemplate(updateTemplate).stream()
-                .map(TemplateTag::getTag)
-                .toList();
+        @Test
+        @DisplayName("템플릿 삭제 성공: 1개 삭제")
+        void deleteTemplateSuccessWithOneTemplate() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template1 = templateRepository.save(TemplateFixture.get(member, category));
+            var template2 = templateRepository.save(TemplateFixture.get(member, category));
 
-        // then
-        assertAll(
-                () -> assertThat(updateTemplate.getTitle()).isEqualTo("updateTitle"),
-                () -> assertThat(updateTemplate.getCategory().getId()).isEqualTo(1L),
-                () -> assertThat(tags).hasSize(2)
-        );
-    }
+            sut.deleteByMemberAndIds(member, List.of(template1.getId()));
+            Page<Template> actual = sut.findAll(member.getId(), null, null, null, PageRequest.of(0, 10));
 
-    @Test
-    @DisplayName("템플릿 수정 실패: 권한 없음")
-    void updateTemplateFailWithUnauthorized() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        Category category = CategoryFixture.getFirstCategory();
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        Template template = saveTemplate(createdTemplate, new Category("category1", member), member);
-        categoryRepository.save(new Category("category2", member));
+            assertThat(actual.getContent()).hasSize(1)
+                    .containsExactly(template2);
+        }
 
-        // when
-        Member otherMember = MemberFixture.getSecondMember();
-        UpdateTemplateRequest updateTemplateRequest = makeUpdateTemplateRequest(2L);
+        @Test
+        @DisplayName("템플릿 삭제 성공: 여러개 삭제")
+        void deleteTemplateSuccessWithMultipleTemplate() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template1 = templateRepository.save(TemplateFixture.get(member, category));
+            var template2 = templateRepository.save(TemplateFixture.get(member, category));
+            var template3 = templateRepository.save(TemplateFixture.get(member, category));
+            var template4 = templateRepository.save(TemplateFixture.get(member, category));
 
-        // then
-        Long templateId = template.getId();
-        assertThatThrownBy(
-                () -> templateService.updateTemplate(otherMember, templateId, updateTemplateRequest, category))
-                .isInstanceOf(CodeZapException.class)
-                .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
-    }
+            sut.deleteByMemberAndIds(member, List.of(template1.getId(), template4.getId()));
+            Page<Template> actual = sut.findAll(member.getId(), null, null, null, PageRequest.of(0, 10));
 
-    @Test
-    @DisplayName("템플릿 삭제 성공: 1개")
-    void deleteTemplateSuccess() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        saveTemplate(createdTemplate, new Category("category1", member), member);
+            assertThat(actual.getContent()).hasSize(2)
+                    .containsExactly(template2, template3);
+        }
 
-        // when
-        templateService.deleteByMemberAndIds(member, List.of(1L));
+        @Test
+        @DisplayName("템플릿 삭제 실패: 존재하지 않는 템플릿 삭제")
+        void deleteTemplateSuccessWithNonExistentTemplate() {
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template = templateRepository.save(TemplateFixture.get(member, category));
+            Long nonExistentID = 100L;
 
-        // then
-        assertThat(templateRepository.findAll()).isEmpty();
-    }
+            assertThatThrownBy(() -> sut.deleteByMemberAndIds(member, List.of(nonExistentID)))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("식별자 " + nonExistentID + "에 해당하는 템플릿이 존재하지 않습니다.");
+        }
 
-    @Test
-    @DisplayName("템플릿 삭제 성공: 2개")
-    void deleteTemplatesSuccess() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        CreateTemplateRequest createdTemplate1 = makeTemplateRequest("title1");
-        CreateTemplateRequest createdTemplate2 = makeTemplateRequest("title2");
-        saveTemplate(createdTemplate1, new Category("category1", member), member);
-        saveTemplate(createdTemplate2, new Category("category1", member), member);
+        @Test
+        @DisplayName("템플릿 삭제 실패: 삭제할 권한이 없는 경우")
+        void deleteTemplateFailWithWrongMember() {
+            var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
+            var otherMember = memberRepository.save(MemberFixture.getSecondMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template = templateRepository.save(TemplateFixture.get(ownerMember, category));
 
-        // when
-        templateService.deleteByMemberAndIds(member, List.of(1L, 2L));
+            assertThatThrownBy(() -> sut.deleteByMemberAndIds(otherMember, List.of(template.getId())))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
 
-        // then
-        assertThat(templateRepository.findAll()).isEmpty();
-    }
+        }
 
-    @Test
-    @DisplayName("템플릿 삭제 실패: 권한 없음")
-    void deleteTemplateFailWithUnauthorized() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        CreateTemplateRequest createdTemplate = makeTemplateRequest("title");
-        saveTemplate(createdTemplate, new Category("category1", member), member);
+        @Test
+        @DisplayName("템플릿 삭제 실패: 동일한 ID가 2개 들어있는 경우")
+        void deleteTemplateFailWithDuplicateID() {
+            var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
+            var otherMember = memberRepository.save(MemberFixture.getSecondMember());
+            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template = templateRepository.save(TemplateFixture.get(ownerMember, category));
 
-        // when
-        Member otherMember = MemberFixture.getSecondMember();
+            assertThatThrownBy(() -> sut.deleteByMemberAndIds(otherMember, List.of(template.getId(), template.getId())))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("삭제하고자 하는 템플릿 ID가 중복되었습니다.");
 
-        // then
-        List<Long> ids = List.of(1L);
-        assertThatThrownBy(() -> templateService.deleteByMemberAndIds(otherMember, ids))
-                .isInstanceOf(CodeZapException.class)
-                .hasMessage("해당 템플릿에 대한 권한이 없습니다.");
-    }
-
-    @Test
-    @DisplayName("템플릿 삭제 실패: 동일한 ID 2개가 들어왔을 때")
-    void deleteTemplatesFailWithSameTemplateId() {
-        // given
-        Member member = MemberFixture.getFirstMember();
-        CreateTemplateRequest createdTemplate1 = makeTemplateRequest("title1");
-        CreateTemplateRequest createdTemplate2 = makeTemplateRequest("title2");
-        saveTemplate(createdTemplate1, new Category("category1", member), member);
-        saveTemplate(createdTemplate2, new Category("category1", member), member);
-
-        // when & then
-        List<Long> ids = List.of(1L, 1L);
-        assertThatThrownBy(() -> templateService.deleteByMemberAndIds(member, ids))
-                .isInstanceOf(CodeZapException.class)
-                .hasMessage("삭제하고자 하는 템플릿 ID가 중복되었습니다.");
+        }
     }
 }

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -144,7 +144,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("멤버 ID로 템플릿 조회 성공: 해당하는 템플릿이 없는 경우")
+        @DisplayName("멤버 ID로 템플릿 조회 성공: 해당하는 템플릿이 없는 경우 빈 목록 반환")
         void getByMemberIdSuccessWithEmptyList() {
             var memberId = 100L;
 
@@ -164,7 +164,7 @@ class TemplateServiceTest {
         private Template template1, template2, template3;
 
         @Test
-        @DisplayName("검색 기능: 회원 ID로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 회원 ID로 템플릿 목록 조회 성공")
         void findAllSuccessByMemberId() {
             saveInitialData();
             Long memberId = member1.getId();
@@ -183,7 +183,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 키워드로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
         void findAllSuccessByKeyword() {
             saveInitialData();
             Long memberId = null;
@@ -207,7 +207,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 카테고리 ID로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 카테고리 ID로 템플릿 목록 조회 성공")
         void findAllSuccessByCategoryId() {
             saveInitialData();
             Long memberId = null;
@@ -226,7 +226,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 태그 ID 목록으로 템플릿 조회, 모든 태그를 가진 템플릿만 조회 성공")
+        @DisplayName("검색 기능: 태그 ID 목록으로 템플릿 목록 조회, 모든 태그를 가진 템플릿만 조회 성공")
         void findAllSuccessByTagIds() {
             saveInitialData();
             Long memberId = null;
@@ -247,7 +247,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 단일 태그 ID로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 단일 태그 ID로 템플릿 목록 조회 성공")
         void findAllSuccessBySingleTagId() {
             saveInitialData();
             Long memberId = null;
@@ -268,7 +268,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 회원 ID와 키워드로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 회원 ID와 키워드로 템플릿 목록 조회 성공")
         void findAllSuccessByMemberIdAndKeyword() {
             saveInitialData();
             Long memberId = member1.getId();
@@ -290,7 +290,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 회원 ID와 카테고리 ID로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 회원 ID와 카테고리 ID로 템플릿 목록 조회 성공")
         void findAllSuccessByMemberIdAndCategoryId() {
             saveInitialData();
             Long memberId = member1.getId();
@@ -309,7 +309,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 회원 ID와 태그 ID 목록으로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 회원 ID와 태그 ID 목록으로 템플릿 목록 조회 성공")
         void findAllSuccessByMemberIdAndTagIds() {
             saveInitialData();
             Long memberId = member1.getId();
@@ -328,7 +328,7 @@ class TemplateServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 모든 검색 기준으로 템플릿 조회 성공")
+        @DisplayName("검색 기능: 모든 검색 기준으로 템플릿 목록 조회 성공")
         void findAllSuccessWithAllCriteria() {
             saveInitialData();
             Long memberId = member1.getId();

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -282,10 +282,9 @@ class TemplateServiceTest {
             assertAll(
                     () -> assertThat(actual.getContent()).hasSize(2),
                     () -> assertThat(actual.getContent())
-                            .allMatch(template ->
-                                    template.getMember().getId().equals(member1.getId())
-                                            && (template.getTitle().contains(keyword) || template.getDescription()
-                                            .contains(keyword)))
+                            .allMatch(template -> template.getMember().getId().equals(member1.getId())
+                                    && (template.getTitle().contains(keyword)
+                                    || template.getDescription().contains(keyword)))
             );
         }
 
@@ -322,8 +321,10 @@ class TemplateServiceTest {
 
             assertAll(
                     () -> assertThat(actual.getContent()).hasSize(2),
-                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
-                            templateRepository.fetchById(2L))
+                    () -> assertThat(actual.getContent())
+                            .containsExactlyInAnyOrder(
+                                    templateRepository.fetchById(1L),
+                                    templateRepository.fetchById(2L))
             );
         }
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #645 

## 📍주요 변경 사항
TemplateService 테스트 작성


## 🎸기타
### 테스트 실패 문제
켬미와 동일하게 flyway 설정 때문에 테스트 코드가 자꾸 실패하는 문제가 발생했었습니다.
이에 테스트 코드에서 사용하는 `application-db.yml`에 다음과 같은 설정을 추가해주었습니다.
```
flyway:
  enabled: false
```
### 중복되는 테스트 코드
- TemplateService의 경우 아래 코드와 같이 TemplateRepository의 반환값을 그대로 리턴하는 메소드들이 몇 개 있습니다.
```java
public Template getById(Long id) {
    return templateRepository.fetchById(id);
}

public List<Template> getByMemberId(Long memberId) {
    return templateRepository.findByMemberId(memberId);
}

public Page<Template> findAll(
        Long memberId, String keyword, Long categoryId, List<Long> tagIds, Pageable pageable
) {
    return templateRepository.findAll(
            new TemplateSpecification(memberId, keyword, categoryId, tagIds), pageable);
}
```
- 이런 경우 RepositoryTest와 중복되는 테스트들이 몇 개 생겨나는데 이런 경우에도 ServiceTest를 작성해야 하는지 의문입니다.
  - 우선 저는 중복되더라도 테스트 코드를 작성하였습니다.
  - 테스트 코드는 해당 클래스의 명세서와도 같고, 테스트 코드를 봤을 때 해당 클래스를 `어떻게 사용하는거구나, 어떤 에러가 발생할 수 있구나` 등을 알 수 있게 하는 것이 목적이라고 생각하기 때문입니다.
  - 다른 분들의 의견이 궁금합니다.

## 지연 로딩 문제
- https://github.com/woowacourse-teams/2024-code-zap/issues/650#issuecomment-2355576069 
- 저도 마찬가지로 짱수와 동일한 프록시 객체 접근 문제가 발생합니다. 
- 몰리와 동일하게 `@Transactional` 어노테이션을 통해 트랜잭션을 생성하는 방식으로 처리했는데, 우선은 프로덕션 코드는 수정되면 안 될 것 같아서 테스트 코드에 `@Transactional`을 추가하는 식으로 해결하였습니다. 
- 추후에 해당 어노테이션을 지우고, 프로덕션 코드에 적용하는 식으로 변경해야 할 것 같습니다.

## 기타 리팩토링 사항
- TemplateService로 넘어오는 파라미터 변경
  - https://github.com/woowacourse-teams/2024-code-zap/issues/650#issuecomment-2357256035
- 리스트를 반환하는 JPA 쿼리 메서드명 변경
  - https://github.com/woowacourse-teams/2024-code-zap/issues/650#issuecomment-2357256035