### PR TITLE
전문 검색 인덱스 적용

### DIFF
--- a/backend/src/main/java/codezap/template/repository/FullTextSearchMySQLDialect.java
+++ b/backend/src/main/java/codezap/template/repository/FullTextSearchMySQLDialect.java
@@ -1,0 +1,46 @@
+package codezap.template.repository;
+
+import java.util.List;
+
+import org.hibernate.boot.model.FunctionContributions;
+import org.hibernate.dialect.MySQLDialect;
+import org.hibernate.query.ReturnableType;
+import org.hibernate.query.sqm.function.NamedSqmFunctionDescriptor;
+import org.hibernate.query.sqm.function.SqmFunctionRegistry;
+import org.hibernate.query.sqm.produce.function.StandardArgumentsValidators;
+import org.hibernate.sql.ast.SqlAstNodeRenderingMode;
+import org.hibernate.sql.ast.SqlAstTranslator;
+import org.hibernate.sql.ast.spi.SqlAppender;
+import org.hibernate.sql.ast.tree.SqlAstNode;
+
+public class FullTextSearchMySQLDialect extends MySQLDialect {
+
+    @Override
+    public void initializeFunctionRegistry(FunctionContributions functionContributions) {
+        super.initializeFunctionRegistry(functionContributions);
+
+        SqmFunctionRegistry functionRegistry = functionContributions.getFunctionRegistry();
+        functionRegistry.register("match", ExactPhraseMatchFunction.INSTANCE);
+    }
+
+    public static class ExactPhraseMatchFunction extends NamedSqmFunctionDescriptor {
+
+        public static final ExactPhraseMatchFunction INSTANCE = new ExactPhraseMatchFunction();
+
+        public ExactPhraseMatchFunction() {
+            super("MATCH", false, StandardArgumentsValidators.exactly(3), null);
+        }
+
+        @Override
+        public void render(SqlAppender sqlAppender, List<? extends SqlAstNode> arguments, ReturnableType<?> returnType, SqlAstTranslator<?> translator) {
+            sqlAppender.appendSql("MATCH(");
+            translator.render(arguments.get(0), SqlAstNodeRenderingMode.DEFAULT);
+            sqlAppender.appendSql(", ");
+            translator.render(arguments.get(1), SqlAstNodeRenderingMode.DEFAULT);
+            sqlAppender.appendSql(") AGAINST (");
+            translator.render(arguments.get(2), SqlAstNodeRenderingMode.DEFAULT);
+            sqlAppender.appendSql(" IN NATURAL LANGUAGE MODE)");
+
+        }
+    }
+}

--- a/backend/src/main/resources/db/migration/V6__add_full_text_index.sql
+++ b/backend/src/main/resources/db/migration/V6__add_full_text_index.sql
@@ -1,0 +1,2 @@
+ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description);
+ALTER TABLE source_code ADD FULLTEXT INDEX idx_source_code_fulltext (content, filename);

--- a/backend/src/test/java/codezap/global/DatabaseCleaner.java
+++ b/backend/src/test/java/codezap/global/DatabaseCleaner.java
@@ -13,7 +13,7 @@ public class DatabaseCleaner extends AbstractTestExecutionListener {
         JdbcTemplate jdbcTemplate = testContext.getApplicationContext().getBean(JdbcTemplate.class);
         List<String> queries = getTruncateQueries(jdbcTemplate);
         truncate(queries, jdbcTemplate);
-        recreateFullTextIndex(jdbcTemplate);
+        createIfNotExistFullTextIndex(jdbcTemplate);
     }
 
     private List<String> getTruncateQueries(final JdbcTemplate jdbcTemplate) {
@@ -31,24 +31,22 @@ public class DatabaseCleaner extends AbstractTestExecutionListener {
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1;");
     }
 
-    private void recreateFullTextIndex(JdbcTemplate jdbcTemplate) {
-        dropIndexIfExists(jdbcTemplate, "template", "idx_template_fulltext");
-        dropIndexIfExists(jdbcTemplate, "source_code", "idx_source_code_fulltext");
-
-        jdbcTemplate.execute("ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description)");
-        jdbcTemplate.execute("ALTER TABLE source_code ADD FULLTEXT INDEX idx_source_code_fulltext (content, filename)");
+    private void createIfNotExistFullTextIndex(JdbcTemplate jdbcTemplate) {
+        if (!indexExists(jdbcTemplate, "template", "idx_template_fulltext")) {
+            jdbcTemplate.execute("ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description)");
+        }
+        if (!indexExists(jdbcTemplate, "source_code", "idx_source_code_fulltext")) {
+            jdbcTemplate.execute("ALTER TABLE source_code ADD FULLTEXT INDEX idx_source_code_fulltext (content, filename)");
+        }
     }
 
-    private void dropIndexIfExists(JdbcTemplate jdbcTemplate, String tableName, String indexName) {
-        String checkIndexQuery = "SELECT COUNT(*) FROM information_schema.statistics " +
-                "WHERE table_schema = DATABASE() " +
-                "AND table_name = ? " +
-                "AND index_name = ?";
-
-        int indexCount = jdbcTemplate.queryForObject(checkIndexQuery, Integer.class, tableName, indexName);
-
-        if (indexCount > 0) {
-            jdbcTemplate.execute("ALTER TABLE " + tableName + " DROP INDEX " + indexName);
-        }
+    private boolean indexExists(JdbcTemplate jdbcTemplate, String tableName, String indexName) {
+        Integer count = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM INFORMATION_SCHEMA.STATISTICS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = ? AND INDEX_NAME = ?",
+                Integer.class,
+                tableName,
+                indexName
+        );
+        return count != null && count > 0;
     }
 }

--- a/backend/src/test/java/codezap/global/DatabaseCleaner.java
+++ b/backend/src/test/java/codezap/global/DatabaseCleaner.java
@@ -13,6 +13,7 @@ public class DatabaseCleaner extends AbstractTestExecutionListener {
         JdbcTemplate jdbcTemplate = testContext.getApplicationContext().getBean(JdbcTemplate.class);
         List<String> queries = getTruncateQueries(jdbcTemplate);
         truncate(queries, jdbcTemplate);
+        recreateFullTextIndex(jdbcTemplate);
     }
 
     private List<String> getTruncateQueries(final JdbcTemplate jdbcTemplate) {
@@ -28,5 +29,26 @@ public class DatabaseCleaner extends AbstractTestExecutionListener {
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 0;");
         queries.forEach(jdbcTemplate::execute);
         jdbcTemplate.execute("SET FOREIGN_KEY_CHECKS = 1;");
+    }
+
+    private void recreateFullTextIndex(JdbcTemplate jdbcTemplate) {
+        dropIndexIfExists(jdbcTemplate, "template", "idx_template_fulltext");
+        dropIndexIfExists(jdbcTemplate, "source_code", "idx_source_code_fulltext");
+
+        jdbcTemplate.execute("ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description)");
+        jdbcTemplate.execute("ALTER TABLE source_code ADD FULLTEXT INDEX idx_source_code_fulltext (content, filename)");
+    }
+
+    private void dropIndexIfExists(JdbcTemplate jdbcTemplate, String tableName, String indexName) {
+        String checkIndexQuery = "SELECT COUNT(*) FROM information_schema.statistics " +
+                "WHERE table_schema = DATABASE() " +
+                "AND table_name = ? " +
+                "AND index_name = ?";
+
+        int indexCount = jdbcTemplate.queryForObject(checkIndexQuery, Integer.class, tableName, indexName);
+
+        if (indexCount > 0) {
+            jdbcTemplate.execute("ALTER TABLE " + tableName + " DROP INDEX " + indexName);
+        }
     }
 }

--- a/backend/src/test/java/codezap/template/repository/TemplateJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateJpaRepositoryTest.java
@@ -4,16 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import java.util.Arrays;
-import java.util.List;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.jpa.domain.Specification;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
@@ -24,11 +18,7 @@ import codezap.global.exception.CodeZapException;
 import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
-import codezap.tag.domain.Tag;
-import codezap.tag.repository.TagRepository;
-import codezap.tag.repository.TemplateTagRepository;
 import codezap.template.domain.Template;
-import codezap.template.domain.TemplateTag;
 
 @JpaRepositoryTest
 class TemplateJpaRepositoryTest {
@@ -39,10 +29,6 @@ class TemplateJpaRepositoryTest {
     private MemberRepository memberRepository;
     @Autowired
     private CategoryRepository categoryRepository;
-    @Autowired
-    private TagRepository tagRepository;
-    @Autowired
-    private TemplateTagRepository templateTagRepository;
 
     @Test
     @DisplayName("카테고리 id로 템플릿 존재 여부 확인 ")
@@ -103,252 +89,6 @@ class TemplateJpaRepositoryTest {
         void findByMemberIdWhenNotExistsMember() {
             Long notSavedId = 1L;
             assertThat(templateRepository.findByMemberId(notSavedId)).isEmpty();
-        }
-    }
-
-    @Nested
-    @DisplayName("검색 테스트")
-    class FindAll {
-
-        private Member member1, member2;
-        private Category category1, category2;
-        private Tag tag1, tag2;
-        private Template template1, template2, template3;
-
-        @Test
-        @DisplayName("검색 테스트: 회원 ID로 템플릿 조회 성공")
-        void testFindByMemberId() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            Specification<Template> spec = new TemplateSpecification(member1.getId(), null, null, null);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent()).hasSize(2),
-                    () -> assertThat(result.getContent())
-                            .allMatch(template -> template.getMember().getId().equals(member1.getId()))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 키워드로 템플릿 조회 성공")
-        void testFindByKeyword() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            String keyword = "Template";
-            Specification<Template> spec = new TemplateSpecification(null, keyword, null, null);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent())
-                            .allMatch(template -> template.getTitle().contains(keyword)
-                                    || template.getDescription().contains(keyword)),
-                    () -> assertThat(result.getContent()).hasSize(3)
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 카테고리 ID로 템플릿 조회 성공")
-        void testFindByCategoryId() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            Specification<Template> spec = new TemplateSpecification(null, null, category1.getId(),
-                    null);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent()).hasSize(2),
-                    () -> assertThat(result.getContent())
-                            .allMatch(template -> template.getCategory().getId().equals(category1.getId()))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 태그 ID 목록으로 템플릿 조회, 모든 태그를 가진 템플릿만 조회 성공")
-        void testFindByTagIds() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
-            Specification<Template> spec = new TemplateSpecification(null, null, null, tagIds);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent())
-                            .containsExactlyInAnyOrder(
-                                    templateRepository.fetchById(1L),
-                                    templateRepository.fetchById(2L)),
-                    () -> assertThat(result.getContent()).hasSize(2)
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 단일 태그 ID로 템플릿 조회 성공")
-        void testFindBySingleTagId() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            List<Long> tagIds = List.of(tag2.getId());
-            Specification<Template> spec = new TemplateSpecification(null, null, null, tagIds);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent())
-                            .containsExactlyInAnyOrder(
-                                    templateRepository.fetchById(1L),
-                                    templateRepository.fetchById(2L),
-                                    templateRepository.fetchById(3L)),
-                    () -> assertThat(result.getContent()).hasSize(3)
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 회원 ID와 키워드로 템플릿 조회 성공")
-        void testFindByMemberIdAndKeyword() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            String keyword = "Template";
-            Specification<Template> spec = new TemplateSpecification(member1.getId(), keyword, null,
-                    null);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent()).hasSize(2),
-                    () -> assertThat(result.getContent())
-                            .allMatch(template -> template.getMember().getId().equals(member1.getId())
-                                    && (template.getTitle().contains(keyword)
-                                    || template.getDescription().contains(keyword)))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 회원 ID와 카테고리 ID로 템플릿 조회 성공")
-        void testFindByMemberIdAndCategoryId() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            Specification<Template> spec = new TemplateSpecification(member1.getId(), null, category1.getId(),
-                    null);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent()).hasSize(1),
-                    () -> assertThat(result.getContent().get(0).getMember().getId()).isEqualTo(member1.getId()),
-                    () -> assertThat(result.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId())
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 회원 ID와 태그 ID 목록으로 템플릿 조회 성공")
-        void testFindByMemberIdAndTagIds() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
-            Specification<Template> spec = new TemplateSpecification(member1.getId(), null, null,
-                    tagIds);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent()).hasSize(2),
-                    () -> assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
-                            templateRepository.fetchById(2L))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 모든 검색 기준으로 템플릿 조회 성공")
-        void testFindWithAllCriteria() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            String keyword = "Template";
-            List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
-            Specification<Template> spec = new TemplateSpecification(member1.getId(), keyword, category1.getId(),
-                    tagIds);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertAll(
-                    () -> assertThat(result.getContent()).hasSize(1),
-                    () -> assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 테스트: 검색 결과가 없는 경우 빈 리스트 반환 성공")
-        void testFindWithNoResults() {
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
-
-            Specification<Template> spec = new TemplateSpecification(null, "NonexistentKeyword", null, null);
-            Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
-
-            assertThat(result.getContent()).isEmpty();
-        }
-
-        private void saveTwoMembers() {
-            member1 = memberRepository.save(MemberFixture.getFirstMember());
-            member2 = memberRepository.save(MemberFixture.getSecondMember());
-        }
-
-        private void saveTwoCategory() {
-            category1 = categoryRepository.save(new Category("Category 1", member1));
-            category2 = categoryRepository.save(new Category("Category 2", member1));
-        }
-
-        private void saveTwoTags() {
-            tag1 = tagRepository.save(new Tag("Tag 1"));
-            tag2 = tagRepository.save(new Tag("Tag 2"));
-        }
-
-        private void saveThreeTemplates() {
-            template1 = templateRepository.save(TemplateFixture.get(member1, category1));
-            template2 = templateRepository.save(TemplateFixture.get(member1, category2));
-            template3 = templateRepository.save(TemplateFixture.get(member2, category1));
-        }
-
-        private void saveTemplateTags() {
-            templateTagRepository.save(new TemplateTag(template1, tag1));
-            templateTagRepository.save(new TemplateTag(template1, tag2));
-
-            templateTagRepository.save(new TemplateTag(template2, tag1));
-            templateTagRepository.save(new TemplateTag(template2, tag2));
-
-            templateTagRepository.save(new TemplateTag(template3, tag2));
         }
     }
 }

--- a/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
@@ -1,0 +1,266 @@
+package codezap.template.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.Arrays;
+import java.util.List;
+
+import jakarta.persistence.EntityManager;
+import jakarta.persistence.PersistenceContext;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.test.context.jdbc.Sql;
+import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
+
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
+import codezap.global.DatabaseIsolation;
+import codezap.global.auditing.JpaAuditingConfiguration;
+import codezap.global.repository.JpaRepositoryTest;
+import codezap.member.domain.Member;
+import codezap.member.repository.MemberRepository;
+import codezap.tag.domain.Tag;
+import codezap.tag.repository.TagRepository;
+import codezap.tag.repository.TemplateTagRepository;
+import codezap.template.domain.Template;
+import codezap.template.domain.TemplateTag;
+
+@DataJpaTest
+@Import(JpaAuditingConfiguration.class)
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql(scripts = "classpath:search.sql", executionPhase = ExecutionPhase.BEFORE_TEST_CLASS)
+class TemplateSearchJpaRepositoryTest {
+
+    @Autowired
+    private TemplateRepository templateRepository;
+    @Autowired
+    private MemberRepository memberRepository;
+    @Autowired
+    private CategoryRepository categoryRepository;
+    @Autowired
+    private TagRepository tagRepository;
+    @Autowired
+    private TemplateTagRepository templateTagRepository;
+
+    private Member member1, member2;
+    private Category category1, category2;
+    private Tag tag1, tag2;
+    private Template template1, template2, template3;
+
+    @BeforeEach
+    void setUp() {
+//        saveInitialData();
+
+        category1 = categoryRepository.fetchById(1L);
+        category2 = categoryRepository.fetchById(2L);
+
+        tag1 = tagRepository.fetchById(1L);
+        tag2 = tagRepository.fetchById(2L);
+
+        template1 = templateRepository.fetchById(1L);
+        template2 = templateRepository.fetchById(2L);
+        template3 = templateRepository.fetchById(3L);
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 회원 ID로 템플릿 조회 성공")
+    void testFindByMemberId() {
+        member1 = memberRepository.fetchById(1L);
+        Specification<Template> spec = new TemplateSpecification(member1.getId(), null, null, null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(2),
+                () -> assertThat(result.getContent())
+                        .allMatch(template -> template.getMember().getId().equals(member1.getId()))
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 키워드로 템플릿 조회 성공")
+    void testFindByKeyword() {
+        String keyword = "Template";
+        Specification<Template> spec = new TemplateSpecification(null, keyword, null, null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent())
+                        .allMatch(template -> template.getTitle().contains(keyword)
+                                || template.getDescription().contains(keyword)),
+                () -> assertThat(result.getContent()).hasSize(3)
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 카테고리 ID로 템플릿 조회 성공")
+    void testFindByCategoryId() {
+        Specification<Template> spec = new TemplateSpecification(null, null, category1.getId(),
+                null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(2),
+                () -> assertThat(result.getContent())
+                        .allMatch(template -> template.getCategory().getId().equals(category1.getId()))
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 태그 ID 목록으로 템플릿 조회, 모든 태그를 가진 템플릿만 조회 성공")
+    void testFindByTagIds() {
+        List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
+        Specification<Template> spec = new TemplateSpecification(null, null, null, tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent())
+                        .containsExactlyInAnyOrder(
+                                templateRepository.fetchById(1L),
+                                templateRepository.fetchById(2L)),
+                () -> assertThat(result.getContent()).hasSize(2)
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 단일 태그 ID로 템플릿 조회 성공")
+    void testFindBySingleTagId() {
+        List<Long> tagIds = List.of(tag2.getId());
+        Specification<Template> spec = new TemplateSpecification(null, null, null, tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent())
+                        .containsExactlyInAnyOrder(
+                                templateRepository.fetchById(1L),
+                                templateRepository.fetchById(2L),
+                                templateRepository.fetchById(3L)),
+                () -> assertThat(result.getContent()).hasSize(3)
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 회원 ID와 키워드로 템플릿 조회 성공")
+    void testFindByMemberIdAndKeyword() {
+        member1 = memberRepository.fetchById(1L);
+        String keyword = "Template";
+        Specification<Template> spec = new TemplateSpecification(member1.getId(), keyword, null,
+                null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(2),
+                () -> assertThat(result.getContent())
+                        .allMatch(template -> template.getMember().getId().equals(member1.getId())
+                                && (template.getTitle().contains(keyword)
+                                || template.getDescription().contains(keyword)))
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 회원 ID와 카테고리 ID로 템플릿 조회 성공")
+    void testFindByMemberIdAndCategoryId() {
+        member1 = memberRepository.fetchById(1L);
+        Specification<Template> spec = new TemplateSpecification(member1.getId(), null, category1.getId(),
+                null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(1),
+                () -> assertThat(result.getContent().get(0).getMember().getId()).isEqualTo(member1.getId()),
+                () -> assertThat(result.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId())
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 회원 ID와 태그 ID 목록으로 템플릿 조회 성공")
+    void testFindByMemberIdAndTagIds() {
+        member1 = memberRepository.fetchById(1L);
+        List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
+        Specification<Template> spec = new TemplateSpecification(member1.getId(), null, null,
+                tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(2),
+                () -> assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
+                        templateRepository.fetchById(2L))
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 모든 검색 기준으로 템플릿 조회 성공")
+    void testFindWithAllCriteria() {
+        member1 = memberRepository.fetchById(1L);
+        String keyword = "Template";
+        List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
+        Specification<Template> spec = new TemplateSpecification(member1.getId(), keyword, category1.getId(),
+                tagIds);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertAll(
+                () -> assertThat(result.getContent()).hasSize(1),
+                () -> assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
+        );
+    }
+
+    @Test
+    @DisplayName("검색 테스트: 검색 결과가 없는 경우 빈 리스트 반환 성공")
+    void testFindWithNoResults() {
+        Specification<Template> spec = new TemplateSpecification(null, "NonexistentKeyword", null, null);
+        Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
+
+        assertThat(result.getContent()).isEmpty();
+    }
+
+    private void saveInitialData() {
+        saveTwoMembers();
+        saveTwoCategory();
+        saveTwoTags();
+        saveThreeTemplates();
+        saveTemplateTags();
+    }
+
+    private void saveTwoMembers() {
+        member1 = memberRepository.save(MemberFixture.getFirstMember());
+        member2 = memberRepository.save(MemberFixture.getSecondMember());
+    }
+
+    private void saveTwoCategory() {
+        category1 = categoryRepository.save(new Category("Category 1", member1));
+        category2 = categoryRepository.save(new Category("Category 2", member1));
+    }
+
+    private void saveTwoTags() {
+        tag1 = tagRepository.save(new Tag("Tag 1"));
+        tag2 = tagRepository.save(new Tag("Tag 2"));
+    }
+
+    private void saveThreeTemplates() {
+        template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+        template2 = templateRepository.save(TemplateFixture.get(member1, category2));
+        template3 = templateRepository.save(TemplateFixture.get(member2, category1));
+    }
+
+    private void saveTemplateTags() {
+        templateTagRepository.save(new TemplateTag(template1, tag1));
+        templateTagRepository.save(new TemplateTag(template1, tag2));
+
+        templateTagRepository.save(new TemplateTag(template2, tag1));
+        templateTagRepository.save(new TemplateTag(template2, tag2));
+
+        templateTagRepository.save(new TemplateTag(template3, tag2));
+
+    }
+}

--- a/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
@@ -6,10 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.Arrays;
 import java.util.List;
 
-import jakarta.persistence.EntityManager;
-import jakarta.persistence.PersistenceContext;
-
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,18 +20,12 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
-import codezap.fixture.MemberFixture;
-import codezap.fixture.TemplateFixture;
-import codezap.global.DatabaseIsolation;
 import codezap.global.auditing.JpaAuditingConfiguration;
-import codezap.global.repository.JpaRepositoryTest;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
 import codezap.tag.domain.Tag;
 import codezap.tag.repository.TagRepository;
-import codezap.tag.repository.TemplateTagRepository;
 import codezap.template.domain.Template;
-import codezap.template.domain.TemplateTag;
 
 @DataJpaTest
 @Import(JpaAuditingConfiguration.class)
@@ -51,33 +41,11 @@ class TemplateSearchJpaRepositoryTest {
     private CategoryRepository categoryRepository;
     @Autowired
     private TagRepository tagRepository;
-    @Autowired
-    private TemplateTagRepository templateTagRepository;
-
-    private Member member1, member2;
-    private Category category1, category2;
-    private Tag tag1, tag2;
-    private Template template1, template2, template3;
-
-    @BeforeEach
-    void setUp() {
-//        saveInitialData();
-
-        category1 = categoryRepository.fetchById(1L);
-        category2 = categoryRepository.fetchById(2L);
-
-        tag1 = tagRepository.fetchById(1L);
-        tag2 = tagRepository.fetchById(2L);
-
-        template1 = templateRepository.fetchById(1L);
-        template2 = templateRepository.fetchById(2L);
-        template3 = templateRepository.fetchById(3L);
-    }
 
     @Test
     @DisplayName("검색 테스트: 회원 ID로 템플릿 조회 성공")
     void testFindByMemberId() {
-        member1 = memberRepository.fetchById(1L);
+        Member member1 = memberRepository.fetchById(1L);
         Specification<Template> spec = new TemplateSpecification(member1.getId(), null, null, null);
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
 
@@ -106,6 +74,7 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 카테고리 ID로 템플릿 조회 성공")
     void testFindByCategoryId() {
+        Category category1 = categoryRepository.fetchById(1L);
         Specification<Template> spec = new TemplateSpecification(null, null, category1.getId(),
                 null);
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
@@ -120,6 +89,8 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 태그 ID 목록으로 템플릿 조회, 모든 태그를 가진 템플릿만 조회 성공")
     void testFindByTagIds() {
+        Tag tag1 = tagRepository.fetchById(1L);
+        Tag tag2 = tagRepository.fetchById(2L);
         List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
         Specification<Template> spec = new TemplateSpecification(null, null, null, tagIds);
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
@@ -136,6 +107,7 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 단일 태그 ID로 템플릿 조회 성공")
     void testFindBySingleTagId() {
+        Tag tag2 = tagRepository.fetchById(2L);
         List<Long> tagIds = List.of(tag2.getId());
         Specification<Template> spec = new TemplateSpecification(null, null, null, tagIds);
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
@@ -153,7 +125,7 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 회원 ID와 키워드로 템플릿 조회 성공")
     void testFindByMemberIdAndKeyword() {
-        member1 = memberRepository.fetchById(1L);
+        Member member1 = memberRepository.fetchById(1L);
         String keyword = "Template";
         Specification<Template> spec = new TemplateSpecification(member1.getId(), keyword, null,
                 null);
@@ -171,7 +143,8 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 회원 ID와 카테고리 ID로 템플릿 조회 성공")
     void testFindByMemberIdAndCategoryId() {
-        member1 = memberRepository.fetchById(1L);
+        Member member1 = memberRepository.fetchById(1L);
+        Category category1 = categoryRepository.fetchById(1L);
         Specification<Template> spec = new TemplateSpecification(member1.getId(), null, category1.getId(),
                 null);
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
@@ -186,7 +159,9 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 회원 ID와 태그 ID 목록으로 템플릿 조회 성공")
     void testFindByMemberIdAndTagIds() {
-        member1 = memberRepository.fetchById(1L);
+        Member member1 = memberRepository.fetchById(1L);
+        Tag tag1 = tagRepository.fetchById(1L);
+        Tag tag2 = tagRepository.fetchById(2L);
         List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
         Specification<Template> spec = new TemplateSpecification(member1.getId(), null, null,
                 tagIds);
@@ -202,7 +177,10 @@ class TemplateSearchJpaRepositoryTest {
     @Test
     @DisplayName("검색 테스트: 모든 검색 기준으로 템플릿 조회 성공")
     void testFindWithAllCriteria() {
-        member1 = memberRepository.fetchById(1L);
+        Member member1 = memberRepository.fetchById(1L);
+        Category category1 = categoryRepository.fetchById(1L);
+        Tag tag1 = tagRepository.fetchById(1L);
+        Tag tag2 = tagRepository.fetchById(2L);
         String keyword = "Template";
         List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
         Specification<Template> spec = new TemplateSpecification(member1.getId(), keyword, category1.getId(),
@@ -222,45 +200,5 @@ class TemplateSearchJpaRepositoryTest {
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
 
         assertThat(result.getContent()).isEmpty();
-    }
-
-    private void saveInitialData() {
-        saveTwoMembers();
-        saveTwoCategory();
-        saveTwoTags();
-        saveThreeTemplates();
-        saveTemplateTags();
-    }
-
-    private void saveTwoMembers() {
-        member1 = memberRepository.save(MemberFixture.getFirstMember());
-        member2 = memberRepository.save(MemberFixture.getSecondMember());
-    }
-
-    private void saveTwoCategory() {
-        category1 = categoryRepository.save(new Category("Category 1", member1));
-        category2 = categoryRepository.save(new Category("Category 2", member1));
-    }
-
-    private void saveTwoTags() {
-        tag1 = tagRepository.save(new Tag("Tag 1"));
-        tag2 = tagRepository.save(new Tag("Tag 2"));
-    }
-
-    private void saveThreeTemplates() {
-        template1 = templateRepository.save(TemplateFixture.get(member1, category1));
-        template2 = templateRepository.save(TemplateFixture.get(member1, category2));
-        template3 = templateRepository.save(TemplateFixture.get(member2, category1));
-    }
-
-    private void saveTemplateTags() {
-        templateTagRepository.save(new TemplateTag(template1, tag1));
-        templateTagRepository.save(new TemplateTag(template1, tag2));
-
-        templateTagRepository.save(new TemplateTag(template2, tag1));
-        templateTagRepository.save(new TemplateTag(template2, tag2));
-
-        templateTagRepository.save(new TemplateTag(template3, tag2));
-
     }
 }

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -1,0 +1,373 @@
+package codezap.template.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+
+import codezap.category.domain.Category;
+import codezap.category.repository.CategoryRepository;
+import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
+import codezap.global.DatabaseIsolation;
+import codezap.global.exception.CodeZapException;
+import codezap.member.domain.Member;
+import codezap.member.repository.MemberRepository;
+import codezap.tag.domain.Tag;
+import codezap.tag.repository.TagRepository;
+import codezap.tag.repository.TemplateTagRepository;
+import codezap.template.domain.SourceCode;
+import codezap.template.domain.Template;
+import codezap.template.domain.TemplateTag;
+import codezap.template.domain.Thumbnail;
+import codezap.template.repository.SourceCodeRepository;
+import codezap.template.repository.TemplateRepository;
+import codezap.template.repository.ThumbnailRepository;
+
+@SpringBootTest
+@DatabaseIsolation
+class TemplateSearchServiceTest {
+
+    @Autowired
+    private TemplateRepository templateRepository;
+
+    @Autowired
+    private CategoryRepository categoryRepository;
+
+    @Autowired
+    private TemplateTagRepository templateTagRepository;
+
+    @Autowired
+    private TagRepository tagRepository;
+
+    @Autowired
+    private MemberRepository memberRepository;
+
+    @Autowired
+    private SourceCodeRepository sourceCodeRepository;
+
+    @Autowired
+    private ThumbnailRepository thumbnailRepository;
+
+    @Autowired
+    private TemplateService sut;
+
+    private Member member1, member2;
+    private Category category1, category2;
+    private Tag tag1, tag2;
+    private Template template1, template2, template3;
+
+    @Nested
+    class FindAll {
+
+        @BeforeEach
+        void setUp() {
+            saveInitialData();
+            member1 = memberRepository.fetchById(1L);
+            member2 = memberRepository.fetchById(2L);
+
+            category1 = categoryRepository.fetchById(1L);
+            category2 = categoryRepository.fetchById(2L);
+
+            tag1 = tagRepository.fetchById(1L);
+            tag2 = tagRepository.fetchById(2L);
+
+            template1 = templateRepository.fetchById(1L);
+            template2 = templateRepository.fetchById(2L);
+            template3 = templateRepository.fetchById(3L);
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID로 템플릿 목록 조회 성공")
+        void findAllSuccessByMemberId() {
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template -> template.getMember().getId().equals(member1.getId()))
+            );
+        }
+
+        @Test
+        @Disabled("Pageable에 대한 null 검증이 필요함")
+        @DisplayName("검색 기능 실패: Pageable을 전달하지 않은 경우")
+        void findAllFailureWithNullPageable() {
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = null;
+
+            assertThatThrownBy(() -> sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("Pageable을 필수로 작성해야 합니다.");
+        }
+
+        @Test
+        @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
+        void findAllSuccessByKeyword() {
+            Long memberId = null;
+            String keyword = "Template";
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template ->
+                                    template.getTitle().contains(keyword) || template.getDescription()
+                                            .contains(keyword)),
+                    () -> assertThat(actual.getContent()).hasSize(3)
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 카테고리 ID로 템플릿 목록 조회 성공")
+        void findAllSuccessByCategoryId() {
+            Long memberId = null;
+            String keyword = null;
+            Long categoryId = category1.getId();
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template -> template.getCategory().getId().equals(category1.getId()))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 태그 ID 목록으로 템플릿 목록 조회, 모든 태그를 가진 템플릿만 조회 성공")
+        void findAllSuccessByTagIds() {
+            Long memberId = null;
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent())
+                            .containsExactlyInAnyOrder(
+                                    templateRepository.fetchById(1L),
+                                    templateRepository.fetchById(2L)),
+                    () -> assertThat(actual.getContent()).hasSize(2)
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 단일 태그 ID로 템플릿 목록 조회 성공")
+        void findAllSuccessBySingleTagId() {
+            Long memberId = null;
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = List.of(tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(
+                            templateRepository.fetchById(1L),
+                            templateRepository.fetchById(2L),
+                            templateRepository.fetchById(3L)),
+                    () -> assertThat(actual.getContent()).hasSize(3)
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID와 키워드로 템플릿 목록 조회 성공")
+        void findAllSuccessByMemberIdAndKeyword() {
+            Long memberId = member1.getId();
+            String keyword = "Template";
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .allMatch(template -> template.getMember().getId().equals(member1.getId())
+                                    && (template.getTitle().contains(keyword)
+                                    || template.getDescription().contains(keyword)))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID와 카테고리 ID로 템플릿 목록 조회 성공")
+        void findAllSuccessByMemberIdAndCategoryId() {
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = category1.getId();
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(1),
+                    () -> assertThat(actual.getContent().get(0).getMember().getId()).isEqualTo(member1.getId()),
+                    () -> assertThat(actual.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId())
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 회원 ID와 태그 ID 목록으로 템플릿 목록 조회 성공")
+        void findAllSuccessByMemberIdAndTagIds() {
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(2),
+                    () -> assertThat(actual.getContent())
+                            .containsExactlyInAnyOrder(
+                                    templateRepository.fetchById(1L),
+                                    templateRepository.fetchById(2L))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 모든 검색 기준으로 템플릿 목록 조회 성공")
+        void findAllSuccessWithAllCriteria() {
+            Long memberId = member1.getId();
+            String keyword = "Template";
+            Long categoryId = category1.getId();
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(1),
+                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
+            );
+        }
+
+        @Test
+        @DisplayName("검색 기능: 검색 결과가 없는 경우 빈 리스트 반환 성공")
+        void findAllSuccessWithNoResults() {
+            Long memberId = null;
+            String keyword = "NonExistentKeyword";
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(0, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertThat(actual.getContent()).isEmpty();
+        }
+    }
+
+
+    @Nested
+    class FindAllPagination {
+
+        @BeforeEach
+        void setUp() {
+            saveTwoMembers();
+            saveTwoCategory();
+
+            for (int i = 0; i < 15; i++) {
+                templateRepository.save(TemplateFixture.get(member1, category1));
+            }
+        }
+
+        @Test
+        @DisplayName("검색 기능: 두 번째 페이지 조회 성공")
+        void findAllSuccessWithSecondPage() {
+            Long memberId = member1.getId();
+            String keyword = null;
+            Long categoryId = null;
+            List<Long> tagIds = null;
+            Pageable pageable = PageRequest.of(1, 10);
+
+            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+
+            assertAll(
+                    () -> assertThat(actual.getContent()).hasSize(5),
+                    () -> assertThat(actual.getContent().get(0).getId()).isEqualTo(11L)
+            );
+        }
+
+    }
+
+    private void saveInitialData() {
+        saveTwoMembers();
+        saveTwoCategory();
+        saveTwoTags();
+        saveThreeTemplates();
+        saveTemplateTags();
+    }
+
+    private void saveTwoMembers() {
+        member1 = memberRepository.save(MemberFixture.getFirstMember());
+        member2 = memberRepository.save(MemberFixture.getSecondMember());
+    }
+
+    private void saveTwoCategory() {
+        category1 = categoryRepository.save(new Category("Category 1", member1));
+        category2 = categoryRepository.save(new Category("Category 2", member1));
+    }
+
+    private void saveTwoTags() {
+        tag1 = tagRepository.save(new Tag("Tag 1"));
+        tag2 = tagRepository.save(new Tag("Tag 2"));
+    }
+
+    private void saveThreeTemplates() {
+        template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+        template2 = templateRepository.save(TemplateFixture.get(member1, category2));
+        template3 = templateRepository.save(TemplateFixture.get(member2, category1));
+
+        SourceCode sourceCode1 = sourceCodeRepository.save(new SourceCode(template1, "filename1", "content1", 1));
+        SourceCode sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "filename2", "content2", 2));
+        SourceCode sourceCode3 = sourceCodeRepository.save(new SourceCode(template3, "filename1", "content1", 1));
+
+        thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
+        thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
+        thumbnailRepository.save(new Thumbnail(template3, sourceCode3));
+    }
+
+    private void saveTemplateTags() {
+        templateTagRepository.save(new TemplateTag(template1, tag1));
+        templateTagRepository.save(new TemplateTag(template1, tag2));
+
+        templateTagRepository.save(new TemplateTag(template2, tag1));
+        templateTagRepository.save(new TemplateTag(template2, tag2));
+
+        templateTagRepository.save(new TemplateTag(template3, tag2));
+    }
+
+}

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -14,7 +13,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,11 +28,7 @@ import codezap.likes.domain.Likes;
 import codezap.likes.repository.LikesRepository;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
-import codezap.tag.domain.Tag;
-import codezap.tag.repository.TagRepository;
-import codezap.tag.repository.TemplateTagRepository;
 import codezap.template.domain.Template;
-import codezap.template.domain.TemplateTag;
 import codezap.template.dto.request.CreateSourceCodeRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
@@ -52,13 +46,8 @@ class TemplateServiceTest {
     private CategoryRepository categoryRepository;
 
     @Autowired
-    private TemplateTagRepository templateTagRepository;
-
-    @Autowired
-    private TagRepository tagRepository;
-
-    @Autowired
     private MemberRepository memberRepository;
+
 
     @Autowired
     private LikesRepository likesRepository;
@@ -165,342 +154,59 @@ class TemplateServiceTest {
     }
 
     @Nested
-    @DisplayName("검색 기능")
-    class FindAll {
-
-        private Member member1, member2;
-        private Category category1, category2;
-        private Tag tag1, tag2;
-        private Template template1, template2, template3;
+    @DisplayName("정렬 기능 테스트")
+    class SortTest {
 
         @Test
-        @DisplayName("검색 기능: 회원 ID로 템플릿 목록 조회 성공")
-        void findAllSuccessByMemberId() {
-            saveInitialData();
-            Long memberId = member1.getId();
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(0, 10);
+        @DisplayName("좋아요 순 정렬 테스트")
+        void sortByLikesCount() {
+            saveMembers10();
+            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            saveTemplates5(category);
+            likeTemplate(3L, 10L);
+            likeTemplate(5L, 7L);
+            likeTemplate(2L, 5L);
+            likeTemplate(4L, 1L);
+            likeTemplate(1L, 0L);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
+            List<Template> templates = sut.findAllBy(null, "", null, null,
+                            PageRequest.of(0, 10, Sort.by(Direction.DESC, "likesCount")))
+                    .getContent();
 
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(2),
-                    () -> assertThat(actual.getContent())
-                            .allMatch(template -> template.getMember().getId().equals(member1.getId()))
+            assertThat(templates).containsExactly(
+                    templateRepository.fetchById(3L),
+                    templateRepository.fetchById(5L),
+                    templateRepository.fetchById(2L),
+                    templateRepository.fetchById(4L),
+                    templateRepository.fetchById(1L)
             );
         }
 
-        @Test
-        @Disabled("Pageable에 대한 null 검증이 필요함")
-        @DisplayName("검색 기능 실패: Pageable을 전달하지 않은 경우")
-        void findAllFailureWithNullPageable() {
-            saveInitialData();
-            Long memberId = member1.getId();
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Pageable pageable = null;
-
-            assertThatThrownBy(() -> sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable))
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("Pageable을 필수로 작성해야 합니다.");
-        }
-
-        @Test
-        @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
-        void findAllSuccessByKeyword() {
-            saveInitialData();
-            Long memberId = null;
-            String keyword = "Template";
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent())
-                            .allMatch(template ->
-                                    template.getTitle().contains(keyword) || template.getDescription()
-                                            .contains(keyword)),
-                    () -> assertThat(actual.getContent()).hasSize(3)
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 카테고리 ID로 템플릿 목록 조회 성공")
-        void findAllSuccessByCategoryId() {
-            saveInitialData();
-            Long memberId = null;
-            String keyword = null;
-            Long categoryId = category1.getId();
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(2),
-                    () -> assertThat(actual.getContent())
-                            .allMatch(template -> template.getCategory().getId().equals(category1.getId()))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 태그 ID 목록으로 템플릿 목록 조회, 모든 태그를 가진 템플릿만 조회 성공")
-        void findAllSuccessByTagIds() {
-            saveInitialData();
-            Long memberId = null;
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent())
-                            .containsExactlyInAnyOrder(
-                                    templateRepository.fetchById(1L),
-                                    templateRepository.fetchById(2L)),
-                    () -> assertThat(actual.getContent()).hasSize(2)
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 단일 태그 ID로 템플릿 목록 조회 성공")
-        void findAllSuccessBySingleTagId() {
-            saveInitialData();
-            Long memberId = null;
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = List.of(tag2.getId());
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(
-                            templateRepository.fetchById(1L),
-                            templateRepository.fetchById(2L),
-                            templateRepository.fetchById(3L)),
-                    () -> assertThat(actual.getContent()).hasSize(3)
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 회원 ID와 키워드로 템플릿 목록 조회 성공")
-        void findAllSuccessByMemberIdAndKeyword() {
-            saveInitialData();
-            Long memberId = member1.getId();
-            String keyword = "Template";
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(2),
-                    () -> assertThat(actual.getContent())
-                            .allMatch(template -> template.getMember().getId().equals(member1.getId())
-                                    && (template.getTitle().contains(keyword)
-                                    || template.getDescription().contains(keyword)))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 회원 ID와 카테고리 ID로 템플릿 목록 조회 성공")
-        void findAllSuccessByMemberIdAndCategoryId() {
-            saveInitialData();
-            Long memberId = member1.getId();
-            String keyword = null;
-            Long categoryId = category1.getId();
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(1),
-                    () -> assertThat(actual.getContent().get(0).getMember().getId()).isEqualTo(member1.getId()),
-                    () -> assertThat(actual.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId())
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 회원 ID와 태그 ID 목록으로 템플릿 목록 조회 성공")
-        void findAllSuccessByMemberIdAndTagIds() {
-            saveInitialData();
-            Long memberId = member1.getId();
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(2),
-                    () -> assertThat(actual.getContent())
-                            .containsExactlyInAnyOrder(
-                                    templateRepository.fetchById(1L),
-                                    templateRepository.fetchById(2L))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 모든 검색 기준으로 템플릿 목록 조회 성공")
-        void findAllSuccessWithAllCriteria() {
-            saveInitialData();
-            Long memberId = member1.getId();
-            String keyword = "Template";
-            Long categoryId = category1.getId();
-            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(1),
-                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
-            );
-        }
-
-        @Test
-        @DisplayName("검색 기능: 검색 결과가 없는 경우 빈 리스트 반환 성공")
-        void findAllSuccessWithNoResults() {
-            saveInitialData();
-            Long memberId = null;
-            String keyword = "NonExistentKeyword";
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(0, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertThat(actual.getContent()).isEmpty();
-        }
-
-        @Test
-        @DisplayName("검색 기능: 두 번째 페이지 조회 성공")
-        void findAllSuccessWithSecondPage() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            for (int i = 0; i < 15; i++) {
-                templateRepository.save(TemplateFixture.get(member, category));
-            }
-            Long memberId = member.getId();
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Pageable pageable = PageRequest.of(1, 10);
-
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, pageable);
-
-            assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(5),
-                    () -> assertThat(actual.getContent().get(0).getId()).isEqualTo(11L)
-            );
-        }
-
-        @Nested
-        @DisplayName("정렬 기능 테스트")
-        class SortTest {
-
-            @Test
-            @DisplayName("좋아요 순 정렬 테스트")
-            void sortByLikesCount() {
-                saveMembers10();
-                Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-                saveTemplates5(category);
-                likeTemplate(3L, 10L);
-                likeTemplate(5L, 7L);
-                likeTemplate(2L, 5L);
-                likeTemplate(4L, 1L);
-                likeTemplate(1L, 0L);
-
-                List<Template> templates = sut.findAllBy(null, "", null, null,
-                                PageRequest.of(0, 10, Sort.by(Direction.DESC, "likesCount")))
-                        .getContent();
-
-                assertThat(templates).containsExactly(
-                        templateRepository.fetchById(3L),
-                        templateRepository.fetchById(5L),
-                        templateRepository.fetchById(2L),
-                        templateRepository.fetchById(4L),
-                        templateRepository.fetchById(1L)
-                );
-            }
-
-            private void saveMembers10() {
-                for (int i = 0; i < 10; i++) {
-                    memberRepository.save(new Member("name" + i, "password" + 1, "salt"));
-                }
-            }
-
-            private void saveTemplates5(Category category) {
-                for (int i = 0; i < 5; i++) {
-                    templateRepository.save(new Template(
-                            memberRepository.fetchById(1L),
-                            "title" + i,
-                            "description",
-                            category
-                    ));
-                }
-            }
-
-            private void likeTemplate(long templateId, long likesCount) {
-                for (long memberId = 1L; memberId <= likesCount; memberId++) {
-                    likesRepository.save(new Likes(
-                            null,
-                            templateRepository.fetchById(templateId),
-                            memberRepository.fetchById(memberId)
-                    ));
-                }
+        private void saveMembers10() {
+            for (int i = 0; i < 10; i++) {
+                memberRepository.save(new Member("name" + i, "password" + 1, "salt"));
             }
         }
 
-        private void saveInitialData() {
-
-            saveTwoMembers();
-            saveTwoCategory();
-            saveTwoTags();
-            saveThreeTemplates();
-            saveTemplateTags();
+        private void saveTemplates5(Category category) {
+            for (int i = 0; i < 5; i++) {
+                templateRepository.save(new Template(
+                        memberRepository.fetchById(1L),
+                        "title" + i,
+                        "description",
+                        category
+                ));
+            }
         }
 
-        private void saveTwoMembers() {
-            member1 = memberRepository.save(MemberFixture.getFirstMember());
-            member2 = memberRepository.save(MemberFixture.getSecondMember());
-        }
-
-        private void saveTwoCategory() {
-            category1 = categoryRepository.save(new Category("Category 1", member1));
-            category2 = categoryRepository.save(new Category("Category 2", member1));
-        }
-
-        private void saveTwoTags() {
-            tag1 = tagRepository.save(new Tag("Tag 1"));
-            tag2 = tagRepository.save(new Tag("Tag 2"));
-        }
-
-        private void saveThreeTemplates() {
-            template1 = templateRepository.save(TemplateFixture.get(member1, category1));
-            template2 = templateRepository.save(TemplateFixture.get(member1, category2));
-            template3 = templateRepository.save(TemplateFixture.get(member2, category1));
-        }
-
-        private void saveTemplateTags() {
-            templateTagRepository.save(new TemplateTag(template1, tag1));
-            templateTagRepository.save(new TemplateTag(template1, tag2));
-
-            templateTagRepository.save(new TemplateTag(template2, tag1));
-            templateTagRepository.save(new TemplateTag(template2, tag2));
-
-            templateTagRepository.save(new TemplateTag(template3, tag2));
+        private void likeTemplate(long templateId, long likesCount) {
+            for (long memberId = 1L; memberId <= likesCount; memberId++) {
+                likesRepository.save(new Likes(
+                        null,
+                        templateRepository.fetchById(templateId),
+                        memberRepository.fetchById(memberId)
+                ));
+            }
         }
     }
 

--- a/backend/src/test/resources/search.sql
+++ b/backend/src/test/resources/search.sql
@@ -1,0 +1,76 @@
+-- 모든 테이블의 데이터 삭제
+DELETE FROM template_tag;
+DELETE FROM thumbnail;
+DELETE FROM source_code;
+DELETE FROM template;
+DELETE FROM category;
+DELETE FROM tag;
+DELETE FROM member;
+
+-- 이제 새로운 데이터 삽입
+-- Member 삽입
+INSERT INTO member (id, created_at, modified_at, name, password, salt)
+VALUES (1, '2024-09-27 08:43:08.752936', '2024-09-27 08:43:08.752936', '몰리', 'password1234', 'salt1');
+
+INSERT INTO member (id, created_at, modified_at, name, password, salt)
+VALUES (2, '2024-09-27 08:43:08.757482', '2024-09-27 08:43:08.757482', '몰리2', 'password1234', 'salt2');
+
+-- Category 삽입
+INSERT INTO category (id, created_at, is_default, member_id, modified_at, name)
+VALUES (1, '2024-09-27 08:43:08.760511', false, 1, '2024-09-27 08:43:08.760511', 'Category 1');
+
+INSERT INTO category (id, created_at, is_default, member_id, modified_at, name)
+VALUES (2, '2024-09-27 08:43:08.763888', false, 1, '2024-09-27 08:43:08.763888', 'Category 2');
+
+-- Tag 삽입
+INSERT INTO tag (id, created_at, modified_at, name)
+VALUES (1, '2024-09-27 08:43:08.767154', '2024-09-27 08:43:08.767154', 'Tag 1');
+
+INSERT INTO tag (id, created_at, modified_at, name)
+VALUES (2, '2024-09-27 08:43:08.769440', '2024-09-27 08:43:08.769440', 'Tag 2');
+
+-- Template 삽입
+INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title)
+VALUES (1, 1, '2024-09-27 08:43:08.773369', 'Description 1', 1, '2024-09-27 08:43:08.773369', 'Template 1');
+
+INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title)
+VALUES (2, 2, '2024-09-27 08:43:08.787995', 'Description 1', 1, '2024-09-27 08:43:08.787995', 'Template 1');
+
+INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title)
+VALUES (3, 1, '2024-09-27 08:43:08.790778', 'Description 1', 2, '2024-09-27 08:43:08.790778', 'Template 1');
+
+-- Source Code 삽입
+INSERT INTO source_code (id, content, created_at, filename, modified_at, ordinal, template_id)
+VALUES (1, 'content1', '2024-09-27 08:43:08.793152', 'filename1', '2024-09-27 08:43:08.793152', 1, 1);
+
+INSERT INTO source_code (id, content, created_at, filename, modified_at, ordinal, template_id)
+VALUES (2, 'content2', '2024-09-27 08:43:08.797349', 'filename2', '2024-09-27 08:43:08.797349', 2, 2);
+
+INSERT INTO source_code (id, content, created_at, filename, modified_at, ordinal, template_id)
+VALUES (3, 'content1', '2024-09-27 08:43:08.810641', 'filename1', '2024-09-27 08:43:08.810641', 1, 3);
+
+-- Thumbnail 삽입
+INSERT INTO thumbnail (id, created_at, modified_at, source_code_id, template_id)
+VALUES (1, '2024-09-27 08:43:08.812840', '2024-09-27 08:43:08.812840', 1, 1);
+
+INSERT INTO thumbnail (id, created_at, modified_at, source_code_id, template_id)
+VALUES (2, '2024-09-27 08:43:08.815866', '2024-09-27 08:43:08.815866', 2, 2);
+
+INSERT INTO thumbnail (id, created_at, modified_at, source_code_id, template_id)
+VALUES (3, '2024-09-27 08:43:08.817850', '2024-09-27 08:43:08.817850', 3, 3);
+
+-- Template_Tag 삽입
+INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
+VALUES ('2024-09-27 08:43:08.835179', '2024-09-27 08:43:08.835179', 1, 1);
+
+INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
+VALUES ('2024-09-27 08:43:08.843467', '2024-09-27 08:43:08.843467', 2, 1);
+
+INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
+VALUES ('2024-09-27 08:43:08.851712', '2024-09-27 08:43:08.851712', 1, 2);
+
+INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
+VALUES ('2024-09-27 08:43:08.860091', '2024-09-27 08:43:08.860091', 2, 2);
+
+INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
+VALUES ('2024-09-27 08:43:08.867619', '2024-09-27 08:43:08.867619', 2, 3);

--- a/backend/src/test/resources/search.sql
+++ b/backend/src/test/resources/search.sql
@@ -74,3 +74,7 @@ VALUES ('2024-09-27 08:43:08.860091', '2024-09-27 08:43:08.860091', 2, 2);
 
 INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
 VALUES ('2024-09-27 08:43:08.867619', '2024-09-27 08:43:08.867619', 2, 3);
+
+-- 전문 검색 인덱스 추가
+CREATE FULLTEXT INDEX idx_template_fulltext ON template (title, description);
+CREATE FULLTEXT INDEX idx_source_code_fulltext ON source_code (content, filename);

--- a/backend/src/test/resources/search.sql
+++ b/backend/src/test/resources/search.sql
@@ -75,7 +75,7 @@ VALUES ('2024-09-27 08:43:08.860091', '2024-09-27 08:43:08.860091', 2, 2);
 INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
 VALUES ('2024-09-27 08:43:08.867619', '2024-09-27 08:43:08.867619', 2, 3);
 
--- 전문 검색 인덱스가 존재하는지 조회
+-- 템플릿 테이블에 전문 검색 인덱스가 존재하는지 조회
 SELECT COUNT(1) INTO @indexExists FROM information_schema.statistics
 WHERE table_name = 'template'
   AND index_name = 'idx_template_fulltext';
@@ -86,7 +86,7 @@ PREPARE stmt FROM @createIndex;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;
 
--- 전문 검색 인덱스가 존재하는지 조회
+-- 소스 코드 테이블에 전문 검색 인덱스가 존재하는지 조회
 SELECT COUNT(1) INTO @indexExists FROM information_schema.statistics
 WHERE table_name = 'source_code'
   AND index_name = 'idx_source_code_fulltext';

--- a/backend/src/test/resources/search.sql
+++ b/backend/src/test/resources/search.sql
@@ -75,6 +75,24 @@ VALUES ('2024-09-27 08:43:08.860091', '2024-09-27 08:43:08.860091', 2, 2);
 INSERT INTO template_tag (created_at, modified_at, tag_id, template_id)
 VALUES ('2024-09-27 08:43:08.867619', '2024-09-27 08:43:08.867619', 2, 3);
 
--- 전문 검색 인덱스 추가
-CREATE FULLTEXT INDEX idx_template_fulltext ON template (title, description);
-CREATE FULLTEXT INDEX idx_source_code_fulltext ON source_code (content, filename);
+-- 전문 검색 인덱스가 존재하는지 조회
+SELECT COUNT(1) INTO @indexExists FROM information_schema.statistics
+WHERE table_name = 'template'
+  AND index_name = 'idx_template_fulltext';
+
+-- 없다면 전문 검색 인덱스 생성
+SET @createIndex = IF(@indexExists = 0, 'CREATE FULLTEXT INDEX idx_template_fulltext ON template (title, description);', 'SELECT 1');
+PREPARE stmt FROM @createIndex;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;
+
+-- 전문 검색 인덱스가 존재하는지 조회
+SELECT COUNT(1) INTO @indexExists FROM information_schema.statistics
+WHERE table_name = 'source_code'
+  AND index_name = 'idx_source_code_fulltext';
+
+-- 없다면 전문 검색 인덱스 생성
+SET @createIndex = IF(@indexExists = 0, 'CREATE FULLTEXT INDEX idx_source_code_fulltext ON source_code (content, filename);', 'SELECT 1');
+PREPARE stmt FROM @createIndex;
+EXECUTE stmt;
+DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #673

## 📍주요 변경 사항
### 1. 템플릿 조회 시 MySQL 전문 검색 인덱스 적용하여 속도 성능 개선

JPA는 전문 검색 인덱스를 지원하지 않습니다.
따라서 직접 JPQL 또는 커스텀 MySQLDialect을 통해 전문 검색 인덱스를 타도록 설정해주어야 합니다.

그런데 현재 검색 쿼리가 동적으로 생성되어 Specification 을 사용하고 있습니다.
Specification과 JPQL은 동시 사용이 불가능하여 커스텀 MySQLDialect 방식으로 구현하였습니다.

## 🎸기타
### 1. 이런걸 더 고려해봐야 할 것 같습니다.

모든 환경의 yml 파일에 아래의 내용이 추가되어야 합니다.
커스텀 MySQLDialect을 등록이 필요합니다.

```yml
  jpa:
    properties:
      hibernate:
        dialect: codezap.template.repository.FullTextSearchMySQLDialect
```