### PR TITLE
Swagger 개발 서버 IP 추가

### DIFF
--- a/backend/src/main/java/codezap/global/swagger/SpringDocConfiguration.java
+++ b/backend/src/main/java/codezap/global/swagger/SpringDocConfiguration.java
@@ -41,10 +41,13 @@ public class SpringDocConfiguration {
                         List.of(
                                 new Server()
                                         .url("https://api.code-zap.com")
-                                        .description("클라우드에 배포되어 있는 테스트 서버입니다."),
+                                        .description("운영 서버"),
+                                new Server()
+                                        .url("https://dev.code-zap.com")
+                                        .description("개발 서버"),
                                 new Server()
                                         .url("http://localhost:8080")
-                                        .description("BE 팀에서 사용할 로컬 환경 테스트를 위한 서버입니다.")
+                                        .description("로컬 서버")
                         )
                 )
                 .addSecurityItem(new SecurityRequirement().addList("쿠키 인증 토큰"));


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #548

## 📍주요 변경 사항
1. 스웨거 서버에 개발 (`dev.code-zap.com`) 서버 추가하였습니다.