### PR TITLE
좋아요한 템플릿 삭제 시 좋아요 테이블 삭제 구현

### DIFF
--- a/backend/src/main/java/codezap/likes/domain/Likes.java
+++ b/backend/src/main/java/codezap/likes/domain/Likes.java
@@ -32,4 +32,8 @@ public class Likes extends BaseTimeEntity {
 
     @ManyToOne(fetch = FetchType.LAZY, optional = false)
     private Member member;
+
+    public Likes(Template template, Member member) {
+        this(null, template, member);
+    }
 }

--- a/backend/src/main/java/codezap/likes/repository/LikesJpaRepository.java
+++ b/backend/src/main/java/codezap/likes/repository/LikesJpaRepository.java
@@ -1,8 +1,16 @@
 package codezap.likes.repository;
 
+import java.util.List;
+
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 
 import codezap.likes.domain.Likes;
 
 public interface LikesJpaRepository extends LikesRepository, JpaRepository<Likes, Long> {
+
+    @Modifying(clearAutomatically = true)
+    @Query("DELETE FROM Likes l WHERE l.template.id in :templateIds")
+    void deleteByTemplateIds(List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/likes/repository/LikesRepository.java
+++ b/backend/src/main/java/codezap/likes/repository/LikesRepository.java
@@ -1,5 +1,7 @@
 package codezap.likes.repository;
 
+import java.util.List;
+
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
@@ -12,4 +14,6 @@ public interface LikesRepository {
     long countByTemplate(Template template);
 
     void deleteByMemberAndTemplate(Member member, Template template);
+
+    void deleteByTemplateIds(List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/likes/service/LikesService.java
+++ b/backend/src/main/java/codezap/likes/service/LikesService.java
@@ -1,5 +1,7 @@
 package codezap.likes.service;
 
+import java.util.List;
+
 import jakarta.transaction.Transactional;
 
 import org.springframework.stereotype.Service;
@@ -36,5 +38,10 @@ public class LikesService {
     public void cancelLike(Member member, long templateId) {
         Template template = templateRepository.fetchById(templateId);
         likesRepository.deleteByMemberAndTemplate(member, template);
+    }
+
+    @Transactional
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
+        likesRepository.deleteByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -93,7 +93,8 @@ public class TemplateApplicationService {
 
     private FindAllTemplatesResponse makeResponse(Page<Template> page, LikedChecker likedChecker) {
         List<Template> templates = page.getContent();
-        List<FindAllTemplateItemResponse> findAllTemplateByResponse = getFindAllTemplateItemResponses(templates, likedChecker);
+        List<FindAllTemplateItemResponse> findAllTemplateByResponse =
+                getFindAllTemplateItemResponses(templates, likedChecker);
 
         return new FindAllTemplatesResponse(
                 page.getTotalPages(),
@@ -101,7 +102,10 @@ public class TemplateApplicationService {
                 findAllTemplateByResponse);
     }
 
-    private List<FindAllTemplateItemResponse> getFindAllTemplateItemResponses(List<Template> templates, LikedChecker likedChecker) {
+    private List<FindAllTemplateItemResponse> getFindAllTemplateItemResponses(
+            List<Template> templates,
+            LikedChecker likedChecker
+    ) {
         List<TemplateTag> allTemplateTagsByTemplates = tagService.getAllTemplateTagsByTemplates(templates);
         List<Thumbnail> allThumbnailsByTemplates = thumbnailService.getAllByTemplates(templates);
 
@@ -144,6 +148,7 @@ public class TemplateApplicationService {
         thumbnailService.deleteByTemplateIds(ids);
         sourceCodeService.deleteByTemplateIds(ids);
         tagService.deleteAllByTemplateIds(ids);
+        likesService.deleteAllByTemplateIds(ids);
         templateService.deleteByMemberAndIds(member, ids);
     }
 }

--- a/backend/src/test/java/codezap/likes/repository/FakeLikeRepository.java
+++ b/backend/src/test/java/codezap/likes/repository/FakeLikeRepository.java
@@ -1,5 +1,7 @@
 package codezap.likes.repository;
 
+import java.util.List;
+
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
@@ -23,5 +25,9 @@ public class FakeLikeRepository implements LikesRepository {
     @Override
     public void deleteByMemberAndTemplate(Member member, Template template) {
 
+    }
+
+    @Override
+    public void deleteByTemplateIds(List<Long> templateIds) {
     }
 }

--- a/backend/src/test/java/codezap/likes/repository/LikesJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/likes/repository/LikesJpaRepositoryTest.java
@@ -2,6 +2,9 @@ package codezap.likes.repository;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -148,6 +151,51 @@ class LikesJpaRepositoryTest {
             ));
 
             assertThat(likesRepository.countByTemplate(template)).isEqualTo(0);
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿 ID로 템플릿에 존재하는 좋아요 삭제 테스트")
+    class DeleteByTemplateIds {
+
+        @Test
+        @DisplayName("성공: 템플릿 ID로 템플릿에 존재하는 좋아요 삭제 (템플릿 1개)")
+        void testDeleteByTemplateId() {
+            var member1 = memberRepository.save(MemberFixture.getFirstMember());
+            var member2 = memberRepository.save(MemberFixture.getSecondMember());
+            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
+            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
+            likesRepository.save(new Likes(template1, member1));
+            likesRepository.save(new Likes(template1, member2));
+            likesRepository.save(new Likes(template2, member1));
+
+            likesRepository.deleteByTemplateIds(List.of(template1.getId()));
+
+            assertAll(
+                    () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),
+                    () -> assertThat(likesRepository.countByTemplate(template2)).isEqualTo(1)
+            );
+        }
+
+        @Test
+        @DisplayName("성공: 템플릿 ID로 템플릿에 존재하는 좋아요 삭제 (템플릿 2개)")
+        void testDeleteByTemplateIds() {
+            var member1 = memberRepository.save(MemberFixture.getFirstMember());
+            var member2 = memberRepository.save(MemberFixture.getSecondMember());
+            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
+            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
+            likesRepository.save(new Likes(template1, member1));
+            likesRepository.save(new Likes(template1, member2));
+            likesRepository.save(new Likes(template2, member1));
+
+            likesRepository.deleteByTemplateIds(List.of(template1.getId(), template2.getId()));
+
+            assertAll(
+                    () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),
+                    () -> assertThat(likesRepository.countByTemplate(template2)).isEqualTo(0)
+            );
         }
     }
 }

--- a/backend/src/test/java/codezap/likes/repository/LikesJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/likes/repository/LikesJpaRepositoryTest.java
@@ -11,6 +11,7 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
@@ -161,11 +162,11 @@ class LikesJpaRepositoryTest {
         @Test
         @DisplayName("성공: 템플릿 ID로 템플릿에 존재하는 좋아요 삭제 (템플릿 1개)")
         void testDeleteByTemplateId() {
-            var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var member2 = memberRepository.save(MemberFixture.getSecondMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
+            Member member1 = memberRepository.save(MemberFixture.getFirstMember());
+            Member member2 = memberRepository.save(MemberFixture.getSecondMember());
+            Category category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Template template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
+            Template template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
             likesRepository.save(new Likes(template1, member1));
             likesRepository.save(new Likes(template1, member2));
             likesRepository.save(new Likes(template2, member1));
@@ -181,11 +182,11 @@ class LikesJpaRepositoryTest {
         @Test
         @DisplayName("성공: 템플릿 ID로 템플릿에 존재하는 좋아요 삭제 (템플릿 2개)")
         void testDeleteByTemplateIds() {
-            var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var member2 = memberRepository.save(MemberFixture.getSecondMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
+            Member member1 = memberRepository.save(MemberFixture.getFirstMember());
+            Member member2 = memberRepository.save(MemberFixture.getSecondMember());
+            Category category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Template template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
+            Template template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
             likesRepository.save(new Likes(template1, member1));
             likesRepository.save(new Likes(template1, member2));
             likesRepository.save(new Likes(template2, member1));

--- a/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
+++ b/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
@@ -2,6 +2,9 @@ package codezap.likes.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.junit.jupiter.api.Assertions.assertAll;
+
+import java.util.List;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -122,6 +125,61 @@ class LikesServiceTest extends ServiceTest {
             ));
 
             assertThat(likesService.isLiked(member, template)).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("템플릿에 해당하는 좋아요 삭제")
+    class DeleteLikeByTemplateIds {
+
+        @Test
+        @DisplayName("성공: 템플릿 1개 삭제")
+        void deleteAllByTemplateIdSuccess() {
+            Member member1 = memberRepository.save(MemberFixture.getFirstMember());
+            Member member2 = memberRepository.save(MemberFixture.getSecondMember());
+            Template template1 = templateRepository.save(TemplateFixture.get(
+                    member1,
+                    categoryRepository.save(CategoryFixture.getFirstCategory())
+            ));
+            Template template2 = templateRepository.save(TemplateFixture.get(
+                    member1,
+                    categoryRepository.save(CategoryFixture.getFirstCategory())
+            ));
+            likesRepository.save(new Likes(template1, member1));
+            likesRepository.save(new Likes(template1, member2));
+            likesRepository.save(new Likes(template2, member1));
+
+            likesService.deleteAllByTemplateIds(List.of(template1.getId()));
+
+            assertAll(
+                    () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),
+                    () -> assertThat(likesRepository.countByTemplate(template2)).isEqualTo(1)
+            );
+        }
+
+        @Test
+        @DisplayName("성공: 템플릿 2개 이상 삭제")
+        void deleteAllByTemplateIdsSuccess() {
+            Member member1 = memberRepository.save(MemberFixture.getFirstMember());
+            Member member2 = memberRepository.save(MemberFixture.getSecondMember());
+            Template template1 = templateRepository.save(TemplateFixture.get(
+                    member1,
+                    categoryRepository.save(CategoryFixture.getFirstCategory())
+            ));
+            Template template2 = templateRepository.save(TemplateFixture.get(
+                    member1,
+                    categoryRepository.save(CategoryFixture.getFirstCategory())
+            ));
+            likesRepository.save(new Likes(template1, member1));
+            likesRepository.save(new Likes(template1, member2));
+            likesRepository.save(new Likes(template2, member1));
+
+            likesService.deleteAllByTemplateIds(List.of(template1.getId(), template2.getId()));
+
+            assertAll(
+                    () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),
+                    () -> assertThat(likesRepository.countByTemplate(template2)).isEqualTo(0)
+            );
         }
     }
 }

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -183,7 +183,6 @@ class TemplateApplicationServiceTest {
         }
     }
 
-
     @Nested
     @DisplayName("템플릿 목록 조회 (비회원)")
     class FindAllBy {
@@ -408,7 +407,7 @@ class TemplateApplicationServiceTest {
     class DeleteByMemberAndIds {
 
         @Test
-        @DisplayName("사용자 정보와 템플릿 ID로 템플릿 삭제 성공")
+        @DisplayName("성공: 썸네일, 소스코드, 태그, 좋아요가 모두 존재하는 템플릿")
         void deleteByMemberAndIds() {
             // given
             var member = memberRepository.save(MemberFixture.getFirstMember());
@@ -419,8 +418,10 @@ class TemplateApplicationServiceTest {
             var sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "filename2", "content2", 2));
             var template3 = templateRepository.save(TemplateFixture.get(member, category));
             var sourceCode3 = sourceCodeRepository.save(new SourceCode(template3, "filename3", "content3", 3));
+            likesRepository.save(new Likes(template1, member));
+            likesRepository.save(new Likes(template2, member));
 
-            var deleteIds = List.of(1L, 2L);
+            var deleteIds = List.of(template1.getId(), template2.getId());
 
             // when
             sut.deleteByMemberAndIds(member, deleteIds);


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #734

## 📍주요 변경 사항
템플릿 삭제 시 템플릿에 연관된 좋아요 삭제 로직 추가

## 🎸기타

### 이거 merge되면 main으로 바로 올립시다
꽤 급한 bug라고 생각해요~ 이거 merge되면 dev에서 확인하고 main 올려요 ~

### cascade
템플릿과 소스코드 양방향 연관관계를 제거한 후, Cascade 설정으로 제거하는 방안 어떨까요?
cascade는 쉽게 설명해서 cascade 설정을 하면 템플릿 삭제 시 자동으로 템플릿과 연관된 데이터가 삭제되는 설정을 의미한다.

> [JPA Cascade는 무엇이고 언제 사용해야 할까?](https://tecoble.techcourse.co.kr/post/2023-08-14-JPA-Cascade/)

#### cascade를 고려해도 좋을 것 같은 도메인

cascade는 ‘게시물’과 ‘댓글’의 관계처럼 부모 - 자식 구조가 명확하다면 Cascade를 사용하는 것은 괜찮은 선택이다. 
우리 서비스에서 이에 해당하는 관계는 다음과 같다. 하지만 하나의 자식에 여러 부모가 대응되는 경우(‘수강 중인 수업’과 ‘학생’의 관계 등)에는 사용하지 않는 것이 좋다. 

우리 서비스에서 템플릿 삭제 시 삭제해야 하는 모든 관계는 부모 - 자식 구조가 명확하다고 생각한다.
- template - like
- template - sourcecode
- sourcecode- thumbnail
- template - tag

#### 현재 바로 변경하지 않은 이유
template와 sourcecode가 양방향 매핑이고, 아직 잘 알진 못하니 더 찾아보려고
+의논이 필요할까해서~ 

> 양방향 매핑은 cascade 사용이 위험하다.
> 그 이유는 위에 참고 자료 확인!
> 간단하게 말하자면 양방향 매핑이면, sourcecode 삭제 시 템플릿 삭제될 수도 있음
