### PR TITLE
[FIX] 에러코드 detail 정보 없는 경우 수정 및 스웨거 수정

### DIFF
--- a/backend/src/main/java/codezap/global/exception/GlobalExceptionHandler.java
+++ b/backend/src/main/java/codezap/global/exception/GlobalExceptionHandler.java
@@ -24,6 +24,7 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     private static final String PROPERTY_ERROR_CODE = "errorCode";
     private static final String PROPERTY_TIMESTAMP = "timestamp";
+    private static final String DEFAULT_DETAIL_MASSAGE = "디테일 값이 존재하지 않습니다.";
 
     @ExceptionHandler
     public ResponseEntity<ProblemDetail> handleCodeZapException(CodeZapException codeZapException) {
@@ -63,17 +64,18 @@ public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
     protected ResponseEntity<Object> createResponseEntity(
             @Nullable Object body, HttpHeaders headers, HttpStatusCode statusCode, WebRequest request
     ) {
-        ProblemDetail problemDetail = ProblemDetail.forStatus(statusCode);
-        if (body instanceof Exception) {
-            problemDetail.setDetail(((Exception) body).getMessage());
+        if (body instanceof ProblemDetail) {
+            return ResponseEntity.status(statusCode)
+                    .body(setProperties((ProblemDetail) body, ErrorCode.SPRING_GLOBAL_EXCEPTION.getCode()));
         }
+        ProblemDetail problemDetail = ProblemDetail.forStatusAndDetail(statusCode, DEFAULT_DETAIL_MASSAGE);
         return ResponseEntity.status(statusCode)
                 .body(setProperties(problemDetail, ErrorCode.SPRING_GLOBAL_EXCEPTION.getCode()));
     }
 
     public static ProblemDetail setProperties(ProblemDetail problemDetail, int code) {
         problemDetail.setProperty(PROPERTY_ERROR_CODE, code);
-        problemDetail.setProperty(PROPERTY_TIMESTAMP, LocalDateTime.now());
+        problemDetail.setProperty(PROPERTY_TIMESTAMP, LocalDateTime.now().toString());
 
         return problemDetail;
     }


### PR DESCRIPTION
## ⚡️ 관련 이슈
#521

## 📍주요 변경 사항

### 문제
- 스프링에서 반환하는 response에는 detail 정보가 없는 문제 있었음
- 스웨거에서 직렬화 하는 코드에서 문제 발생 -> problemDetail에 새로운 값으로 LocalDateTime이 추가되는데 이는 직렬화가 안됨

### 해결
- 커스텀하기 전 전달 객체가 이미 ProblemDetail이어서 전달 객체에 커스텀 properties만 추가
- problemDetail에 LocalDateTime을 toString()해서 문자열로 변환

## 🎸기타

