### PR TITLE
백엔드 로그 수정

### DIFF
--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -13,7 +13,7 @@
     </logger>
 
     <root level="WARN">
-        <appender-ref ref="warn-appender"/>
+        <appender-ref ref="warn-appender"/> 
         <appender-ref ref="error-appender"/>
     </root>
 

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -14,7 +14,7 @@
 
     <turboFilter class="ch.qos.logback.classic.turbo.MatchingFilter">
         <filterExpression>
-            message.contains("/actuator/ahealth")
+            message.contains("/actuator/health")
         </filterExpression>
         <onMatch>DENY</onMatch>
         <onMismatch>NEUTRAL</onMismatch>

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -12,16 +12,7 @@
         <appender-ref ref="console-appender"/>
     </logger>
 
-    <turboFilter class="ch.qos.logback.classic.turbo.MatchingFilter">
-        <filterExpression>
-            message.contains("/actuator/health")
-        </filterExpression>
-        <onMatch>DENY</onMatch>
-        <onMismatch>NEUTRAL</onMismatch>
-    </turboFilter>
-
-    <root level="INFO">
-        <appender-ref ref="info-appender"/>
+    <root level="WARN">
         <appender-ref ref="warn-appender"/>
         <appender-ref ref="error-appender"/>
     </root>

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -13,7 +13,7 @@
     </logger>
 
     <root level="WARN">
-        <appender-ref ref="warn-appender"/> 
+        <appender-ref ref="warn-appender"/>
         <appender-ref ref="error-appender"/>
     </root>
 

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -14,7 +14,7 @@
 
     <turboFilter class="ch.qos.logback.classic.turbo.MatchingFilter">
         <filterExpression>
-            message.contains("/health")
+            message.contains("/actuator/ahealth")
         </filterExpression>
         <onMatch>DENY</onMatch>
         <onMismatch>NEUTRAL</onMismatch>

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -12,6 +12,14 @@
         <appender-ref ref="console-appender"/>
     </logger>
 
+    <turboFilter class="ch.qos.logback.classic.turbo.MatchingFilter">
+        <filterExpression>
+            message.contains("/health")
+        </filterExpression>
+        <onMatch>DENY</onMatch>
+        <onMismatch>NEUTRAL</onMismatch>
+    </turboFilter>
+
     <root level="INFO">
         <appender-ref ref="info-appender"/>
         <appender-ref ref="warn-appender"/>


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #723 

## 📍주요 변경 사항
~1. `/actuator/health`를 포함하는 요청에 대한 로그는 찍지 않게 했습니다.~
1. INFO 로그는 전부 안보이도록 변경하였습니다.

## 🎸기타
1. 로드밸런서에서 30초마다 한 번씩 헬스체크를 진행하는데 해당 로그들이 너무 많이 보여서 로그의 길이가 불필요하게 길어집니다.