### PR TITLE
태그 이름으로 태그 조회 시 대소문자를 구분하지 않아 태그가 중복으로 반환되는 버그 수정

### DIFF
--- a/backend/src/main/java/codezap/tag/repository/TagJpaRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TagJpaRepository.java
@@ -27,8 +27,6 @@ public interface TagJpaRepository extends TagRepository, JpaRepository<Tag, Long
     @Query(value = "SELECT * FROM tag WHERE tag.name = BINARY :name", nativeQuery = true)
     Optional<Tag> findByName(@Param("name") String name);
 
-    @Query(
-            value = "SELECT * FROM tag WHERE tag.name COLLATE utf8mb4_bin IN :names",
-            nativeQuery = true)
+    @Query(value = "SELECT * FROM tag WHERE tag.name COLLATE utf8mb4_bin IN :names", nativeQuery = true)
     List<Tag> findAllByNames(@Param("names") List<String> names);
 }

--- a/backend/src/main/java/codezap/tag/repository/TagJpaRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TagJpaRepository.java
@@ -24,8 +24,11 @@ public interface TagJpaRepository extends TagRepository, JpaRepository<Tag, Long
                 () -> new CodeZapException(HttpStatus.NOT_FOUND, "이름이 " + name + "인 태그는 존재하지 않습니다."));
     }
 
-    Optional<Tag> findByName(String name);
+    @Query(value = "SELECT * FROM tag WHERE tag.name = BINARY :name", nativeQuery = true)
+    Optional<Tag> findByName(@Param("name") String name);
 
-    @Query("select t.name from Tag t where t.name in :names")
-    List<String> findNameByNamesIn(@Param("names") List<String> names);
+    @Query(
+            value = "SELECT * FROM tag WHERE tag.name COLLATE utf8mb4_bin IN :names",
+            nativeQuery = true)
+    List<Tag> findAllByNames(@Param("names") List<String> names);
 }

--- a/backend/src/main/java/codezap/tag/repository/TagRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TagRepository.java
@@ -13,7 +13,7 @@ public interface TagRepository {
 
     Optional<Tag> findByName(String name);
 
-    List<Tag> findByNameIn(List<String> names);
+    List<Tag> findAllByNames(List<String> names);
 
     Tag save(Tag tag);
 

--- a/backend/src/main/java/codezap/tag/repository/TemplateTagJpaRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TemplateTagJpaRepository.java
@@ -5,6 +5,7 @@ import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import codezap.tag.domain.Tag;
 import codezap.template.domain.Template;
@@ -51,5 +52,5 @@ public interface TemplateTagJpaRepository extends TemplateTagRepository, JpaRepo
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM TemplateTag t WHERE t.template.id in :templateIds")
-    void deleteByTemplateIds(List<Long> templateIds);
+    void deleteByTemplateIds(@Param("templateIds") List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/tag/service/TagService.java
+++ b/backend/src/main/java/codezap/tag/service/TagService.java
@@ -24,7 +24,7 @@ public class TagService {
 
     @Transactional
     public void createTags(Template template, List<String> tagNames) {
-        List<Tag> existingTags = new ArrayList<>(tagRepository.findByNameIn(tagNames));
+        List<Tag> existingTags = new ArrayList<>(tagRepository.findAllByNames(tagNames));
         List<String> existNames = existingTags.stream()
                 .map(Tag::getName)
                 .toList();

--- a/backend/src/test/java/codezap/tag/repository/TagJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/tag/repository/TagJpaRepositoryTest.java
@@ -3,6 +3,7 @@ package codezap.tag.repository;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.junit.jupiter.api.DisplayName;
@@ -58,6 +59,19 @@ class TagJpaRepositoryTest {
         }
 
         @Test
+        @DisplayName("태그명으로 태그 조회 성공 : 대소문자 구분")
+        void findByNameSuccessCaseSensitive() {
+            Tag lowerCaseTag = tagRepository.save(new Tag("java"));
+            Tag upperCaseTag = tagRepository.save(new Tag("Java"));
+
+            var actual1 = tagRepository.fetchByName("java");
+            var actual2 = tagRepository.fetchByName("Java");
+
+            assertThat(actual1).isEqualTo(lowerCaseTag);
+            assertThat(actual2).isEqualTo(upperCaseTag);
+        }
+
+        @Test
         @DisplayName("태그명으로 태그 조회 실패 : 존재하지 않는 태그명인 경우 에러가 발생한다.")
         void fetchByNameFailByNotExistsId() {
             String notExistTagName = "태그";
@@ -87,6 +101,36 @@ class TagJpaRepositoryTest {
             Optional<Tag> actual = tagRepository.findByName("태그");
 
             assertThat(actual).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("태그명 리스트로 태그 조회")
+    class FindAllByNames {
+
+        @Test
+        @DisplayName("태그명 리스트로 태그 조회 성공")
+        void findAllByNamesSuccess() {
+            Tag lowerCaseTag1 = tagRepository.save(new Tag("java"));
+            Tag lowerCaseTag2 = tagRepository.save(new Tag("javascript"));
+            Tag lowerCaseTag3 = tagRepository.save(new Tag("typescript"));
+            Tag upperCaseTag1 = tagRepository.save(new Tag("Java"));
+            Tag upperCaseTag2 = tagRepository.save(new Tag("Javascript"));
+            Tag upperCaseTag3 = tagRepository.save(new Tag("Typescript"));
+            tagRepository.saveAll(List.of(
+                    lowerCaseTag1,
+                    lowerCaseTag2,
+                    lowerCaseTag3,
+                    upperCaseTag1,
+                    upperCaseTag2,
+                    upperCaseTag3));
+
+            var names = List.of(lowerCaseTag1.getName(), lowerCaseTag3.getName());
+            var actual = tagRepository.findAllByNames(names);
+
+            assertThat(actual)
+                    .containsExactlyInAnyOrder(lowerCaseTag1, lowerCaseTag3)
+                    .doesNotContain(lowerCaseTag2, upperCaseTag1, upperCaseTag2, upperCaseTag3);
         }
     }
 }

--- a/backend/src/test/java/codezap/template/repository/FakeTagRepository.java
+++ b/backend/src/test/java/codezap/template/repository/FakeTagRepository.java
@@ -42,7 +42,7 @@ public class FakeTagRepository implements TagRepository {
     }
 
     @Override
-    public List<Tag> findByNameIn(List<String> names) {
+    public List<Tag> findAllByNames(List<String> names) {
         return List.of();
     }
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #758
related #757

## 📍 주요 변경 사항

## 1. 태그 조회 시 binary 비교를 통해 대소문자를 구분하여 조회합니다. 

요구사항은 다음과 같습니다.
- 대소문자 구분
- `tag.name` 칼럼에 설정된 인덱스 효율 유지
- 단건 조회, 다건 조회 모두 적용

### AS-IS

```java
    Optional<Tag> findByName(String name);

    @Query("select t.name from Tag t where t.name in :names")
    List<String> findNameByNamesIn(@Param("names") List<String> names);
```

### TO-BE

```java
    @Query(value = "SELECT * FROM tag WHERE tag.name = BINARY :name", nativeQuery = true)
    Optional<Tag> findByName(@Param("name") String name);

    @Query(value = "SELECT * FROM tag WHERE tag.name COLLATE utf8mb4_bin IN :names", nativeQuery = true)
    List<Tag> findAllByNames(@Param("names") List<String> names);
```

#### ❌ 틀린 방법

만약 다음과 같이 사용할 경우, name 칼럼의 인덱스를 사용하지 않고 full scan 합니다.

```java
    @Query(value = "SELECT * FROM tag WHERE BINARY tag.name = :name", nativeQuery = true)
    Optional<Tag> findByName(@Param("name") String name);
```

#### MySQL의 COLLATE

[COLLATE 사용에 대한 ChatGPT의 설명](https://github.com/woowacourse-teams/2024-code-zap/issues/758#issuecomment-2399493034)을 참고하세용

## 2.TagJpaRepository와 TagRepository의 메서드 불일치를 해결합니다. 

메서드 시그니처가 달라서 TagRepository의 메서드가 구현되지 않았습니다. 

### AS-IS

```java
// TagRepository.java
List<Tag> findByNameIn(List<String> names);

// TagJpaRepository.java
List<String> findNameByNamesIn(@Param("names") List<String> names);
```

### TO-BE

```java
// TagRepository.java
List<Tag> findAllByNames(List<String> names);

// TagJpaRepository.java
List<Tag> findAllByNames(@Param("names") List<String> names);
```

## 3. 테스트코드를 추가합니다. 

관련 테스트코드가 없었습니다. 테스트코드를 추가했습니다. 

## 🎸 이런 것도 고려해야 해요
- Service 로직에서 소문자로 변경해서 저장
