### PR TITLE
로그백 설정 오류로 서버가 실행되지 않는 버그 픽스

### DIFF
--- a/backend/src/main/resources/logger/file/error-appender.xml
+++ b/backend/src/main/resources/logger/file/error-appender.xml
@@ -16,7 +16,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/error/error%i.log</fileNamePattern>
+            <fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/error.log</fileNamePattern>
             <totalSizeCap>5GB</totalSizeCap>
             <maxHistory>30</maxHistory>
         </rollingPolicy>

--- a/backend/src/main/resources/logger/file/info-appender.xml
+++ b/backend/src/main/resources/logger/file/info-appender.xml
@@ -16,7 +16,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/info/info%i.log</fileNamePattern>
+            <fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/info.log</fileNamePattern>
             <totalSizeCap>5GB</totalSizeCap>
             <maxHistory>30</maxHistory>
         </rollingPolicy>

--- a/backend/src/main/resources/logger/file/warn-appender.xml
+++ b/backend/src/main/resources/logger/file/warn-appender.xml
@@ -16,7 +16,7 @@
         </encoder>
 
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
-            <fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/warn/warn%i.log</fileNamePattern>
+            <fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/warn.log</fileNamePattern>
             <totalSizeCap>5GB</totalSizeCap>
             <maxHistory>30</maxHistory>
         </rollingPolicy>


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #790 

## 📍주요 변경 사항
로그백 설정이 변경됩니다. 

### AS-IS
```xml
// info-appender.xml
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/info/info%i.log</fileNamePattern>

// warn-appender.xml
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/warn/warn%i.log</fileNamePattern>

// error-appender.xml
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/error/error%i.log</fileNamePattern>
```

### TO-BE
```xml
// info-appender.xml
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/info.log</fileNamePattern>
// warn-appender.xml
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/warn.log</fileNamePattern>
// error-appender.xml
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/error.log</fileNamePattern>
```


## 🎸기타

TimeBasedRollingPolicy에서는 파일별 용량을 고려해 rolling할 수 없는 것으로 보입니다. 

대신 압축은 지원해요. 

> TimeBasedRollingPolicy supports automatic file compression. This feature is enabled if the value of the fileNamePattern option ends with .gz or .zip.

## 🍗 PR 첫 리뷰 마감 기한
ASAP
