### PR TITLE
[접근성 개선] 로그인 input 및 상세페이지 소스코드 접기 버튼 접근성 개선

### DIFF
--- a/frontend/src/components/Input/Input.style.ts
+++ b/frontend/src/components/Input/Input.style.ts
@@ -2,6 +2,7 @@ import { css } from '@emotion/react';
 import styled from '@emotion/styled';
 
 import { theme } from '@/style/theme';
+
 import type { BaseProps, TextFieldProps } from './Input';
 
 const sizes = {
@@ -143,6 +144,12 @@ export const Adornment = styled.div<BaseProps>`
     css`
       width: 1.5rem;
       height: 1.5rem;
+    `}
+
+    ${({ as }) =>
+    as === 'button' &&
+    css`
+      cursor: pointer;
     `}
 `;
 

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -23,7 +23,9 @@ export interface TextFieldProps extends InputHTMLAttributes<HTMLInputElement> {
 
 export interface LabelProps extends LabelHTMLAttributes<HTMLLabelElement> {}
 
-export interface AdornmentProps extends HTMLAttributes<HTMLDivElement> {}
+export interface AdornmentProps extends HTMLAttributes<HTMLDivElement> {
+  as?: 'div' | 'button';
+}
 
 export interface HelperTextProps extends HTMLAttributes<HTMLSpanElement> {}
 

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -45,12 +45,15 @@ const TextField = ({ ...rests }: TextFieldProps) => <S.TextField {...rests} />;
 
 const Label = ({ children, ...rests }: PropsWithChildren<LabelProps>) => <S.Label {...rests}>{children}</S.Label>;
 
-const Adornment = ({ children, ...rests }: PropsWithChildren<AdornmentProps>) => (
-  <S.Adornment {...rests} data-adornment>
-    {children}
-  </S.Adornment>
-);
+const Adornment = ({ children, as, ...rests }: PropsWithChildren<AdornmentProps>) => {
+  const buttonProps = as === 'button' ? { type: 'button' } : {};
 
+  return (
+    <S.Adornment as={as} {...rests} {...buttonProps} data-adornment>
+      {children}
+    </S.Adornment>
+  );
+};
 const HelperText = ({ children, ...rests }: PropsWithChildren<HelperTextProps>) => (
   <S.HelperText {...rests}>{children}</S.HelperText>
 );

--- a/frontend/src/components/SourceCodeViewer/SourceCodeViewer.tsx
+++ b/frontend/src/components/SourceCodeViewer/SourceCodeViewer.tsx
@@ -30,10 +30,13 @@ const SourceCodeViewer = ({ mode = 'detailView', filename = '', content, sourceC
       {mode === 'detailView' && (
         <S.FilenameContainer>
           <S.ToggleButton onClick={toggleSourceCode}>
-            <S.SourceCodeToggleIcon isOpen={isSourceCodeOpen} aria-label='소스코드 펼침'>
+            <S.SourceCodeToggleIcon
+              isOpen={isSourceCodeOpen}
+              aria-label={isSourceCodeOpen ? '소스코드 접기' : '소스코드 펼침'}
+            >
               <ChevronIcon />
             </S.SourceCodeToggleIcon>
-            <S.NoScrollbarContainer>
+            <S.NoScrollbarContainer aria-label={`파일명 ${filename}`}>
               <Text.Small color={theme.color.light.white} weight='bold'>
                 {filename}
               </Text.Small>

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -30,10 +30,10 @@ const LoginPage = () => {
               <Input.TextField
                 type='text'
                 placeholder='아이디를 입력해주세요'
+                placeholderColor='transparent'
                 value={name}
                 onChange={handleNameChange}
                 autoComplete='username'
-                css={{ '::placeholder': { color: 'transparent' } }}
               />
               <Input.HelperText>{errors.name}</Input.HelperText>
             </Input>
@@ -43,10 +43,10 @@ const LoginPage = () => {
               <Input.TextField
                 type={showPassword ? 'text' : 'password'}
                 placeholder='비밀번호를 입력해주세요'
+                placeholderColor='transparent'
                 value={password}
                 onChange={handlePasswordChange}
                 autoComplete='current-password'
-                css={{ '::placeholder': { color: 'transparent' } }}
               />
               <Input.Adornment>
                 <button aria-label='비밀번호 보기'>

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -48,10 +48,8 @@ const LoginPage = () => {
                 onChange={handlePasswordChange}
                 autoComplete='current-password'
               />
-              <Input.Adornment>
-                <button aria-label='비밀번호 보기'>
-                  <EyeIcon onClick={handlePasswordToggle} css={{ cursor: 'pointer' }} aria-hidden />
-                </button>
+              <Input.Adornment as='button' aria-label='비밀번호 보기' onClick={handlePasswordToggle}>
+                <EyeIcon aria-hidden />
               </Input.Adornment>
               <Input.HelperText>{errors.password}</Input.HelperText>
             </Input>

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -27,7 +27,14 @@ const LoginPage = () => {
           >
             <Input variant='outlined' size='medium' isValid={!errors.name}>
               <Input.Label>아이디 (닉네임)</Input.Label>
-              <Input.TextField type='text' value={name} onChange={handleNameChange} autoComplete='username' />
+              <Input.TextField
+                type='text'
+                placeholder='아이디를 입력해주세요'
+                value={name}
+                onChange={handleNameChange}
+                autoComplete='username'
+                css={{ '::placeholder': { color: 'transparent' } }}
+              />
               <Input.HelperText>{errors.name}</Input.HelperText>
             </Input>
 
@@ -35,12 +42,16 @@ const LoginPage = () => {
               <Input.Label>비밀번호</Input.Label>
               <Input.TextField
                 type={showPassword ? 'text' : 'password'}
+                placeholder='비밀번호를 입력해주세요'
                 value={password}
                 onChange={handlePasswordChange}
                 autoComplete='current-password'
+                css={{ '::placeholder': { color: 'transparent' } }}
               />
               <Input.Adornment>
-                <EyeIcon onClick={handlePasswordToggle} css={{ cursor: 'pointer' }} aria-label='비밀번호 보기' />
+                <button aria-label='비밀번호 보기'>
+                  <EyeIcon onClick={handlePasswordToggle} css={{ cursor: 'pointer' }} aria-hidden />
+                </button>
               </Input.Adornment>
               <Input.HelperText>{errors.password}</Input.HelperText>
             </Input>


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #722 

## 📍주요 변경 사항
### 1. 로그인 페이지에서 모든 입력 필드에 적절한 안내해주기
- placeholder를 추가하고, 해당 placeholder 스타일을 투명하게 주어 보이지 않게 처리했습니다.
### 2. 로그인 페이지에서 눈 아이콘 버튼 focus 되면 `비밀번호 보기 버튼` 읽게 하기
- button 태그를 추가하고 해당 버튼에 aria-label 달아주었습니다.
### 3. 상세페이지에서 쉐브론 이미지 대신 `소스코드 접기` 버튼으로 읽기
- isSourceCodeOpen 여부에 따라 aria-label 읽도록 설정해주었습니다.

- 상세페이지 구현 결과

https://github.com/user-attachments/assets/b5898253-7197-4f75-9fc0-c3ef51beb0fd

- 로그인페이지 구현 결과

https://github.com/user-attachments/assets/03c67da0-4676-4181-b318-1ea46c64bd2d

(컴퓨터에서 녹화했는데 왜인지 소리는 녹음이 안되네요😂)