### PR TITLE
MyTemplatePage 초기 랜더링 Layoutshift 개선

### DIFF
--- a/frontend/src/api/templates.ts
+++ b/frontend/src/api/templates.ts
@@ -41,7 +41,6 @@ export const getTemplateList = async ({
   memberId,
 }: TemplateListRequest) => {
   const queryParams = new URLSearchParams({
-    keyword,
     sort,
     page: page.toString(),
     size: size.toString(),
@@ -57,6 +56,10 @@ export const getTemplateList = async ({
 
   if (tagIds?.length !== 0 && tagIds !== undefined) {
     queryParams.append('tagIds', tagIds.toString());
+  }
+
+  if (keyword) {
+    queryParams.append('keyword', keyword);
   }
 
   const url = `${TEMPLATE_API_URL}${memberId ? '/login' : ''}?${queryParams.toString()}`;

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,23 +1,32 @@
 import { Text } from '@/components';
+import { useAuth } from '@/hooks/authentication';
 
 import * as S from './Footer.style';
 
-const Footer = () => (
-  <S.FooterContainer>
-    <Text.Small color='inherit'>
-      Copyright{' '}
-      <Text.Small color='inherit' weight='bold'>
-        Codezap
-      </Text.Small>{' '}
-      © All rights reserved.
-    </Text.Small>
-    <S.ContactEmail href='mailto:codezap2024@gmail.com'>
-      <Text.Small color='inherit' weight='bold'>
-        문의 :
-      </Text.Small>{' '}
-      <Text.Small color='inherit'>codezap2024@gmail.com</Text.Small>{' '}
-    </S.ContactEmail>
-  </S.FooterContainer>
-);
+const Footer = () => {
+  const { isChecking } = useAuth();
+
+  if (isChecking) {
+    return null;
+  }
+
+  return (
+    <S.FooterContainer>
+      <Text.Small color='inherit'>
+        Copyright{' '}
+        <Text.Small color='inherit' weight='bold'>
+          Codezap
+        </Text.Small>{' '}
+        © All rights reserved.
+      </Text.Small>
+      <S.ContactEmail href='mailto:codezap2024@gmail.com'>
+        <Text.Small color='inherit' weight='bold'>
+          문의 :
+        </Text.Small>{' '}
+        <Text.Small color='inherit'>codezap2024@gmail.com</Text.Small>{' '}
+      </S.ContactEmail>
+    </S.FooterContainer>
+  );
+};
 
 export default Footer;

--- a/frontend/src/components/LoadingFallback/LoadingFallback.style.ts
+++ b/frontend/src/components/LoadingFallback/LoadingFallback.style.ts
@@ -1,0 +1,10 @@
+import styled from '@emotion/styled';
+
+export const FallbackContainer = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: center;
+
+  width: 100vw;
+  height: 100vh;
+`;

--- a/frontend/src/components/LoadingFallback/LoadingFallback.tsx
+++ b/frontend/src/components/LoadingFallback/LoadingFallback.tsx
@@ -1,0 +1,10 @@
+import LoadingBall from '../LoadingBall/LoadingBall';
+import * as S from './LoadingFallback.style';
+
+const LoadingFallback = () => (
+  <S.FallbackContainer>
+    <LoadingBall />
+  </S.FallbackContainer>
+);
+
+export default LoadingFallback;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -22,3 +22,4 @@ export { default as Footer } from './Footer/Footer';
 
 // Skeleton UI
 export { default as LoadingBall } from './LoadingBall/LoadingBall';
+export { default as LoadingFallback } from './LoadingFallback/LoadingFallback';

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, Suspense } from 'react';
+import { useState, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 
 import { DEFAULT_SORTING_OPTION, SORTING_OPTIONS } from '@/api';
@@ -42,9 +42,9 @@ const MyTemplatePage = () => {
     page,
   });
 
-  const templates = templateData?.templates || [];
-  const categories = categoryData?.categories || [];
-  const tags = tagData?.tags || [];
+  const templateList = templateData?.templates || [];
+  const categoryList = categoryData?.categories || [];
+  const tagList = tagData?.tags || [];
   const totalPages = templateData?.totalPages || 0;
 
   const { mutateAsync: deleteTemplates } = useTemplateDeleteMutation(selectedList);
@@ -70,13 +70,13 @@ const MyTemplatePage = () => {
   };
 
   const handleAllSelected = () => {
-    if (selectedList.length === templates.length) {
+    if (selectedList.length === templateList.length) {
       setSelectedList([]);
 
       return;
     }
 
-    setSelectedList(templates.map((template) => template.id));
+    setSelectedList(templateList.map((template) => template.id));
   };
 
   const handleDelete = () => {
@@ -86,7 +86,7 @@ const MyTemplatePage = () => {
   };
 
   const renderTemplateContent = () => {
-    if (templates.length === 0) {
+    if (templateList.length === 0) {
       if (debouncedKeyword !== '') {
         return (
           <Flex justify='center' align='center' padding='2rem'>
@@ -101,7 +101,7 @@ const MyTemplatePage = () => {
 
     return (
       <TemplateGrid
-        templates={templates}
+        templateList={templateList}
         cols={getGridCols(windowWidth)}
         isEditMode={isEditMode}
         selectedList={selectedList}
@@ -115,7 +115,7 @@ const MyTemplatePage = () => {
       <TopBanner name={name ?? '나'} />
       <S.MainContainer>
         <Flex direction='column' gap='2.5rem' style={{ marginTop: '4.5rem' }}>
-          <CategoryFilterMenu categories={categories} onSelectCategory={handleCategoryMenuClick} />
+          <CategoryFilterMenu categoryList={categoryList} onSelectCategory={handleCategoryMenuClick} />
         </Flex>
 
         <Flex direction='column' width='100%' gap='1rem'>
@@ -126,7 +126,7 @@ const MyTemplatePage = () => {
                   돌아가기
                 </Button>
                 <Button variant='outlined' size='small' onClick={handleAllSelected}>
-                  {selectedList.length === templates.length ? '전체 해제' : '전체 선택'}
+                  {selectedList.length === templateList.length ? '전체 해제' : '전체 선택'}
                 </Button>
                 <Button
                   variant={selectedList.length ? 'contained' : 'text'}
@@ -161,12 +161,12 @@ const MyTemplatePage = () => {
               getOptionLabel={(option) => option.value}
             />
           </Flex>
-          {tags.length !== 0 && (
-            <TagFilterMenu tags={tags} selectedTagIds={selectedTagIds} onSelectTags={handleTagMenuClick} />
+          {tagList.length !== 0 && (
+            <TagFilterMenu tagList={tagList} selectedTagIds={selectedTagIds} onSelectTags={handleTagMenuClick} />
           )}
-          <Suspense fallback={<div>거짓말이야~~</div>}>{renderTemplateContent()}</Suspense>
+          {renderTemplateContent()}
 
-          {templates.length !== 0 && (
+          {templateList.length !== 0 && (
             <Flex justify='center' gap='0.5rem' margin='1rem 0'>
               <PagingButtons currentPage={page} totalPages={totalPages} onPageChange={handlePageChange} />
             </Flex>

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -3,18 +3,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { DEFAULT_SORTING_OPTION, SORTING_OPTIONS } from '@/api';
 import { ArrowUpIcon, PlusIcon, SearchIcon } from '@/assets/images';
-import {
-  Flex,
-  Heading,
-  Input,
-  PagingButtons,
-  Dropdown,
-  Button,
-  Modal,
-  Text,
-  LoadingBall,
-  NoSearchResults,
-} from '@/components';
+import { Flex, Heading, Input, PagingButtons, Dropdown, Button, Modal, Text, NoSearchResults } from '@/components';
 import { useWindowWidth, useDebounce, useToggle, useDropdown, useInput } from '@/hooks';
 import { useAuth } from '@/hooks/authentication';
 import { useTemplateDeleteMutation, useTemplateCategoryTagQueries } from '@/queries/templates';

--- a/frontend/src/pages/MyTemplatesPage/components/CategoryFilterMenu/CategoryFilterMenu.stories.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/CategoryFilterMenu/CategoryFilterMenu.stories.tsx
@@ -7,7 +7,7 @@ import CategoryFilterMenu from './CategoryFilterMenu';
 const meta: Meta<typeof CategoryFilterMenu> = {
   title: 'CategoryFilterMenu',
   component: CategoryFilterMenu,
-  args: { categories },
+  args: { categoryList: categories },
 };
 
 export default meta;

--- a/frontend/src/pages/MyTemplatesPage/components/CategoryFilterMenu/CategoryFilterMenu.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/CategoryFilterMenu/CategoryFilterMenu.tsx
@@ -10,11 +10,11 @@ import { CategoryEditModal } from '../';
 import * as S from './CategoryFilterMenu.style';
 
 interface CategoryMenuProps {
-  categories: Category[];
+  categoryList: Category[];
   onSelectCategory: (selectedCategoryId: number) => void;
 }
 
-const CategoryFilterMenu = ({ categories, onSelectCategory }: CategoryMenuProps) => {
+const CategoryFilterMenu = ({ categoryList, onSelectCategory }: CategoryMenuProps) => {
   const [selectedId, setSelectedId] = useState<number>(0);
   const [isEditModalOpen, toggleEditModal] = useToggle();
   const [isMenuOpen, toggleMenu] = useToggle(false);
@@ -35,17 +35,17 @@ const CategoryFilterMenu = ({ categories, onSelectCategory }: CategoryMenuProps)
     }
   };
 
-  const [defaultCategory, ...userCategories] = categories.length ? categories : [{ id: 0, name: '' }];
+  const [defaultCategory, ...userCategories] = categoryList.length ? categoryList : [{ id: 0, name: '' }];
 
   const indexById: Record<number, number> = useMemo(() => {
-    const map: Record<number, number> = { 0: 0, [defaultCategory.id]: categories.length };
+    const map: Record<number, number> = { 0: 0, [defaultCategory.id]: categoryList.length };
 
     userCategories.forEach(({ id }, index) => {
       map[id] = index + 1;
     });
 
     return map;
-  }, [categories.length, defaultCategory.id, userCategories]);
+  }, [categoryList.length, defaultCategory.id, userCategories]);
 
   return (
     <>
@@ -81,7 +81,7 @@ const CategoryFilterMenu = ({ categories, onSelectCategory }: CategoryMenuProps)
           <S.HighlightBox
             data-testid='category-highlighter-box'
             selectedIndex={indexById[selectedId]}
-            categoryCount={categories.length}
+            categoryCount={categoryList.length}
             isMenuOpen={isMenuOpen}
           />
         </S.CategoryListContainer>

--- a/frontend/src/pages/MyTemplatesPage/components/TagFilterMenu/TagFilterMenu.stories.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TagFilterMenu/TagFilterMenu.stories.tsx
@@ -1,12 +1,13 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { tags } from '@/mocks/tagList.json';
+
 import TagFilterMenu from './TagFilterMenu';
 
 const meta: Meta<typeof TagFilterMenu> = {
   title: 'TagFilterMenu',
   component: TagFilterMenu,
-  args: { tags },
+  args: { tagList: tags },
 };
 
 export default meta;

--- a/frontend/src/pages/MyTemplatesPage/components/TagFilterMenu/TagFilterMenu.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TagFilterMenu/TagFilterMenu.tsx
@@ -11,12 +11,12 @@ import * as S from './TagFilterMenu.style';
 const LINE_HEIGHT_REM = 1.875;
 
 interface Props {
-  tags: Tag[];
+  tagList: Tag[];
   selectedTagIds: number[];
   onSelectTags: (selectedTagIds: number[]) => void;
 }
 
-const TagFilterMenu = ({ tags, selectedTagIds, onSelectTags }: Props) => {
+const TagFilterMenu = ({ tagList, selectedTagIds, onSelectTags }: Props) => {
   const [deselectedTags, setDeselectedTags] = useState<Tag[]>([]);
   const [isTagBoxOpen, toggleTagBox] = useToggle(false);
   const [height, setHeight] = useState(`${LINE_HEIGHT_REM}rem`);
@@ -40,11 +40,11 @@ const TagFilterMenu = ({ tags, selectedTagIds, onSelectTags }: Props) => {
     };
 
     updateTagContainerState();
-  }, [tags, selectedTagIds, isTagBoxOpen, windowWidth]);
+  }, [tagList, selectedTagIds, isTagBoxOpen, windowWidth]);
 
   const handleButtonClick = (tagId: number) => {
     if (selectedTagIds.includes(tagId)) {
-      const deselectedTag = tags.find((tag) => tag.id === tagId);
+      const deselectedTag = tagList.find((tag) => tag.id === tagId);
 
       if (deselectedTag) {
         setDeselectedTags((prev) => [deselectedTag, ...prev.filter((tag) => tag.id !== tagId)]);
@@ -57,10 +57,10 @@ const TagFilterMenu = ({ tags, selectedTagIds, onSelectTags }: Props) => {
     }
   };
 
-  const selectedTags = selectedTagIds.map((id) => tags.find((tag) => tag.id === id)!).filter(Boolean);
+  const selectedTags = selectedTagIds.map((id) => tagList.find((tag) => tag.id === id)!).filter(Boolean);
 
   const unselectedTags = deselectedTags.concat(
-    tags.filter(
+    tagList.filter(
       (tag) => !selectedTagIds.includes(tag.id) && !deselectedTags.some((deselectedTag) => deselectedTag.id === tag.id),
     ),
   );

--- a/frontend/src/pages/MyTemplatesPage/components/TagFilterMenu/TagFilterMenu.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TagFilterMenu/TagFilterMenu.tsx
@@ -19,26 +19,26 @@ interface Props {
 const TagFilterMenu = ({ tags, selectedTagIds, onSelectTags }: Props) => {
   const [deselectedTags, setDeselectedTags] = useState<Tag[]>([]);
   const [isTagBoxOpen, toggleTagBox] = useToggle(false);
-  const [height, setHeight] = useState('auto');
+  const [height, setHeight] = useState(`${LINE_HEIGHT_REM}rem`);
   const containerRef = useRef<HTMLDivElement>(null);
   const [showMoreButton, setShowMoreButton] = useState(false);
   const windowWidth = useWindowWidth();
 
-  const updateTagContainerState = () => {
-    if (containerRef.current) {
-      const containerHeight = containerRef.current.scrollHeight;
-
-      setHeight(isTagBoxOpen ? `${containerHeight}px` : `${LINE_HEIGHT_REM}rem`);
-
-      if (containerHeight > remToPx(LINE_HEIGHT_REM)) {
-        setShowMoreButton(true);
-      } else {
-        setShowMoreButton(false);
-      }
-    }
-  };
-
   useEffect(() => {
+    const updateTagContainerState = () => {
+      if (containerRef.current) {
+        const containerHeight = containerRef.current.scrollHeight;
+
+        setHeight(isTagBoxOpen ? `${containerHeight}px` : `${LINE_HEIGHT_REM}rem`);
+
+        if (containerHeight > remToPx(LINE_HEIGHT_REM)) {
+          setShowMoreButton(true);
+        } else {
+          setShowMoreButton(false);
+        }
+      }
+    };
+
     updateTagContainerState();
   }, [tags, selectedTagIds, isTagBoxOpen, windowWidth]);
 

--- a/frontend/src/pages/MyTemplatesPage/components/TemplateGrid/TemplateGrid.stories.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TemplateGrid/TemplateGrid.stories.tsx
@@ -1,13 +1,14 @@
 import type { Meta, StoryObj } from '@storybook/react';
 
 import { templates } from '@/mocks/templateList.json';
+
 import TemplateGrid from './TemplateGrid';
 
 const meta: Meta<typeof TemplateGrid> = {
   title: 'TemplateGrid',
   component: TemplateGrid,
   args: {
-    templates,
+    templateList: templates,
   },
 };
 

--- a/frontend/src/pages/MyTemplatesPage/components/TemplateGrid/TemplateGrid.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TemplateGrid/TemplateGrid.tsx
@@ -3,17 +3,18 @@ import { Link } from 'react-router-dom';
 
 import { TemplateCard } from '@/components';
 import { TemplateListItem } from '@/types';
+
 import * as S from './TemplateGrid.style';
 
 interface Props {
-  templates: TemplateListItem[];
+  templateList: TemplateListItem[];
   isEditMode: boolean;
   selectedList: number[];
   setSelectedList: React.Dispatch<React.SetStateAction<number[]>>;
   cols?: number;
 }
 
-const TemplateGrid = ({ templates, isEditMode, selectedList, setSelectedList, cols = 2 }: Props) => {
+const TemplateGrid = ({ templateList, isEditMode, selectedList, setSelectedList, cols = 2 }: Props) => {
   useEffect(() => {
     const resetSelectedList = () => {
       setSelectedList([]);
@@ -30,7 +31,7 @@ const TemplateGrid = ({ templates, isEditMode, selectedList, setSelectedList, co
 
   return (
     <S.TemplateContainer cols={cols}>
-      {templates.map((template) =>
+      {templateList.map((template) =>
         isEditMode ? (
           <S.TemplateCardWrapper
             key={template.id}

--- a/frontend/src/pages/TemplatePage/TemplatePage.tsx
+++ b/frontend/src/pages/TemplatePage/TemplatePage.tsx
@@ -5,7 +5,18 @@ import CodeMirror, { EditorView } from '@uiw/react-codemirror';
 import { useParams } from 'react-router-dom';
 
 import { ChevronIcon, ClockIcon, PersonIcon } from '@/assets/images';
-import { Button, Flex, Heading, LikeButton, Modal, SelectList, TagButton, Text, NonmemberAlerter } from '@/components';
+import {
+  Button,
+  Flex,
+  Heading,
+  LikeButton,
+  Modal,
+  SelectList,
+  TagButton,
+  Text,
+  NonmemberAlerter,
+  LoadingFallback,
+} from '@/components';
 import { ToastContext } from '@/contexts';
 import { useCustomContext, useToggle } from '@/hooks';
 import { useAuth } from '@/hooks/authentication';
@@ -65,7 +76,7 @@ const TemplatePage = () => {
   };
 
   if (!template) {
-    return <div>템플릿을 불러오는 중...</div>;
+    return <LoadingFallback />;
   }
 
   return (

--- a/frontend/src/queries/templates/index.ts
+++ b/frontend/src/queries/templates/index.ts
@@ -4,3 +4,4 @@ export { useTemplateQuery } from './useTemplateQuery';
 export { useTemplateUploadMutation } from './useTemplateUploadMutation';
 export { useTemplateEditMutation } from './useTemplateEditMutation';
 export { useTemplateDeleteMutation } from './useTemplateDeleteMutation';
+export { useTemplateCategoryTagQueries } from './useTemplateCategoryTagQueries';

--- a/frontend/src/queries/templates/useTemplateCategoryTagQueries.ts
+++ b/frontend/src/queries/templates/useTemplateCategoryTagQueries.ts
@@ -1,0 +1,44 @@
+import { useSuspenseQueries } from '@tanstack/react-query';
+
+import { QUERY_KEY, getTemplateList, getTagList, getCategoryList, DEFAULT_SORTING_OPTION, PAGE_SIZE } from '@/api';
+import { useAuth } from '@/hooks/authentication/useAuth';
+import type { SortingKey } from '@/types';
+
+interface Props {
+  keyword?: string;
+  categoryId?: number;
+  tagIds?: number[];
+  sort?: SortingKey;
+  page?: number;
+  size?: number;
+}
+
+export const useTemplateCategoryTagQueries = ({
+  keyword,
+  categoryId,
+  tagIds,
+  sort = DEFAULT_SORTING_OPTION.key,
+  page = 1,
+  size = PAGE_SIZE,
+}: Props) => {
+  const {
+    memberInfo: { memberId },
+  } = useAuth();
+
+  return useSuspenseQueries({
+    queries: [
+      {
+        queryKey: [QUERY_KEY.TEMPLATE_LIST, keyword, categoryId, tagIds, sort, page, size, memberId],
+        queryFn: () => getTemplateList({ keyword, categoryId, tagIds, sort, page, size, memberId }),
+      },
+      {
+        queryKey: [QUERY_KEY.CATEGORY_LIST],
+        queryFn: () => getCategoryList({ memberId }),
+      },
+      {
+        queryKey: [QUERY_KEY.TAG_LIST],
+        queryFn: () => getTagList({ memberId }),
+      },
+    ],
+  });
+};

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -2,7 +2,7 @@ import { ErrorBoundary } from '@sentry/react';
 import { Suspense } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
-import { Flex, Layout, LoadingBall } from '@/components';
+import { Layout, LoadingFallback } from '@/components';
 import {
   TemplatePage,
   TemplateUploadPage,
@@ -31,13 +31,7 @@ const router = createBrowserRouter([
         element: (
           <RouteGuard isLoginRequired redirectTo={END_POINTS.LOGIN}>
             <ErrorBoundary fallback={<NotFoundPage />}>
-              <Suspense
-                fallback={
-                  <Flex align='center' justify='center' width='100vw' height='100vh'>
-                    <LoadingBall />
-                  </Flex>
-                }
-              >
+              <Suspense fallback={<LoadingFallback />}>
                 <MyTemplatePage />
               </Suspense>
             </ErrorBoundary>

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -33,7 +33,7 @@ const router = createBrowserRouter([
             <ErrorBoundary fallback={<NotFoundPage />}>
               <Suspense
                 fallback={
-                  <Flex align='center' justify='center' css={{ width: '100vw', height: '100vh' }}>
+                  <Flex align='center' justify='center' width='100vw' height='100vh'>
                     <LoadingBall />
                   </Flex>
                 }

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,6 +1,8 @@
+import { ErrorBoundary } from '@sentry/react';
+import { Suspense } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
-import { Layout } from '@/components';
+import { Flex, Layout, LoadingBall } from '@/components';
 import {
   TemplatePage,
   TemplateUploadPage,
@@ -28,7 +30,17 @@ const router = createBrowserRouter([
         path: END_POINTS.MY_TEMPLATES,
         element: (
           <RouteGuard isLoginRequired redirectTo={END_POINTS.LOGIN}>
-            <MyTemplatePage />
+            <ErrorBoundary fallback={<NotFoundPage />}>
+              <Suspense
+                fallback={
+                  <Flex align='center' justify='center' css={{ width: '100vw', height: '100vh' }}>
+                    <LoadingBall />
+                  </Flex>
+                }
+              >
+                <MyTemplatePage />
+              </Suspense>
+            </ErrorBoundary>
           </RouteGuard>
         ),
       },


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #695

## 🪧 리펙토링 결과
- MyTemplatePage 초기 랜더링 Layoutshift 개선 
**- GLS 0.837 => 0.012 로 개선**

|Before|After|
|---|---|
|<img width="570" alt="image" src="https://github.com/user-attachments/assets/557b0b27-751c-418f-abad-863bd28f151c">|![image](https://github.com/user-attachments/assets/cbbf86db-a517-4298-ae34-413cfd01c5da)


## 📍주요 변경 사항
### 1. 템플릿 목록, 카테고리 목록, 태그 목록을 한 번에 불러오도록 하고, 서스펜스를 통해 감싸주어 Layoutshift를 개선
- `useTemplateCategoryTagQueries` 에서 3개의 요청이 모두 성공할 때 까지 기다림

### 2. 템플릿 목록 요청시 keyword 있는 경우에만 params 에 추가하도록 변경
- 기존에는 키워드 없어도 '' 으로 보내줬으나, 백엔드 측에서 사용하지 않는 params 보내지 않도록 변경 요청하여 반영함.

### 3. `-List` 로 용어 통일
- templates, categories, tags => templateList, categoryList, tagList로 이름 변경
- 컨벤션으로 복수형보다는 List 와 같은 명시적인 단어로 표현하기로 했기 때문.

## 🎸기타
### 1. 현재 서스펜스가 `MyTemplatePage` 자체를 감싸고 있기 때문에, 새로운 요청을 보낼때마다 페이지 전체가 fallback 이 보이는 현상이 있습니다. 개인적으로 이 부분은 사용자 경험이 좋지 않아 반드시 개선되어야 한다고 생각합니다.
=> 추후 컴포넌트 계층 분리를 다시 한 후 서스펜스를 각각 감싸보면 어떨까 싶습니다.
