### PR TITLE
group 설정 추가로 @Validated 검증 로직 보완

### DIFF
--- a/backend/src/main/java/codezap/template/dto/request/CreateSourceCodeRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/CreateSourceCodeRequest.java
@@ -21,7 +21,7 @@ public record CreateSourceCodeRequest(
         String content,
 
         @Schema(description = "소스 코드 순서", example = "1")
-        @NotNull(message = "소스 코드 순서가 null 입니다.")
+        @NotNull(message = "소스 코드 순서가 null 입니다.", groups = NotNullGroup.class)
         int ordinal
 ) {
 }

--- a/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
@@ -31,15 +31,15 @@ public record CreateTemplateRequest(
         List<CreateSourceCodeRequest> sourceCodes,
 
         @Schema(description = "썸네일 순서", example = "1")
-        @NotNull(message = "썸네일 순서가 null 입니다.")
+        @NotNull(message = "썸네일 순서가 null 입니다.", groups = NotNullGroup.class)
         int thumbnailOrdinal,
 
         @Schema(description = "카테고리 ID", example = "1")
-        @NotNull(message = "카테고리 ID가 null 입니다.")
+        @NotNull(message = "카테고리 ID가 null 입니다.", groups = NotNullGroup.class)
         Long categoryId,
 
         @Schema(description = "태그 목록")
-        @NotNull(message = "태그 목록이 null 입니다.")
+        @NotNull(message = "태그 목록이 null 입니다.", groups = NotNullGroup.class)
         List<String> tags
 ) implements ValidatedSourceCodesOrdinalRequest {
     @Override

--- a/backend/src/main/java/codezap/template/dto/request/UpdateSourceCodeRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/UpdateSourceCodeRequest.java
@@ -11,7 +11,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UpdateSourceCodeRequest(
         @Schema(description = "소스 코드 ID", example = "0")
-        @NotNull(message = "소스 코드 ID가 null 입니다.")
+        @NotNull(message = "소스 코드 ID가 null 입니다.", groups = NotNullGroup.class)
         Long id,
 
         @Schema(description = "파일명", example = "Main.java")
@@ -25,7 +25,7 @@ public record UpdateSourceCodeRequest(
         String content,
 
         @Schema(description = "소스 코드 순서", example = "1")
-        @NotNull(message = "소스 코드 순서가 null 입니다.")
+        @NotNull(message = "소스 코드 순서가 null 입니다.", groups = NotNullGroup.class)
         int ordinal
 ) {
 }

--- a/backend/src/main/java/codezap/template/dto/request/UpdateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/UpdateTemplateRequest.java
@@ -37,15 +37,15 @@ public record UpdateTemplateRequest(
         List<UpdateSourceCodeRequest> updateSourceCodes,
 
         @Schema(description = "삭제하는 소스 코드 ID 목록")
-        @NotNull(message = "삭제하는 소스 코드 ID 목록이 null 입니다.")
+        @NotNull(message = "삭제하는 소스 코드 ID 목록이 null 입니다.", groups = NotNullGroup.class)
         List<Long> deleteSourceCodeIds,
 
         @Schema(description = "카테고리 ID", example = "1")
-        @NotNull(message = "카테고리 ID가 null 입니다.")
+        @NotNull(message = "카테고리 ID가 null 입니다.", groups = NotNullGroup.class)
         Long categoryId,
 
         @Schema(description = "태그 목록")
-        @NotNull(message = "태그 목록이 null 입니다.")
+        @NotNull(message = "태그 목록이 null 입니다.", groups = NotNullGroup.class)
         List<String> tags
 ) implements ValidatedSourceCodesOrdinalRequest, ValidatedSourceCodesCountRequest {
     @Override

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -17,6 +17,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
@@ -26,6 +27,10 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import com.fasterxml.jackson.databind.ObjectMapper;
 
 import codezap.auth.configuration.AuthArgumentResolver;
+import codezap.auth.encryption.PasswordEncryptor;
+import codezap.auth.encryption.RandomSaltGenerator;
+import codezap.auth.encryption.SHA2PasswordEncryptor;
+import codezap.auth.encryption.SaltGenerator;
 import codezap.auth.manager.CookieCredentialManager;
 import codezap.auth.provider.basic.BasicAuthCredentialProvider;
 import codezap.category.dto.request.CreateCategoryRequest;
@@ -40,10 +45,6 @@ import codezap.member.dto.MemberDto;
 import codezap.member.repository.FakeMemberRepository;
 import codezap.member.repository.MemberRepository;
 import codezap.member.service.MemberService;
-import codezap.auth.encryption.PasswordEncryptor;
-import codezap.auth.encryption.RandomSaltGenerator;
-import codezap.auth.encryption.SHA2PasswordEncryptor;
-import codezap.auth.encryption.SaltGenerator;
 import codezap.tag.service.TemplateTagService;
 import codezap.template.dto.request.CreateSourceCodeRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
@@ -154,6 +155,28 @@ class TemplateControllerTest {
                     .andExpect(status().isCreated());
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {"", "      "})
+        @DisplayName("템플릿 생성 실패: 템플릿명이 비어 있거나 공백")
+        void createTemplateFailWithBlankTitle(String title) throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    title,
+                    "description",
+                    List.of(new CreateSourceCodeRequest("a", "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿명이 비어 있거나 공백입니다."));
+        }
+
         @Test
         @DisplayName("템플릿 생성 실패: 템플릿명 길이 초과")
         void createTemplateFailWithLongTitle() throws Exception {
@@ -176,9 +199,30 @@ class TemplateControllerTest {
                     .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
         }
 
+        @Test
+        @DisplayName("템플릿 생성 실패: 템플릿 설명 null")
+        void createTemplateFailWithNullDescription() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    null,
+                    List.of(new CreateSourceCodeRequest("title", "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿 설명이 null 입니다."));
+        }
+
         @ParameterizedTest
-        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
         @CsvSource({"a, 65536", "ㄱ, 21846"})
+        @DisplayName("템플릿 생성 실패: 템플릿 설명 길이 초과")
         void createTemplateFailWithLongDescription(String repeatTarget, int exceededLength) throws Exception {
             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
                     "title",
@@ -196,6 +240,28 @@ class TemplateControllerTest {
                             .content(objectMapper.writeValueAsString(templateRequest)))
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "      "})
+        @DisplayName("템플릿 생성 실패: 파일명이 비어 있거나 공백")
+        void createTemplateFailWithBlankFileName(String fileName) throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "fileName",
+                    "description",
+                    List.of(new CreateSourceCodeRequest(fileName, "content", 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("파일명이 비어 있거나 공백입니다."));
         }
 
         @Test
@@ -221,9 +287,31 @@ class TemplateControllerTest {
         }
 
         @ParameterizedTest
+        @DisplayName("템플릿 생성 실패: 소스 코드가 비어 있거나 공백")
+        @ValueSource(strings = {"", "      "})
+        void createTemplateFailWithBlankContent(String sourceCode) throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("title", sourceCode, 1)),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드가 비어 있거나 공백입니다."));
+        }
+
+        @ParameterizedTest
         @DisplayName("템플릿 생성 실패: 소스 코드 길이 초과")
         @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void createTemplateFailWithLongContent(String repeatTarget, int exceededLength) throws Exception {
+        void createTemplateFailWithLongSourceCode(String repeatTarget, int exceededLength) throws Exception {
             CreateTemplateRequest templateRequest = new CreateTemplateRequest(
                     "title",
                     "description",
@@ -241,6 +329,70 @@ class TemplateControllerTest {
                     .andExpect(status().isBadRequest())
                     .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
         }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 소스 코드 0개")
+        void createTemplateFailWithLongEmptySourceCode() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(),
+                    1,
+                    1L,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드 최소 1개 입력해야 합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 카테고리 ID null")
+        void createTemplateFailWithLongNullCategoryId() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("title", "sourceCode", 1)),
+                    1,
+                    null,
+                    List.of("tag1", "tag2")
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("카테고리 ID가 null 입니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 생성 실패: 태그 목록 null")
+        void createTemplateFailWithLongNullTags() throws Exception {
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("title", "sourceCode", 1)),
+                    1,
+                    1L,
+                    null
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("태그 목록이 null 입니다."));
+        }
+
 
         @ParameterizedTest
         @DisplayName("템플릿 생성 실패: 잘못된 소스 코드 순서 입력")
@@ -439,6 +591,436 @@ class TemplateControllerTest {
                     .andExpect(status().isOk());
         }
 
+        @ParameterizedTest
+        @ValueSource(strings = {"", "      "})
+        @DisplayName("템플릿 생성 실패: 템플릿명이 비어 있거나 공백")
+        void updateTemplateFailWithBlankName(String title) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    title,
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿명이 비어 있거나 공백입니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 템플릿명 길이 초과")
+        void updateTemplateFailWithLongName() throws Exception {
+            // given
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    exceededTitle,
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 템플릿 설명 null")
+        void updateTemplateFailWithNullContent() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    null,
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿 설명이 null 입니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 템플릿 설명 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    repeatTarget.repeat(exceedLength),
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "      "})
+        @DisplayName("템플릿 수정 실패: 파일 이름이 비어 있거나 공백")
+        void updateTemplateFailWithBlankFileName(String fileName) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest(fileName, "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("파일명이 비어 있거나 공백입니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 파일 이름 길이 초과")
+        void updateTemplateFailWithLongFileName() throws Exception {
+            // given
+            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest(exceededTitle, "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
+        }
+
+        @ParameterizedTest
+        @ValueSource(strings = {"", "      "})
+        @DisplayName("템플릿 수정 실패: 소스 코드가 비어 있거나 공백")
+        void updateTemplateFailWithLongFileSourceCode(String sourceCode) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", sourceCode, 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드가 비어 있거나 공백입니다."));
+        }
+
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 소스 코드 길이 초과")
+        @CsvSource({"a, 65536", "ㄱ, 21846"})
+        void updateTemplateFailWithLongFileSourceCode(String repeatTarget, int exceedLength) throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", repeatTarget.repeat(exceedLength), 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 추가하는 소스 코드 목록 null")
+        void updateTemplateFailWithNullCreateSourceCode() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    null,
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    1L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("추가하는 소스 코드 목록이 null 입니다."));
+
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 삭제, 생성 소스 코드를 제외한 모든 소스 코드 목록 null")
+        void updateTemplateFailWithNullUpdateSourceCode() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    null,
+                    List.of(1L),
+                    1L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("삭제, 생성 소스 코드를 제외한 모든 소스 코드 목록이 null 입니다."));
+
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 삭제 소스 코드 목록 null")
+        void updateTemplateFailWithNullDeleteSourceCode() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    null,
+                    1L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("삭제하는 소스 코드 ID 목록이 null 입니다."));
+
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 카테고리 ID null")
+        void updateTemplateFailWithNullCategoryId() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    null,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("카테고리 ID가 null 입니다."));
+
+        }
+
+        @Test
+        @DisplayName("템플릿 수정 실패: 태그 목록 null")
+        void updateTemplateFailWithNullTags() throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", 2),
+                            new CreateSourceCodeRequest("filename4", "content4", 3)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
+                    ),
+                    List.of(1L),
+                    1L,
+                    null
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("태그 목록이 null 입니다."));
+
+        }
+
+        // 정상 요청: 2, 3, 1
+        @ParameterizedTest
+        @DisplayName("템플릿 수정 실패: 잘못된 소스 코드 순서 입력")
+        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
+        void updateTemplateFailWithWrongSourceCodeOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal)
+                throws Exception {
+            // given
+            createTemplateAndTwoCategories();
+            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
+                    "updateTitle",
+                    "description",
+                    List.of(
+                            new CreateSourceCodeRequest("filename3", "content3", createOrdinal1),
+                            new CreateSourceCodeRequest("filename4", "content4", createOrdinal2)
+                    ),
+                    List.of(
+                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
+                    ),
+                    List.of(1L),
+                    2L,
+                    List.of("tag1", "tag3")
+            );
+
+            // when & then
+            mvc.perform(post("/templates/1")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("소스 코드 순서가 잘못되었습니다."));
+        }
+
         @Test
         @DisplayName("템플릿 수정 실패: 권한 없음")
         void updateTemplateFailWithUnauthorized() throws Exception {
@@ -475,163 +1057,6 @@ class TemplateControllerTest {
                             .content(objectMapper.writeValueAsString(updateTemplateRequest)))
                     .andExpect(status().isUnauthorized())
                     .andExpect(jsonPath("$.detail").value("해당 템플릿에 대한 권한이 없습니다."));
-        }
-
-        @Test
-        @DisplayName("템플릿 수정 실패: 템플릿명 길이 초과")
-        void updateTemplateFailWithLongName() throws Exception {
-            // given
-            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    exceededTitle,
-                    "description",
-                    List.of(
-                            new CreateSourceCodeRequest("filename3", "content3", 2),
-                            new CreateSourceCodeRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            mvc.perform(post("/templates/1")
-                            .cookie(cookie)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.detail").value("템플릿명은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @Test
-        @DisplayName("템플릿 수정 실패: 파일 이름 길이 초과")
-        void updateTemplateFailWithLongFileName() throws Exception {
-            // given
-            String exceededTitle = "a".repeat(MAX_LENGTH + 1);
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(
-                            new CreateSourceCodeRequest(exceededTitle, "content3", 2),
-                            new CreateSourceCodeRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            mvc.perform(post("/templates/1")
-                            .cookie(cookie)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.detail").value("파일명은 최대 255자까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 수정 실패: 파일 내용 길이 초과")
-        @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void updateTemplateFailWithLongFileContent(String repeatTarget, int exceedLength) throws Exception {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "title",
-                    "description",
-                    List.of(
-                            new CreateSourceCodeRequest("filename3", repeatTarget.repeat(exceedLength), 2),
-                            new CreateSourceCodeRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            mvc.perform(post("/templates/1")
-                            .cookie(cookie)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.detail").value("소스 코드는 최대 65,535 Byte까지 입력 가능합니다."));
-        }
-
-        @ParameterizedTest
-        @DisplayName("템플릿 수정 실패: 템플릿 설명 길이 초과")
-        @CsvSource({"a, 65536", "ㄱ, 21846"})
-        void updateTemplateFailWithLongContent(String repeatTarget, int exceedLength) throws Exception {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "title",
-                    repeatTarget.repeat(exceedLength),
-                    List.of(
-                            new CreateSourceCodeRequest("filename3", "content3", 2),
-                            new CreateSourceCodeRequest("filename4", "content4", 3)
-                    ),
-                    List.of(
-                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", 1)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            mvc.perform(post("/templates/1")
-                            .cookie(cookie)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.detail").value("템플릿 설명은 최대 65,535 Byte까지 입력 가능합니다."));
-        }
-
-        // 정상 요청: 2, 3, 1
-        @ParameterizedTest
-        @DisplayName("템플릿 수정 실패: 잘못된 소스 코드 순서 입력")
-        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
-        void updateTemplateFailWithWrongSourceCodeOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal)
-                throws Exception {
-            // given
-            createTemplateAndTwoCategories();
-            UpdateTemplateRequest updateTemplateRequest = new UpdateTemplateRequest(
-                    "updateTitle",
-                    "description",
-                    List.of(
-                            new CreateSourceCodeRequest("filename3", "content3", createOrdinal1),
-                            new CreateSourceCodeRequest("filename4", "content4", createOrdinal2)
-                    ),
-                    List.of(
-                            new UpdateSourceCodeRequest(2L, "updateFilename2", "updateContent2", updateOrdinal)
-                    ),
-                    List.of(1L),
-                    2L,
-                    List.of("tag1", "tag3")
-            );
-
-            // when & then
-            mvc.perform(post("/templates/1")
-                            .cookie(cookie)
-                            .accept(MediaType.APPLICATION_JSON)
-                            .contentType(MediaType.APPLICATION_JSON)
-                            .content(objectMapper.writeValueAsString(updateTemplateRequest)))
-                    .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.detail").value("소스 코드 순서가 잘못되었습니다."));
         }
 
         private void createTemplateAndTwoCategories() {


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #667

## 📍주요 변경 사항
- `@Validated` 으로 검증 로직을 작동시키기 위해 dto 필드에 group 설정 추가

## 🎸기타
### 테스트 코드 추가
아직 컨트롤러 테스트 보완이 안되있어서 고민하다가 그래도 현재 fix하는 로직이 잘 작동하는지 확인하기 위해 dto 검증 테스트 코드 추가했습니다.

### primitive type not null 로직
primitive type 은 null 일 수 없으니 NotNull 체크가 없어도 될 것 같은데 어떻게 생각하시나요?

### Dto 단에서 추가해야하는 검증 로직

> 이 외에도 없는지 추후 컨트롤러 테스트 보완하면서 확인하면 좋을 것 같다

- [ ] CreateTemplateRequest.thumbnailOrdinal 은 1부터 시작한다
- [ ] CreateSourceCodeRequest.ordinal 은 1부터 시작한다


