### PR TITLE
[접근성 개선] - 상단 Header, 로그인 Input

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "code-zap",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/frontend/src/components/Header/Header.style.ts
+++ b/frontend/src/components/Header/Header.style.ts
@@ -99,7 +99,7 @@ export const MobileMenuContainer = styled.div`
   }
 `;
 
-export const HamburgerIconWrapper = styled.div`
+export const HamburgerIconWrapper = styled.button`
   display: none;
 
   @media (max-width: 768px) {

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -64,16 +64,24 @@ const Header = ({ headerRef }: { headerRef: React.RefObject<HTMLDivElement> }) =
               weight='bold'
               hoverStyle='none'
               onClick={handleTemplateUploadButton}
+              aria-description='템플릿 작성 페이지로 이동됩니다.'
             >
-              <PlusIcon aria-label='' />새 템플릿
+              <PlusIcon />새 템플릿
             </S.MobileHiddenButton>
 
             {!isChecking && isLogin ? <LogoutButton /> : <LoginButton />}
           </S.NavContainer>
         </S.HeaderMenu>
         <S.MobileMenuContainer>
-          <Button variant='outlined' size='small' weight='bold' hoverStyle='none' onClick={handleTemplateUploadButton}>
-            <PlusIcon aria-label='' />새 템플릿
+          <Button
+            variant='outlined'
+            size='small'
+            weight='bold'
+            hoverStyle='none'
+            onClick={handleTemplateUploadButton}
+            aria-description='템플릿 작성 페이지로 이동됩니다.'
+          >
+            <PlusIcon />새 템플릿
           </Button>
           <HeaderMenuButton menuOpen={menuOpen} toggleMenu={toggleMenu} />
         </S.MobileMenuContainer>

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -125,7 +125,7 @@ const LoginButton = () => (
 );
 
 const HeaderMenuButton = ({ menuOpen, toggleMenu }: { menuOpen: boolean; toggleMenu: () => void }) => (
-  <S.HamburgerIconWrapper>
+  <S.HamburgerIconWrapper aria-label='메뉴'>
     <HamburgerIcon menuOpen={menuOpen} onClick={toggleMenu} />
   </S.HamburgerIconWrapper>
 );

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -27,7 +27,13 @@ const LoginPage = () => {
           >
             <Input variant='outlined' size='medium' isValid={!errors.name}>
               <Input.Label>아이디 (닉네임)</Input.Label>
-              <Input.TextField type='text' value={name} onChange={handleNameChange} autoComplete='username' />
+              <Input.TextField
+                type='text'
+                value={name}
+                onChange={handleNameChange}
+                autoComplete='username'
+                aria-label='아이디 입력. 1자 ~ 255자의 올바른 문자를 입력해주세요'
+              />
               <Input.HelperText>{errors.name}</Input.HelperText>
             </Input>
 
@@ -38,6 +44,7 @@ const LoginPage = () => {
                 value={password}
                 onChange={handlePasswordChange}
                 autoComplete='current-password'
+                aria-label='비밀번호 입력. 영문자, 숫자를 포함한 8 ~ 16자의 비밀번호를 입력해주세요.'
               />
               <Input.Adornment>
                 <EyeIcon onClick={handlePasswordToggle} css={{ cursor: 'pointer' }} aria-label='비밀번호 보기' />


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #722 

## 📍주요 변경 사항
1. 헤더의 햄버거 메뉴 태그를 button으로 변경 후 aria-label='메뉴' 추가
2. 헤더의 새 템플릿 버튼 포커스 시, '템플릿 작성 페이지로 이동됩니다' aria-description 추가
3. 로그인 페이지의 아이디, 비밀번호 input에 요구사항을 스크린 리더가 읽도록 aria-label로 추가

## 🎸기타
1. 한가지 고려해볼 사항이 있는데, 코멘트로 남길게요.
