### PR TITLE
RDS reader writer 적용

### DIFF
--- a/backend/src/main/java/codezap/global/rds/DataSourceConfig.java
+++ b/backend/src/main/java/codezap/global/rds/DataSourceConfig.java
@@ -45,8 +45,8 @@ public class DataSourceConfig {
         DataSource readerDataSource = readeDataSource();
 
         Map<Object, Object> dataSourceMap = new HashMap<>();
-        dataSourceMap.put("write", writerDataSource);
-        dataSourceMap.put("read", readerDataSource);
+        dataSourceMap.put(DataSourceRouter.WRITER_KEY, writerDataSource);
+        dataSourceMap.put(DataSourceRouter.READER_KEY, readerDataSource);
 
         dataSourceRouter.setTargetDataSources(dataSourceMap);
         dataSourceRouter.setDefaultTargetDataSource(writerDataSource);

--- a/backend/src/main/java/codezap/global/rds/DataSourceConfig.java
+++ b/backend/src/main/java/codezap/global/rds/DataSourceConfig.java
@@ -1,0 +1,63 @@
+package codezap.global.rds;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import javax.sql.DataSource;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.jdbc.DataSourceBuilder;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.DependsOn;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+import org.springframework.jdbc.datasource.LazyConnectionDataSourceProxy;
+
+import com.zaxxer.hikari.HikariDataSource;
+
+import lombok.RequiredArgsConstructor;
+
+@Configuration
+@RequiredArgsConstructor
+@Profile("prod")
+@EnableJpaRepositories(basePackages = "codezap")
+public class DataSourceConfig {
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.write")
+    public DataSource writeDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @ConfigurationProperties("spring.datasource.read")
+    public DataSource readeDataSource() {
+        return DataSourceBuilder.create().type(HikariDataSource.class).build();
+    }
+
+    @Bean
+    @DependsOn({"writeDataSource", "readeDataSource"})
+    public DataSource routeDataSource() {
+        DataSourceRouter dataSourceRouter = new DataSourceRouter();
+        DataSource writerDataSource = writeDataSource();
+        DataSource readerDataSource = readeDataSource();
+
+        Map<Object, Object> dataSourceMap = new HashMap<>();
+        dataSourceMap.put("write", writerDataSource);
+        dataSourceMap.put("read", readerDataSource);
+
+        dataSourceRouter.setTargetDataSources(dataSourceMap);
+        dataSourceRouter.setDefaultTargetDataSource(writerDataSource);
+
+        return dataSourceRouter;
+    }
+
+    @Bean
+    @Primary
+    @DependsOn({"routeDataSource"})
+    public DataSource dataSource() {
+        return new LazyConnectionDataSourceProxy(routeDataSource());
+    }
+}

--- a/backend/src/main/java/codezap/global/rds/DataSourceRouter.java
+++ b/backend/src/main/java/codezap/global/rds/DataSourceRouter.java
@@ -1,0 +1,17 @@
+package codezap.global.rds;
+
+import org.springframework.jdbc.datasource.lookup.AbstractRoutingDataSource;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
+
+public class DataSourceRouter extends AbstractRoutingDataSource {
+
+    @Override
+    protected Object determineCurrentLookupKey() {
+        boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
+
+        if(readOnly) {
+            return "read";
+        }
+        return "write";
+    }
+}

--- a/backend/src/main/java/codezap/global/rds/DataSourceRouter.java
+++ b/backend/src/main/java/codezap/global/rds/DataSourceRouter.java
@@ -5,13 +5,16 @@ import org.springframework.transaction.support.TransactionSynchronizationManager
 
 public class DataSourceRouter extends AbstractRoutingDataSource {
 
+    public static final String READER_KEY = "read";
+    public static final String WRITER_KEY = "write";
+
     @Override
     protected Object determineCurrentLookupKey() {
         boolean readOnly = TransactionSynchronizationManager.isCurrentTransactionReadOnly();
 
         if(readOnly) {
-            return "read";
+            return READER_KEY;
         }
-        return "write";
+        return WRITER_KEY;
     }
 }

--- a/backend/src/main/java/codezap/likes/service/LikesService.java
+++ b/backend/src/main/java/codezap/likes/service/LikesService.java
@@ -21,6 +21,7 @@ public class LikesService {
     private final MemberRepository memberRepository;
     private final LikesRepository likesRepository;
 
+    @Transactional
     public void like(MemberDto memberDto, long templateId) {
         Template template = templateRepository.fetchById(templateId);
         Member member = memberRepository.fetchById(memberDto.id());

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -25,6 +25,7 @@ public class TemplateService {
 
     private final TemplateRepository templateRepository;
 
+    @Transactional
     public Template create(Member member, CreateTemplateRequest createTemplateRequest, Category category) {
         Template template = new Template(
                 member,

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -52,6 +52,7 @@ public class TemplateService {
         return templateRepository.findAll(new TemplateSpecification(memberId, keyword, categoryId, tagIds), pageable);
     }
 
+    @Transactional
     public Template update(
             Member member,
             Long templateId,

--- a/backend/src/main/java/codezap/template/service/ThumbnailService.java
+++ b/backend/src/main/java/codezap/template/service/ThumbnailService.java
@@ -18,6 +18,7 @@ public class ThumbnailService {
 
     private final ThumbnailRepository thumbnailRepository;
 
+    @Transactional
     public void createThumbnail(Template template, SourceCode thumbnail) {
         thumbnailRepository.save(new Thumbnail(template, thumbnail));
     }

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -12,7 +12,8 @@
         <appender-ref ref="console-appender"/>
     </logger>
 
-    <root level="WARN">
+    <root level="INFO">
+        <appender-ref ref="info-appender"/>
         <appender-ref ref="warn-appender"/>
         <appender-ref ref="error-appender"/>
     </root>


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #699 

## 📍주요 변경 사항
1. 운영 환경의 데이터베이스를 RDS로 변경합니다.
2. `@Transational(readOnly=true)`를 설정하면 Reader 인스턴스를 사용하게 되고, `@Transactional`을 사용하거나 아예 사용하지 않으면 Writer 인스턴스를 사용합니다.
3. 해당 설정은 운영환경에만 적용됩니다.

