### PR TITLE
목록 조회 페이지 기본 값을 0으로 변경

### DIFF
--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -51,7 +51,7 @@ public class TemplateController implements SpringDocTemplateController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) List<Long> tagIds,
-            @PageableDefault(size = 20, page = 1) Pageable pageable
+            @PageableDefault(size = 20) Pageable pageable
     ) {
         FindAllTemplatesResponse response = memberTemplateApplicationService.getAllTemplatesBy(
                 memberId, keyword, categoryId, tagIds, pageable);
@@ -65,7 +65,7 @@ public class TemplateController implements SpringDocTemplateController {
             @RequestParam(required = false) String keyword,
             @RequestParam(required = false) Long categoryId,
             @RequestParam(required = false) List<Long> tagIds,
-            @PageableDefault(size = 20, page = 1) Pageable pageable
+            @PageableDefault(size = 20) Pageable pageable
     ) {
         FindAllTemplatesResponse response = memberTemplateApplicationService.getAllTemplatesByWithMember(
                 memberId, keyword, categoryId, tagIds, pageable, memberDto);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #690

## 📍주요 변경 사항
```
spring:
  data.web.pageable.one-indexed-parameters: true
```

사용 시 기본 Controller 단에 도착하기 전에 위 설정이 적용되어 page 값이 1 적게 옵니다.
내부 레포지토리 로직에서는 여전히 0-based 인덱스를 사용합니다.

따라서 Controller에서 기본 값을 1이 아닌 0으로 재설정해줍니다.