### PR TITLE
좋아요 기능의 응답 코드를 통일

### DIFF
--- a/backend/src/main/java/codezap/likes/controller/LikesController.java
+++ b/backend/src/main/java/codezap/likes/controller/LikesController.java
@@ -26,6 +26,6 @@ public class LikesController implements SpringDocsLikesController {
     @DeleteMapping("like/{templateId}")
     public ResponseEntity<Void> cancelLike(@AuthenticationPrinciple MemberDto memberDto, @PathVariable long templateId) {
         likesService.cancelLike(memberDto, templateId);
-        return ResponseEntity.noContent().build();
+        return ResponseEntity.ok().build();
     }
 }


### PR DESCRIPTION
이전의 좋아요 기능 응답 코드는 다음과 같았습니다.

- 좋아요 성공 : 200
- 좋아요 취소 성공 : 204

200 응답은 좋아요를 하나의 동작으로 본 경우, 204 응답은 좋아요를 하나의 자원으로 본 경우라고 생각해요.
좋아요를 하나의 동작으로 본다면 200 / 200 응답이, 하나의 자원으로 본다면 201 / 204 응답이 적절할 것 같습니다.

이에 대한 논의는 아마 각자의 선호도가 달라 통일시키기 어려울 것으로 보입니다. 
또한, 옳고 그름의 문제가 아닌지라 어떤 선택이든 납득이 가능하기도 해요.

그래서 헤인의 "그렇다면 예외 처리 하기 편하게 200 으로 던져줘도 될까?" 라는 요청을 고려해 200 / 200 응답으로 수정합니다.