### PR TITLE
build시 정적 리소스에 cache busting 기법 적용

### DIFF
--- a/frontend/webpack.common.js
+++ b/frontend/webpack.common.js
@@ -1,12 +1,13 @@
 const { sentryWebpackPlugin } = require('@sentry/webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const path = require('path');
+const packageJson = require('./package.json');
 
 module.exports = {
   entry: './src/index.tsx',
   output: {
     path: path.resolve(__dirname, 'dist'),
-    filename: 'bundle.js',
+    filename: `bundle.v${packageJson.version}.[contenthash].js`,
     clean: true,
   },
   devServer: {
@@ -27,6 +28,9 @@ module.exports = {
           dataUrlCondition: {
             maxSize: 4 * 1024, // 4kb
           },
+        },
+        generator: {
+          filename: `images/[name].[contenthash][ext]`,
         },
       },
       {
@@ -57,7 +61,7 @@ module.exports = {
         test: /\.(woff|woff2|eot|ttf|otf)$/i,
         type: 'asset/resource',
         generator: {
-          filename: 'fonts/[name][ext][query]',
+          filename: `fonts/[name].[contenthash][ext]`,
         },
       },
     ],


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #695 

## 📍주요 변경 사항
1. 캐시 관리
- 빌드시 cache busting 적용
  - 빌드 파일에 버전 정보와 content hash를 붙입니다. content hash는 파일 내용에 따라 hash가 결정되며 변경사항이 없을 시 동일한 hash 값이 붙습니다.
  - hash에 더불어 version도 붙이는 것이 명시적이라고 생각했습니다. 해당 부분 관련해서 논의할 내용이 있다면 알려주세요.

## 🎸기타
1. [hash 관련 참고 자료](https://velog.io/@jiseong/Webpack-hash-chunkhash-%EA%B7%B8%EB%A6%AC%EA%B3%A0-contenthash-%EC%BA%90%EC%8B%B1%EC%A0%84%EB%9E%B5)
