### PR TITLE
문의하기 모달 생성

### DIFF
--- a/frontend/src/components/ContactUs/ContactUs.style.ts
+++ b/frontend/src/components/ContactUs/ContactUs.style.ts
@@ -1,0 +1,11 @@
+import styled from '@emotion/styled';
+
+export const ContactUSButton = styled.button`
+  cursor: pointer;
+`;
+
+export const Form = styled.form`
+  display: flex;
+  flex-direction: column;
+  gap: 2rem;
+`;

--- a/frontend/src/components/ContactUs/ContactUs.style.ts
+++ b/frontend/src/components/ContactUs/ContactUs.style.ts
@@ -7,5 +7,5 @@ export const ContactUSButton = styled.button`
 export const Form = styled.form`
   display: flex;
   flex-direction: column;
-  gap: 2rem;
+  gap: 1.25rem;
 `;

--- a/frontend/src/components/ContactUs/ContactUs.tsx
+++ b/frontend/src/components/ContactUs/ContactUs.tsx
@@ -1,0 +1,66 @@
+import { useInput, useInputWithValidate, useToggle } from '@/hooks';
+import { validateEmail } from '@/service/validates';
+import { theme } from '@/style/theme';
+
+import { Button, Input, Modal, Text, Textarea } from '..';
+import * as S from './ContactUs.style';
+
+const ContactUs = () => {
+  const [isModalOpen, toggleModal] = useToggle();
+  const [contents, handleContents] = useInput('');
+  const {
+    value: email,
+    handleChange: handleEmail,
+    errorMessage: emailErrorMessage,
+  } = useInputWithValidate('', validateEmail);
+
+  const isValidContents = contents.trim().length;
+
+  const handleSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+    e.preventDefault();
+
+    if (!isValidContents) {
+      return;
+    }
+
+    toggleModal();
+  };
+
+  return (
+    <>
+      <S.ContactUSButton onClick={toggleModal}>
+        <Text.Medium weight='bold' color={theme.color.light.secondary_800}>
+          문의하기
+        </Text.Medium>
+      </S.ContactUSButton>
+      <Modal isOpen={isModalOpen} toggleModal={toggleModal} size='large'>
+        <Modal.Header>문의하기</Modal.Header>
+        <Modal.Body>
+          <S.Form onSubmit={handleSubmit}>
+            <Text.Medium as='p' color={theme.color.light.secondary_500}>
+              질문/피드백을 편하게 남겨주세요! 여러분의 의견은 더 나은 서비스를 만드는 데 큰 도움이 됩니다. <br />
+              답변이 필요하시면 아래 이메일 주소를 남겨주세요. 이메일은 오직 답변을 위해서만 사용됩니다 :)
+            </Text.Medium>
+            <Textarea id='voc' variant='outlined'>
+              <Textarea.Label htmlFor={'voc'}>무엇을 도와드릴까요?</Textarea.Label>
+              <Textarea.TextField minRows={5} maxRows={10} value={contents} onChange={handleContents} />
+            </Textarea>
+            <Input variant='outlined' isValid={!emailErrorMessage}>
+              <Input.Label>이메일 (선택)</Input.Label>
+              <Input.TextField value={email} onChange={handleEmail} />
+              <Input.HelperText>{emailErrorMessage}</Input.HelperText>
+            </Input>
+          </S.Form>
+        </Modal.Body>
+        <Modal.Footer>
+          <Button onClick={toggleModal} variant='outlined'>
+            닫기
+          </Button>
+          <Button disabled={isValidContents ? false : true}>보내기</Button>
+        </Modal.Footer>
+      </Modal>
+    </>
+  );
+};
+
+export default ContactUs;

--- a/frontend/src/components/ContactUs/ContactUs.tsx
+++ b/frontend/src/components/ContactUs/ContactUs.tsx
@@ -18,7 +18,7 @@ const ContactUs = () => {
 
   const { failAlert, successAlert } = useToast();
 
-  const isValidContents = message.trim().length;
+  const isValidContents = message.trim().length !== 0;
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement> | React.MouseEvent<HTMLButtonElement>) => {
     e.preventDefault();

--- a/frontend/src/components/Footer/Footer.tsx
+++ b/frontend/src/components/Footer/Footer.tsx
@@ -1,4 +1,4 @@
-import { Text } from '@/components';
+import { ContactUs, Text } from '@/components';
 import { useAuth } from '@/hooks/authentication';
 
 import * as S from './Footer.style';
@@ -19,11 +19,8 @@ const Footer = () => {
         </Text.Small>{' '}
         © All rights reserved.
       </Text.Small>
-      <S.ContactEmail href='mailto:codezap2024@gmail.com'>
-        <Text.Small color='inherit' weight='bold'>
-          문의 :
-        </Text.Small>{' '}
-        <Text.Small color='inherit'>codezap2024@gmail.com</Text.Small>{' '}
+      <S.ContactEmail>
+        <ContactUs />
       </S.ContactEmail>
     </S.FooterContainer>
   );

--- a/frontend/src/components/Header/Header.style.ts
+++ b/frontend/src/components/Header/Header.style.ts
@@ -17,7 +17,7 @@ export const HeaderContainer = styled.nav`
   padding: 0 2rem;
 
   background: white;
-  border-bottom: 2px solid ${theme.color.light.secondary_200};
+  border-bottom: 1px solid ${theme.color.light.secondary_300};
 
   @media (max-width: 768px) {
     padding: 0 1rem;

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -92,14 +92,21 @@ const Header = ({ headerRef }: { headerRef: React.RefObject<HTMLDivElement> }) =
   );
 };
 
-const Logo = () => (
-  <Link to={END_POINTS.HOME}>
-    <Flex align='center' gap='0.5rem'>
-      <CodeZapLogo aria-label='로고 버튼' />
-      <Heading.XSmall color={theme.color.light.secondary_800}>코드잽</Heading.XSmall>
-    </Flex>
-  </Link>
-);
+const Logo = () => {
+  const location = useLocation();
+  const isLandingPage = location.pathname === '/';
+
+  return (
+    <Link to={END_POINTS.HOME}>
+      <Flex align='center' gap='0.5rem'>
+        <CodeZapLogo aria-label='로고 버튼' />
+        <Heading.XSmall color={isLandingPage ? theme.color.light.primary_500 : theme.color.light.secondary_800}>
+          코드잽
+        </Heading.XSmall>
+      </Flex>
+    </Link>
+  );
+};
 
 const NavOption = ({ route, name }: { route: string; name: string }) => {
   const location = useLocation();

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -96,7 +96,7 @@ const Logo = () => (
   <Link to={END_POINTS.HOME}>
     <Flex align='center' gap='0.5rem'>
       <CodeZapLogo aria-label='로고 버튼' />
-      <Heading.XSmall color={theme.color.light.primary_500}>코드잽</Heading.XSmall>
+      <Heading.XSmall color={theme.color.light.secondary_800}>코드잽</Heading.XSmall>
     </Flex>
   </Link>
 );

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -2,7 +2,7 @@ import { useEffect } from 'react';
 import { Link, useLocation } from 'react-router-dom';
 
 import { CodeZapLogo, HamburgerIcon, PlusIcon } from '@/assets/images';
-import { Button, Flex, Heading, Text } from '@/components';
+import { Button, ContactUs, Flex, Heading, Text } from '@/components';
 import { ToastContext } from '@/contexts';
 import { useCustomContext, useCustomNavigate, useToggle } from '@/hooks';
 import { useAuth } from '@/hooks/authentication/useAuth';
@@ -56,6 +56,7 @@ const Header = ({ headerRef }: { headerRef: React.RefObject<HTMLDivElement> }) =
           <S.NavContainer>
             {!isChecking && isLogin && <NavOption route={END_POINTS.MY_TEMPLATES} name='내 템플릿' />}
             <NavOption route={END_POINTS.TEMPLATES_EXPLORE} name='구경가기' />
+            <ContactUs />
           </S.NavContainer>
           <S.NavContainer>
             <S.MobileHiddenButton
@@ -100,15 +101,23 @@ const Logo = () => (
   </Link>
 );
 
-const NavOption = ({ route, name }: { route: string; name: string }) => (
-  <Link to={route}>
-    <S.NavOptionButton>
-      <Text.Medium weight='bold' color={theme.color.light.secondary_800}>
-        {name}
-      </Text.Medium>
-    </S.NavOptionButton>
-  </Link>
-);
+const NavOption = ({ route, name }: { route: string; name: string }) => {
+  const location = useLocation();
+  const isCurrentPage = location.pathname === route;
+
+  return (
+    <Link to={route}>
+      <S.NavOptionButton>
+        <Text.Medium
+          weight='bold'
+          color={isCurrentPage ? theme.color.light.primary_500 : theme.color.light.secondary_800}
+        >
+          {name}
+        </Text.Medium>
+      </S.NavOptionButton>
+    </Link>
+  );
+};
 
 const LogoutButton = () => {
   const { mutateAsync } = useLogoutMutation();

--- a/frontend/src/components/Input/Input.tsx
+++ b/frontend/src/components/Input/Input.tsx
@@ -1,12 +1,6 @@
-import {
-  Children,
-  HTMLAttributes,
-  InputHTMLAttributes,
-  isValidElement,
-  LabelHTMLAttributes,
-  PropsWithChildren,
-  ReactNode,
-} from 'react';
+import { HTMLAttributes, InputHTMLAttributes, LabelHTMLAttributes, PropsWithChildren } from 'react';
+
+import { getChildOfType, getChildrenWithoutTypes } from '@/utils';
 
 import * as S from './Input.style';
 
@@ -28,18 +22,6 @@ export interface AdornmentProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 export interface HelperTextProps extends HTMLAttributes<HTMLSpanElement> {}
-
-const getChildOfType = (children: ReactNode, type: unknown) => {
-  const childrenArray = Children.toArray(children);
-
-  return childrenArray.find((child) => isValidElement(child) && child.type === type);
-};
-
-const getChildrenWithoutTypes = (children: ReactNode, types: unknown[]) => {
-  const childrenArray = Children.toArray(children);
-
-  return childrenArray.filter((child) => !(isValidElement(child) && types.includes(child.type)));
-};
 
 const TextField = ({ ...rests }: TextFieldProps) => <S.TextField {...rests} />;
 

--- a/frontend/src/components/Modal/Modal.tsx
+++ b/frontend/src/components/Modal/Modal.tsx
@@ -1,6 +1,9 @@
 import { HTMLAttributes, PropsWithChildren, ReactNode } from 'react';
 import { createPortal } from 'react-dom';
 
+import { usePressESC } from '@/hooks/usePressESC';
+import { useScrollDisable } from '@/hooks/useScrollDisable';
+
 import { theme } from '../../style/theme';
 import Heading from '../Heading/Heading';
 import * as S from './Modal.style';
@@ -14,6 +17,9 @@ export interface BaseProps extends HTMLAttributes<HTMLDivElement> {
 }
 
 const Base = ({ isOpen, toggleModal, size = 'small', children, ...props }: PropsWithChildren<BaseProps>) => {
+  usePressESC(isOpen, toggleModal);
+  useScrollDisable(isOpen);
+
   if (!isOpen) {
     return null;
   }

--- a/frontend/src/components/Textarea/Textarea.stories.tsx
+++ b/frontend/src/components/Textarea/Textarea.stories.tsx
@@ -1,0 +1,179 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { useState, ReactNode } from 'react';
+
+import Textarea, { BaseProps, TextFieldProps } from './Textarea';
+
+type TextareaStoryProps = BaseProps & {
+  children?: ReactNode;
+  minRows?: TextFieldProps['minRows'];
+  maxRows?: TextFieldProps['maxRows'];
+};
+
+const meta: Meta<TextareaStoryProps> = {
+  title: 'Textarea',
+  component: Textarea,
+  argTypes: {
+    variant: {
+      control: {
+        type: 'radio',
+        options: ['filled', 'outlined', 'text'],
+      },
+    },
+    size: {
+      control: {
+        type: 'radio',
+        options: ['small', 'medium', 'large', 'xlarge'],
+      },
+    },
+    isValid: {
+      control: {
+        type: 'boolean',
+      },
+    },
+    minRows: {
+      control: {
+        type: 'number',
+        min: 1,
+      },
+    },
+    maxRows: {
+      control: {
+        type: 'number',
+        min: 1,
+      },
+    },
+  },
+};
+
+export default meta;
+
+type Story = StoryObj<TextareaStoryProps>;
+
+export const Filled: Story = {
+  args: {
+    minRows: 3,
+    maxRows: 8,
+  },
+  render: (args) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <div style={{ width: '500px' }}>
+        <Textarea variant={args.variant} size={args.size} isValid={args.isValid}>
+          <Textarea.TextField
+            placeholder='Enter Text'
+            onChange={(e) => setValue(e.target.value)}
+            value={value}
+            minRows={args.minRows}
+            maxRows={args.maxRows}
+          />
+        </Textarea>
+      </div>
+    );
+  },
+};
+
+export const Outlined: Story = {
+  args: {
+    variant: 'outlined',
+    minRows: 3,
+    maxRows: 8,
+  },
+  render: (args) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <div style={{ width: '500px' }}>
+        <Textarea variant={args.variant} size={args.size} isValid={args.isValid}>
+          <Textarea.TextField
+            placeholder='Enter Text'
+            onChange={(e) => setValue(e.target.value)}
+            value={value}
+            minRows={args.minRows}
+            maxRows={args.maxRows}
+          />
+        </Textarea>
+      </div>
+    );
+  },
+};
+
+export const Text: Story = {
+  args: {
+    variant: 'text',
+    minRows: 3,
+    maxRows: 8,
+  },
+  render: (args) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <div style={{ width: '500px' }}>
+        <Textarea variant={args.variant} size={args.size} isValid={args.isValid}>
+          <Textarea.TextField
+            placeholder='Enter Text'
+            onChange={(e) => setValue(e.target.value)}
+            value={value}
+            minRows={args.minRows}
+            maxRows={args.maxRows}
+          />
+        </Textarea>
+      </div>
+    );
+  },
+};
+
+export const WithLabel: Story = {
+  args: {
+    variant: 'outlined',
+    minRows: 3,
+    maxRows: 8,
+  },
+  render: (args) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <div style={{ width: '500px' }}>
+        <Textarea id='helper' variant={args.variant} size={args.size} isValid={args.isValid}>
+          <Textarea.Label htmlFor='helper'>라벨</Textarea.Label>
+          <Textarea.TextField
+            placeholder='Enter Text'
+            onChange={(e) => setValue(e.target.value)}
+            value={value}
+            minRows={args.minRows}
+            maxRows={args.maxRows}
+          />
+        </Textarea>
+      </div>
+    );
+  },
+};
+
+export const WithHelperText: Story = {
+  args: {
+    variant: 'outlined',
+    size: 'medium',
+    isValid: false,
+    minRows: 3,
+    maxRows: 8,
+  },
+  render: (args) => {
+    const [value, setValue] = useState('');
+
+    return (
+      <div style={{ width: '500px' }}>
+        <Textarea id='helper' variant={args.variant} size={args.size} isValid={args.isValid}>
+          <Textarea.Label htmlFor='helper'>라벨</Textarea.Label>
+          <Textarea.TextField
+            placeholder='Enter Text'
+            onChange={(e) => setValue(e.target.value)}
+            value={value}
+            minRows={args.minRows}
+            maxRows={args.maxRows}
+          />
+          <Textarea.HelperText>설명입니다</Textarea.HelperText>
+        </Textarea>
+      </div>
+    );
+  },
+};

--- a/frontend/src/components/Textarea/Textarea.style.ts
+++ b/frontend/src/components/Textarea/Textarea.style.ts
@@ -1,0 +1,101 @@
+import { css } from '@emotion/react';
+import styled from '@emotion/styled';
+
+import { theme } from '@/style/theme';
+
+import { BaseProps, TextFieldProps } from './Textarea';
+
+const variants = (color: string | undefined) => ({
+  filled: css`
+    background-color: ${color ?? '#ffffff'};
+  `,
+  outlined: css`
+    background: none;
+    border: 1px solid ${color ?? theme.color.light.tertiary_400};
+  `,
+  text: css`
+    background: none;
+  `,
+});
+
+const sizes = {
+  small: css`
+    padding: 8px;
+    font-size: 14px;
+    border-radius: 8px;
+  `,
+  medium: css`
+    padding: 12px;
+    font-size: 16px;
+    border-radius: 10px;
+  `,
+  large: css`
+    padding: 16px;
+    font-size: 18px;
+    border-radius: 12px;
+  `,
+  xlarge: css`
+    padding: 16px;
+    font-size: 32px;
+    border-radius: 12px;
+  `,
+};
+
+export const Container = styled.div`
+  cursor: text;
+
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+
+  width: 100%;
+`;
+
+export const Base = styled.div<BaseProps>`
+  display: flex;
+  flex-direction: column;
+  width: 100%;
+
+  ${({ variant, inputColor }) => variant && variants(inputColor)[variant]};
+  ${({ size = 'medium' }) => sizes[size]};
+  ${({ isValid }) =>
+    isValid === false &&
+    css`
+      border-color: ${theme.color.light.analogous_primary_400};
+    `};
+`;
+
+export const TextareaField = styled.textarea<TextFieldProps>`
+  resize: none;
+
+  width: 100%;
+
+  font-family: inherit;
+  font-size: inherit;
+  line-height: 1.5;
+
+  background: none;
+  border: none;
+  outline: none;
+
+  &::placeholder {
+    color: ${({ placeholderColor }) => placeholderColor || theme.color.light.tertiary_400};
+  }
+
+  &:disabled {
+    cursor: default;
+    opacity: 0.6;
+  }
+`;
+
+export const Label = styled.label`
+  font-size: 1rem;
+  line-height: 100%;
+`;
+
+export const HelperText = styled.span`
+  height: 1rem;
+  margin-left: 0.5rem;
+  font-size: 1rem;
+  color: ${theme.color.light.analogous_primary_400};
+`;

--- a/frontend/src/components/Textarea/Textarea.tsx
+++ b/frontend/src/components/Textarea/Textarea.tsx
@@ -1,0 +1,118 @@
+import { PropsWithChildren, useEffect, useRef } from 'react';
+
+import { getChildOfType, getChildrenWithoutTypes } from '@/utils';
+
+import * as S from './Textarea.style';
+
+export interface BaseProps extends React.HTMLAttributes<HTMLDivElement> {
+  size?: 'small' | 'medium' | 'large' | 'xlarge';
+  variant?: 'filled' | 'outlined' | 'text';
+  isValid?: boolean;
+  inputColor?: string;
+}
+
+export interface TextFieldProps extends React.TextareaHTMLAttributes<HTMLTextAreaElement> {
+  size?: 'small' | 'medium' | 'large' | 'xlarge';
+  minRows?: number;
+  maxRows?: number;
+  placeholderColor?: string;
+}
+
+export interface LabelProps extends React.LabelHTMLAttributes<HTMLLabelElement> {}
+
+export interface HelperTextProps extends React.HTMLAttributes<HTMLSpanElement> {}
+
+const Label = ({ children, ...rests }: PropsWithChildren<LabelProps>) => <S.Label {...rests}>{children}</S.Label>;
+
+const HelperText = ({ children, ...rests }: PropsWithChildren<HelperTextProps>) => (
+  <S.HelperText {...rests}>{children}</S.HelperText>
+);
+
+const LabelType = (<Label />).type;
+const HelperTextType = (<HelperText />).type;
+
+const Base = ({
+  variant = 'filled',
+  size = 'medium',
+  isValid = true,
+  children,
+  ...rests
+}: PropsWithChildren<BaseProps>) => {
+  const textarea = getChildrenWithoutTypes(children, [HelperTextType, LabelType]);
+  const helperText = getChildOfType(children, HelperTextType);
+  const label = getChildOfType(children, LabelType);
+
+  const handleFocusInput = (e: React.MouseEvent<HTMLDivElement>) => {
+    const target = e.target as HTMLElement;
+    const isAdornmentClicked = target.closest('[data-adornment]');
+    const isInputClicked = target.tagName === 'INPUT';
+
+    if (isAdornmentClicked) {
+      return;
+    }
+
+    const input = e.currentTarget.querySelector('input');
+
+    if (input && !isInputClicked) {
+      input.focus();
+
+      const length = input.value.length;
+
+      input.setSelectionRange(length, length);
+    }
+  };
+
+  return (
+    <S.Container>
+      {label}
+      <S.Base variant={variant} size={size} isValid={isValid} {...rests} onClick={handleFocusInput}>
+        {textarea}
+      </S.Base>
+      {helperText}
+    </S.Container>
+  );
+};
+
+const fontSize = {
+  small: 14,
+  medium: 16,
+  large: 18,
+  xlarge: 32,
+} as const;
+
+const TextField = ({ size = 'medium', minRows = 1, maxRows = 1, placeholderColor, ...rest }: TextFieldProps) => {
+  const textareaRef = useRef<HTMLTextAreaElement | null>(null);
+
+  const adjustHeight = () => {
+    if (textareaRef.current) {
+      textareaRef.current.style.height = 'auto';
+      const scrollHeight = textareaRef.current.scrollHeight;
+
+      textareaRef.current.style.height = `${Math.min(scrollHeight, maxRows * (fontSize[size] * 1.5))}px`;
+    }
+  };
+
+  useEffect(() => {
+    adjustHeight();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return (
+    <S.TextareaField
+      ref={textareaRef}
+      rows={minRows}
+      maxRows={maxRows}
+      onInput={adjustHeight}
+      placeholderColor={placeholderColor}
+      {...rest}
+    />
+  );
+};
+
+const Textarea = Object.assign(Base, {
+  TextField,
+  Label,
+  HelperText,
+});
+
+export default Textarea;

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -25,6 +25,7 @@ export { default as CategoryDropdown } from './CategoryDropdown/CategoryDropdown
 export { default as CategoryGuide } from './CategoryGuide/CategoryGuide';
 export { default as NewCategoryInput } from './NewCategoryInput/NewCategoryInput';
 export { default as NoSearchResults } from './NoSearchResults/NoSearchResults';
+export { default as Textarea } from './Textarea/Textarea';
 
 // Skeleton UI
 export { default as LoadingBall } from './LoadingBall/LoadingBall';

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -26,6 +26,7 @@ export { default as CategoryGuide } from './CategoryGuide/CategoryGuide';
 export { default as NewCategoryInput } from './NewCategoryInput/NewCategoryInput';
 export { default as NoSearchResults } from './NoSearchResults/NoSearchResults';
 export { default as Textarea } from './Textarea/Textarea';
+export { default as ContactUs } from './ContactUs/ContactUs';
 
 // Skeleton UI
 export { default as LoadingBall } from './LoadingBall/LoadingBall';

--- a/frontend/src/hooks/useInput.ts
+++ b/frontend/src/hooks/useInput.ts
@@ -3,7 +3,7 @@ import { useState } from 'react';
 export const useInput = (initValue: string = '') => {
   const [value, setValue] = useState(initValue);
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => setValue(e.target.value);
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => setValue(e.target.value);
 
   const resetValue = () => {
     setValue('');

--- a/frontend/src/service/validates.ts
+++ b/frontend/src/service/validates.ts
@@ -75,3 +75,19 @@ export const validateTagLength = (tag: string) => {
 
   return '';
 };
+
+export const validateEmail = (email: string) => {
+  const emailRegex = /^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$/;
+
+  const isValid = emailRegex.test(email);
+
+  if (!email.length) {
+    return '';
+  }
+
+  if (!isValid) {
+    return '이메일 형식이 잘못되었습니다.';
+  }
+
+  return '';
+};

--- a/frontend/src/utils/index.ts
+++ b/frontend/src/utils/index.ts
@@ -4,3 +4,4 @@ export { getByteSize } from './getByteSize';
 export { getLanguageByFilename } from './getLanguageByFileName';
 export { remToPx } from './remToPx';
 export { scroll } from './scroll';
+export { getChildOfType, getChildrenWithoutTypes } from './reactChildrenHelpers';

--- a/frontend/src/utils/reactChildrenHelpers.ts
+++ b/frontend/src/utils/reactChildrenHelpers.ts
@@ -1,0 +1,13 @@
+import { Children, isValidElement, ReactNode } from 'react';
+
+export const getChildOfType = (children: ReactNode, type: unknown) => {
+  const childrenArray = Children.toArray(children);
+
+  return childrenArray.find((child) => isValidElement(child) && child.type === type);
+};
+
+export const getChildrenWithoutTypes = (children: ReactNode, types: unknown[]) => {
+  const childrenArray = Children.toArray(children);
+
+  return childrenArray.filter((child) => !(isValidElement(child) && types.includes(child.type)));
+};


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #751 

## 🪧 주요 목표
### ✔️ 문의하기 모달 생성
<img width="1021" alt="image" src="https://github.com/user-attachments/assets/5b767616-54f3-4f44-a6ef-49fc93a6aedb">

- 페이지가 아닌 모달로 구현한 이유 : 모든 페이지에서 쉽게 접근하고, 쉽게 보낼 수 있도록 하는게 중요하다고 생각했기 때문입니다. 새템플릿을 작성하고 있는 와중에 페이지 이동이 되면 불편할 것이라고 판단되어 모달로 구현하였습니다.

## 📍주요 변경 사항
### 1. `Textarea` 컴포넌트 생성
- 사용의 편의성을 위해 `Input` 컴포넌트와 유사한 구조로 구현하였습니다.
- `minRow` 와 `maxRow`를 받아  최소 `minRow`만큼 보여주고,  `maxRow`가 넘어갈 경우 스크롤 처리가 됩니다.
### 2. `ContactUs` 컴포넌트 생성
- 본 컴포넌트가 바로 문의하기 모달입니다.
- 현재 `Header` 와 `Footer`에 달아주었습니다.
- 별도의 훅으로 로직을 분리하지 않고, 구글시트와 연동 등 모든 로직을 컴포넌트 내부에 함께 두었습니다. 그 이유는 로직이 단순하고, 변경될 여지가 적으며, 재사용될 가능성이 현저히 낮기 때문입니다.
### 3. `Header` 현재 위치에 따라 스타일 변경
<img width="382" alt="image" src="https://github.com/user-attachments/assets/2e62fff9-5750-4b31-b9d8-5a6879f57c2b">

- 현재 사용자가 위치한 라우터에 따라 Header 에서 어디에 있는지 알 수 있도록 스타일을 변경해주었습니다.

## 🎸기타
#### - 구글 시트 관련 env 를 추가하였습니다. 현재 빌드 과정에서는 자동으로 포함되게 해두었습니다. 
