### PR TITLE
태그 및 카테고리 생성 시 글자수 검증

### DIFF
--- a/backend/src/main/java/codezap/category/dto/request/CreateCategoryRequest.java
+++ b/backend/src/main/java/codezap/category/dto/request/CreateCategoryRequest.java
@@ -10,7 +10,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 public record CreateCategoryRequest(
         @Schema(description = "카테고리 이름", example = "Spring")
         @NotBlank(message = "카테고리 이름이 null 입니다.", groups = NotNullGroup.class)
-        @Size(max = 255, message = "카테고리 이름은 최대 255자까지 입력 가능합니다.", groups = SizeCheckGroup.class)
+        @Size(max = 15, message = "카테고리 이름은 최대 15자까지 입력 가능합니다.", groups = SizeCheckGroup.class)
         String name
 ) {
 }

--- a/backend/src/main/java/codezap/global/validation/ByteLength.java
+++ b/backend/src/main/java/codezap/global/validation/ByteLength.java
@@ -10,7 +10,7 @@ import jakarta.validation.Payload;
 
 @Target(ElementType.FIELD)
 @Retention(RetentionPolicy.RUNTIME)
-@Constraint(validatedBy = ByteLengthValidator.class)
+@Constraint(validatedBy = {ByteLengthValidator.class, GroupedByteLengthValidator.class})
 public @interface ByteLength {
 
     String message();

--- a/backend/src/main/java/codezap/global/validation/GroupedByteLengthValidator.java
+++ b/backend/src/main/java/codezap/global/validation/GroupedByteLengthValidator.java
@@ -23,7 +23,7 @@ public class GroupedByteLengthValidator implements ConstraintValidator<ByteLengt
                 .allMatch(this::isValid);
     }
 
-    public boolean isValid(String target) {
+    private boolean isValid(String target) {
         int byteLength = target.getBytes(StandardCharsets.UTF_8).length;
         return min <= byteLength && byteLength <= max;
     }

--- a/backend/src/main/java/codezap/global/validation/GroupedByteLengthValidator.java
+++ b/backend/src/main/java/codezap/global/validation/GroupedByteLengthValidator.java
@@ -1,0 +1,30 @@
+package codezap.global.validation;
+
+import java.nio.charset.StandardCharsets;
+import java.util.List;
+
+import jakarta.validation.ConstraintValidator;
+import jakarta.validation.ConstraintValidatorContext;
+
+public class GroupedByteLengthValidator implements ConstraintValidator<ByteLength, List<String>> {
+
+    private int max;
+    private int min;
+
+    @Override
+    public void initialize(ByteLength constraintAnnotation) {
+        max = constraintAnnotation.max();
+        min = constraintAnnotation.min();
+    }
+
+    @Override
+    public boolean isValid(List<String> strings, ConstraintValidatorContext constraintValidatorContext) {
+        return strings.stream()
+                .allMatch(this::isValid);
+    }
+
+    public boolean isValid(String target) {
+        int byteLength = target.getBytes(StandardCharsets.UTF_8).length;
+        return min <= byteLength && byteLength <= max;
+    }
+}

--- a/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
@@ -40,10 +40,15 @@ public record CreateTemplateRequest(
 
         @Schema(description = "태그 목록")
         @NotNull(message = "태그 목록이 null 입니다.", groups = NotNullGroup.class)
+        @ByteLength(max = 30, message = "태그 명은 최대 30자까지 입력 가능합니다.", groups = SizeCheckGroup.class)
+        @Valid
         List<String> tags
 ) implements ValidatedSourceCodesOrdinalRequest {
+
     @Override
     public List<Integer> extractSourceCodesOrdinal() {
-        return sourceCodes.stream().map(CreateSourceCodeRequest::ordinal).toList();
+        return sourceCodes.stream()
+                .map(CreateSourceCodeRequest::ordinal)
+                .toList();
     }
 }

--- a/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
@@ -76,7 +76,7 @@ class CategoryControllerTest extends MockMvcTest {
 
         @Test
         @DisplayName("카테고리 생성 실패: 카테고리 이름 길이 초과")
-        void createCategoryFailWithlongName() throws Exception {
+        void createCategoryFailWithLongName() throws Exception {
             CreateCategoryRequest createCategoryRequest = new CreateCategoryRequest("a".repeat(MAX_LENGTH + 1));
 
             mvc.perform(post("/categories")
@@ -84,7 +84,7 @@ class CategoryControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON)
                             .content(objectMapper.writeValueAsString(createCategoryRequest)))
                     .andExpect(status().isBadRequest())
-                    .andExpect(jsonPath("$.detail").value("카테고리 이름은 최대 255자까지 입력 가능합니다."));
+                    .andExpect(jsonPath("$.detail").value("카테고리 이름은 최대 15자까지 입력 가능합니다."));
         }
     }
 

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -383,6 +383,28 @@ class TemplateControllerTest {
                     .andExpect(jsonPath("$.detail").value("태그 목록이 null 입니다."));
         }
 
+        @Test
+        @DisplayName("템플릿 생성 실패: 태그 목록에서 30자 초과인 태그 존재")
+        void createTemplateFailWithOverSizeTags() throws Exception {
+            String exceededTag = "a".repeat(31);
+
+            CreateTemplateRequest templateRequest = new CreateTemplateRequest(
+                    "title",
+                    "description",
+                    List.of(new CreateSourceCodeRequest("title", "sourceCode", 1)),
+                    1,
+                    1L,
+                    List.of(exceededTag)
+            );
+
+            mvc.perform(post("/templates")
+                            .cookie(cookie)
+                            .accept(MediaType.APPLICATION_JSON)
+                            .contentType(MediaType.APPLICATION_JSON)
+                            .content(objectMapper.writeValueAsString(templateRequest)))
+                    .andExpect(status().isBadRequest())
+                    .andExpect(jsonPath("$.detail").value("태그 명은 최대 30자까지 입력 가능합니다."));
+        }
 
         @ParameterizedTest
         @DisplayName("템플릿 생성 실패: 잘못된 소스 코드 순서 입력")


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #512

## 📍주요 변경 사항
1. 태그 및 카테고리 생성 시 글자수 검증
2. 기존 `@ByteLength`에 List<String> 에 대해 글자 수 검증을 하는 GroupedByteLengthValidator 객체를 추가하였습니다.
  + `@ByteLength` 사용 시 타입에 맞는 validator 클래스가 선택되어 검증합니다.