### PR TITLE
백엔드 CD 변경

### DIFF
--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -4,39 +4,67 @@ on:
   push:
     branches:
       - main
-      - dev/be
+      - develop
 
 jobs:
   build:
     runs-on:
-      - self-hosted
-      - spring
-      - ${{ contains(github.ref, 'main') && 'production' || 'develop' }}
+      - ubuntu-latest
     steps:
       - name: 체크아웃
         uses: actions/checkout@v4
+
+      - name: JDK 설치
+        uses: actions/setup-java@v4
+        with:
+          java-version: 17
+          distribution: temurin
 
       - name: gradle 캐싱
         uses: gradle/actions/setup-gradle@v4
 
       - name: bootJar로 jar 파일 생성
-        run: |
-          ./gradlew bootJar
-          mv build/libs/*.jar ${{ secrets.JAR_DIRECTORY }}
-        working-directory: ./backend
+        run: ./gradlew bootJar
+        working-directory: backend
 
-      - name: 클린업
-        if: always()
-        run: rm -rf ../2024-code-zap/*
+      - name: Artifact 업로드
+        uses: actions/upload-artifact@v4
+        with:
+          name: code-zap-jar
+          path: backend/build/libs/*.jar
 
-  deploy:
+  deploy_instance_a:
     needs: build
     runs-on:
       - self-hosted
       - spring
-      - ${{ contains(github.ref, 'main') && 'production' || 'develop' }}
+      - ${{ contains(github.ref, 'main') && 'prod_a' || 'develop' }}
     steps:
+      - name: Artifact 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: code-zap-jar
+          path: ${{ secrets.SPRING_DIRECTORY }}
       - name: 배포 스크립트 실행
         run: |
-          cd ${{ secrets.ZAP_DIRECTORY }}
+          cd ${{ secrets.SPRING_DIRECTORY }}
+          ls -l
+          mv code-zap*.jar ${{ secrets.JAR_NAME }}
+          docker compose restart
+  deploy_instance_b:
+    needs: build
+    runs-on:
+      - self-hosted
+      - spring
+      - ${{ contains(github.ref, 'main') && 'prod_b' || 'develop' }}
+    steps:
+      - name: Artifact 다운로드
+        uses: actions/download-artifact@v4
+        with:
+          name: code-zap-jar
+          path: ${{ secrets.SPRING_DIRECTORY }}
+      - name: 배포 스크립트 실행
+        run: |
+          cd ${{ secrets.SPRING_DIRECTORY }}
+          mv code-zap*.jar ${{ secrets.JAR_NAME }}
           docker compose restart

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -48,7 +48,6 @@ jobs:
       - name: 배포 스크립트 실행
         run: |
           cd ${{ secrets.SPRING_DIRECTORY }}
-          ls -l
           mv code-zap*.jar ${{ secrets.JAR_NAME }}
           docker compose restart
   deploy_instance_b:

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -56,7 +56,7 @@ jobs:
     runs-on:
       - self-hosted
       - spring
-      - ${{ contains(github.ref, 'main') && 'prod_b' || 'develop' }}
+      - prod_b
     steps:
       - name: Artifact 다운로드
         uses: actions/download-artifact@v4

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -52,6 +52,7 @@ jobs:
           docker compose restart
   deploy_instance_b:
     needs: build
+    if: ${{ contains(github.ref, 'main') }}
     runs-on:
       - self-hosted
       - spring

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           cd ${{ secrets.SPRING_DIRECTORY }}
           mv code-zap*.jar ${{ secrets.JAR_NAME }}
+          cd ${{ secrets.COMPOSE_DIRECTORY }}
           docker compose restart
   deploy_instance_b:
     needs: build
@@ -66,4 +67,5 @@ jobs:
         run: |
           cd ${{ secrets.SPRING_DIRECTORY }}
           mv code-zap*.jar ${{ secrets.JAR_NAME }}
+          cd ${{ secrets.COMPOSE_DIRECTORY }}
           docker compose restart

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -4,7 +4,7 @@ on:
   push:
     branches:
       - main
-      - develop
+      - dev/be
 
 jobs:
   build:

--- a/.github/workflows/backend_cd.yml
+++ b/.github/workflows/backend_cd.yml
@@ -49,7 +49,6 @@ jobs:
         run: |
           cd ${{ secrets.SPRING_DIRECTORY }}
           mv code-zap*.jar ${{ secrets.JAR_NAME }}
-          cd ${{ secrets.COMPOSE_DIRECTORY }}
           docker compose restart
   deploy_instance_b:
     needs: build
@@ -67,5 +66,4 @@ jobs:
         run: |
           cd ${{ secrets.SPRING_DIRECTORY }}
           mv code-zap*.jar ${{ secrets.JAR_NAME }}
-          cd ${{ secrets.COMPOSE_DIRECTORY }}
           docker compose restart


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #683 

## 📍주요 변경 사항
1. 빌드를 self-hosted runner에서 ubuntu-latest로 변경하였습니다.
2. 빌드 시 아티팩트를 저장한 후, 배포 시에는 아티팩트를 다운받아 실행시킵니다.

## 🎸기타
1. ubuntu-latest를 사용함에 따라 JDK 설치, 아티팩트 업로드 코드가 추가되었습니다.
2. 배포 시 아티팩트를 다운받는 코드가 추가되었습니다.
3. 배포 시 prod-a, prod-b 두 개의 인스턴스에 동시에 배포됩니다.

