### PR TITLE
delete 메서드명 명확하게 변경

### DIFF
--- a/backend/src/main/java/codezap/likes/repository/LikesJpaRepository.java
+++ b/backend/src/main/java/codezap/likes/repository/LikesJpaRepository.java
@@ -13,5 +13,5 @@ public interface LikesJpaRepository extends LikesRepository, JpaRepository<Likes
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Likes l WHERE l.template.id in :templateIds")
-    void deleteByTemplateIds(@Param(value = "templateIds") List<Long> templateIds);
+    void deleteAllByTemplateIds(@Param(value = "templateIds") List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/likes/repository/LikesRepository.java
+++ b/backend/src/main/java/codezap/likes/repository/LikesRepository.java
@@ -16,5 +16,5 @@ public interface LikesRepository {
 
     void deleteByMemberAndTemplate(Member member, Template template);
 
-    void deleteByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/likes/service/LikesService.java
+++ b/backend/src/main/java/codezap/likes/service/LikesService.java
@@ -42,6 +42,6 @@ public class LikesService {
 
     @Transactional
     public void deleteAllByTemplateIds(List<Long> templateIds) {
-        likesRepository.deleteByTemplateIds(templateIds);
+        likesRepository.deleteAllByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/tag/repository/TemplateTagJpaRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TemplateTagJpaRepository.java
@@ -53,5 +53,5 @@ public interface TemplateTagJpaRepository extends TemplateTagRepository, JpaRepo
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM TemplateTag t WHERE t.template.id in :templateIds")
-    void deleteByTemplateIds(@Param("templateIds") List<Long> templateIds);
+    void deleteAllByTemplateIds(@Param("templateIds") List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/tag/repository/TemplateTagJpaRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TemplateTagJpaRepository.java
@@ -20,7 +20,7 @@ public interface TemplateTagJpaRepository extends TemplateTagRepository, JpaRepo
             JOIN TemplateTag tt ON t.id = tt.id.tagId
             WHERE tt.template = :template
             """)
-    List<Tag> findAllTagsByTemplate(Template template);
+    List<Tag> findAllTagsByTemplate(@Param("template") Template template);
 
     @Query("""
             SELECT tt, t
@@ -28,7 +28,7 @@ public interface TemplateTagJpaRepository extends TemplateTagRepository, JpaRepo
             JOIN FETCH tt.tag t
             WHERE tt.id.templateId = :templateId
             """)
-    List<TemplateTag> findAllByTemplateId(Long templateId);
+    List<TemplateTag> findAllByTemplateId(@Param("templateId") Long templateId);
 
     @Query("""
             SELECT tt, t
@@ -36,7 +36,7 @@ public interface TemplateTagJpaRepository extends TemplateTagRepository, JpaRepo
             JOIN FETCH tt.tag t
             WHERE tt.id.templateId in :templateIds
             """)
-    List<TemplateTag> findAllByTemplateIdsIn(List<Long> templateIds);
+    List<TemplateTag> findAllByTemplateIdsIn(@Param("templateIds") List<Long> templateIds);
 
     @Query("""
             SELECT DISTINCT t
@@ -49,7 +49,7 @@ public interface TemplateTagJpaRepository extends TemplateTagRepository, JpaRepo
                 )
             )
             """)
-    List<Tag> findAllTagDistinctByMemberId(Long memberId);
+    List<Tag> findAllTagDistinctByMemberId(@Param("memberId") Long memberId);
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM TemplateTag t WHERE t.template.id in :templateIds")

--- a/backend/src/main/java/codezap/tag/repository/TemplateTagRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TemplateTagRepository.java
@@ -24,5 +24,5 @@ public interface TemplateTagRepository {
 
     void deleteAllByTemplateId(Long templateId);
 
-    void deleteByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/tag/service/TagService.java
+++ b/backend/src/main/java/codezap/tag/service/TagService.java
@@ -72,6 +72,6 @@ public class TagService {
 
     @Transactional
     public void deleteAllByTemplateIds(List<Long> templateIds) {
-        templateTagRepository.deleteByTemplateIds(templateIds);
+        templateTagRepository.deleteAllByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/controller/TemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/TemplateController.java
@@ -109,7 +109,7 @@ public class TemplateController implements SpringDocTemplateController {
             @AuthenticationPrinciple Member member,
             @PathVariable List<Long> ids
     ) {
-        templateApplicationService.deleteByMemberAndIds(member, ids);
+        templateApplicationService.deleteAllByMemberAndTemplateIds(member, ids);
         return ResponseEntity.noContent().build();
     }
 }

--- a/backend/src/main/java/codezap/template/repository/SourceCodeJpaRepository.java
+++ b/backend/src/main/java/codezap/template/repository/SourceCodeJpaRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import codezap.global.exception.CodeZapException;
 import codezap.global.exception.ErrorCode;
@@ -37,5 +38,5 @@ public interface SourceCodeJpaRepository extends SourceCodeRepository, JpaReposi
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM SourceCode s WHERE s.template.id in :templateIds")
-    void deleteAllByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(@Param("templateIds") List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/template/repository/SourceCodeJpaRepository.java
+++ b/backend/src/main/java/codezap/template/repository/SourceCodeJpaRepository.java
@@ -37,5 +37,5 @@ public interface SourceCodeJpaRepository extends SourceCodeRepository, JpaReposi
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM SourceCode s WHERE s.template.id in :templateIds")
-    void deleteByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/template/repository/SourceCodeRepository.java
+++ b/backend/src/main/java/codezap/template/repository/SourceCodeRepository.java
@@ -26,5 +26,5 @@ public interface SourceCodeRepository {
 
     void deleteById(Long id);
 
-    void deleteByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(List<Long> templateIds);
 }

--- a/backend/src/main/java/codezap/template/repository/ThumbnailJpaRepository.java
+++ b/backend/src/main/java/codezap/template/repository/ThumbnailJpaRepository.java
@@ -33,7 +33,7 @@ public interface ThumbnailJpaRepository extends
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Thumbnail t WHERE t.template.id in :templateIds")
-    void deleteByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(List<Long> templateIds);
 
     @Query("""
             SELECT t, sc

--- a/backend/src/main/java/codezap/template/repository/ThumbnailJpaRepository.java
+++ b/backend/src/main/java/codezap/template/repository/ThumbnailJpaRepository.java
@@ -6,6 +6,7 @@ import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import codezap.global.exception.CodeZapException;
 import codezap.global.exception.ErrorCode;
@@ -28,12 +29,12 @@ public interface ThumbnailJpaRepository extends
             join fetch t.sourceCode sc
             WHERE t.template = :template
             """)
-    Optional<Thumbnail> findByTemplate(Template template);
+    Optional<Thumbnail> findByTemplate(@Param("template") Template template);
 
 
     @Modifying(clearAutomatically = true)
     @Query("DELETE FROM Thumbnail t WHERE t.template.id in :templateIds")
-    void deleteAllByTemplateIds(List<Long> templateIds);
+    void deleteAllByTemplateIds(@Param("templateIds") List<Long> templateIds);
 
     @Query("""
             SELECT t, sc
@@ -41,7 +42,7 @@ public interface ThumbnailJpaRepository extends
             join fetch t.sourceCode sc
             WHERE t.template.id IN :templateIds
             """)
-    List<Thumbnail> findAllByTemplateIn(List<Long> templateIds);
+    List<Thumbnail> findAllByTemplateIn(@Param("templateIds") List<Long> templateIds);
 
     void deleteByTemplateId(Long id);
 

--- a/backend/src/main/java/codezap/template/repository/ThumbnailRepository.java
+++ b/backend/src/main/java/codezap/template/repository/ThumbnailRepository.java
@@ -18,5 +18,5 @@ public interface ThumbnailRepository {
 
     Thumbnail save(Thumbnail thumbnail);
 
-    void deleteByTemplateIds(List<Long> ids);
+    void deleteAllByTemplateIds(List<Long> ids);
 }

--- a/backend/src/main/java/codezap/template/service/SourceCodeService.java
+++ b/backend/src/main/java/codezap/template/service/SourceCodeService.java
@@ -100,6 +100,6 @@ public class SourceCodeService {
 
     @Transactional
     public void deleteAllByTemplateIds(List<Long> templateIds) {
-        sourceCodeRepository.deleteByTemplateIds(templateIds);
+        sourceCodeRepository.deleteAllByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/service/SourceCodeService.java
+++ b/backend/src/main/java/codezap/template/service/SourceCodeService.java
@@ -99,7 +99,7 @@ public class SourceCodeService {
     }
 
     @Transactional
-    public void deleteByTemplateIds(List<Long> templateIds) {
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
         sourceCodeRepository.deleteByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/service/ThumbnailService.java
+++ b/backend/src/main/java/codezap/template/service/ThumbnailService.java
@@ -40,7 +40,7 @@ public class ThumbnailService {
     }
 
     @Transactional
-    public void deleteByTemplateIds(List<Long> templateIds) {
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
         thumbnailRepository.deleteByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/service/ThumbnailService.java
+++ b/backend/src/main/java/codezap/template/service/ThumbnailService.java
@@ -41,6 +41,6 @@ public class ThumbnailService {
 
     @Transactional
     public void deleteAllByTemplateIds(List<Long> templateIds) {
-        thumbnailRepository.deleteByTemplateIds(templateIds);
+        thumbnailRepository.deleteAllByTemplateIds(templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -146,7 +146,7 @@ public class TemplateApplicationService {
     @Transactional
     public void deleteAllByMemberAndTemplateIds(Member member, List<Long> templateIds) {
         thumbnailService.deleteAllByTemplateIds(templateIds);
-        sourceCodeService.deleteByTemplateIds(templateIds);
+        sourceCodeService.deleteAllByTemplateIds(templateIds);
         tagService.deleteAllByTemplateIds(templateIds);
         likesService.deleteAllByTemplateIds(templateIds);
         templateService.deleteByMemberAndIds(member, templateIds);

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -144,11 +144,11 @@ public class TemplateApplicationService {
     }
 
     @Transactional
-    public void deleteByMemberAndIds(Member member, List<Long> ids) {
-        thumbnailService.deleteByTemplateIds(ids);
-        sourceCodeService.deleteByTemplateIds(ids);
-        tagService.deleteAllByTemplateIds(ids);
-        likesService.deleteAllByTemplateIds(ids);
-        templateService.deleteByMemberAndIds(member, ids);
+    public void deleteAllByMemberAndTemplateIds(Member member, List<Long> templateIds) {
+        thumbnailService.deleteByTemplateIds(templateIds);
+        sourceCodeService.deleteByTemplateIds(templateIds);
+        tagService.deleteAllByTemplateIds(templateIds);
+        likesService.deleteAllByTemplateIds(templateIds);
+        templateService.deleteByMemberAndIds(member, templateIds);
     }
 }

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -145,7 +145,7 @@ public class TemplateApplicationService {
 
     @Transactional
     public void deleteAllByMemberAndTemplateIds(Member member, List<Long> templateIds) {
-        thumbnailService.deleteByTemplateIds(templateIds);
+        thumbnailService.deleteAllByTemplateIds(templateIds);
         sourceCodeService.deleteByTemplateIds(templateIds);
         tagService.deleteAllByTemplateIds(templateIds);
         likesService.deleteAllByTemplateIds(templateIds);

--- a/backend/src/test/java/codezap/likes/repository/FakeLikeRepository.java
+++ b/backend/src/test/java/codezap/likes/repository/FakeLikeRepository.java
@@ -28,6 +28,6 @@ public class FakeLikeRepository implements LikesRepository {
     }
 
     @Override
-    public void deleteByTemplateIds(List<Long> templateIds) {
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
     }
 }

--- a/backend/src/test/java/codezap/likes/repository/LikesJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/likes/repository/LikesJpaRepositoryTest.java
@@ -171,7 +171,7 @@ class LikesJpaRepositoryTest {
             likesRepository.save(new Likes(template1, member2));
             likesRepository.save(new Likes(template2, member1));
 
-            likesRepository.deleteByTemplateIds(List.of(template1.getId()));
+            likesRepository.deleteAllByTemplateIds(List.of(template1.getId()));
 
             assertAll(
                     () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),
@@ -191,7 +191,7 @@ class LikesJpaRepositoryTest {
             likesRepository.save(new Likes(template1, member2));
             likesRepository.save(new Likes(template2, member1));
 
-            likesRepository.deleteByTemplateIds(List.of(template1.getId(), template2.getId()));
+            likesRepository.deleteAllByTemplateIds(List.of(template1.getId(), template2.getId()));
 
             assertAll(
                     () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),

--- a/backend/src/test/java/codezap/template/repository/FakeSourceCodeRepository.java
+++ b/backend/src/test/java/codezap/template/repository/FakeSourceCodeRepository.java
@@ -97,7 +97,7 @@ public class FakeSourceCodeRepository implements SourceCodeRepository {
     }
 
     @Override
-    public void deleteByTemplateIds(List<Long> templateIds) {
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
         templateIds.forEach(id ->
                 sourceCodes.removeIf(sourceCode -> Objects.equals(sourceCode.getId(), id)));
     }

--- a/backend/src/test/java/codezap/template/repository/FakeTemplateTagRepository.java
+++ b/backend/src/test/java/codezap/template/repository/FakeTemplateTagRepository.java
@@ -61,7 +61,7 @@ public class FakeTemplateTagRepository implements TemplateTagRepository {
     }
 
     @Override
-    public void deleteByTemplateIds(List<Long> templateIds) {
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
         templateIds.forEach(id ->
                 templateTags.removeIf(templateTag -> Objects.equals(templateTag.getId(), id)));
     }

--- a/backend/src/test/java/codezap/template/repository/FakeThumbnailRepository.java
+++ b/backend/src/test/java/codezap/template/repository/FakeThumbnailRepository.java
@@ -58,7 +58,7 @@ public class FakeThumbnailRepository implements ThumbnailRepository {
     }
 
     @Override
-    public void deleteByTemplateIds(List<Long> templateIds) {
+    public void deleteAllByTemplateIds(List<Long> templateIds) {
         templateIds.forEach(id ->
                 thumbnails.removeIf(thumbnail -> Objects.equals(thumbnail.getId(), id)));
     }

--- a/backend/src/test/java/codezap/template/repository/SourceCodeRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/SourceCodeRepositoryTest.java
@@ -182,7 +182,7 @@ public class SourceCodeRepositoryTest {
             sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", 2));
             sut.save(new SourceCode(template2, "SourceCode 3", "Content 3", 1));
 
-            sut.deleteByTemplateIds(List.of(1L));
+            sut.deleteAllByTemplateIds(List.of(1L));
             var result = sut.findAllByTemplate(template1);
 
             assertThat(result).isEmpty();

--- a/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
@@ -125,7 +125,7 @@ public class ThumbnailRepositoryTest {
             sut.save(new Thumbnail(template, sourceCode));
 
             // when
-            sut.deleteByTemplateIds(List.of(template.getId()));
+            sut.deleteAllByTemplateIds(List.of(template.getId()));
 
             // then
             assertThatThrownBy(() -> sut.fetchByTemplate(template))
@@ -136,7 +136,7 @@ public class ThumbnailRepositoryTest {
         @Test
         @DisplayName("템플릿 id로 썸네일 삭제 성공: 존재하지 않는 템플릿의 id로 삭제해도 예외로 처리하지 않는다.")
         void deleteByNotExistTemplateId() {
-            assertThatCode(() -> sut.deleteByTemplateIds(List.of(100L)))
+            assertThatCode(() -> sut.deleteAllByTemplateIds(List.of(100L)))
                     .doesNotThrowAnyException();
         }
     }

--- a/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
@@ -429,7 +429,7 @@ class SourceCodeServiceTest extends ServiceTest {
             sourceCodeRepository.save(SourceCodeFixture.get(template, 2));
 
             // when
-            sourceCodeService.deleteByTemplateIds(List.of(template.getId()));
+            sourceCodeService.deleteAllByTemplateIds(List.of(template.getId()));
 
             // then
             assertThat(sourceCodeRepository.findAllByTemplate(template)).isEmpty();
@@ -447,7 +447,7 @@ class SourceCodeServiceTest extends ServiceTest {
             sourceCodeRepository.save(SourceCodeFixture.get(template2, 2));
 
             // when
-            sourceCodeService.deleteByTemplateIds(List.of(template1.getId(), template2.getId()));
+            sourceCodeService.deleteAllByTemplateIds(List.of(template1.getId(), template2.getId()));
 
             // then
             assertAll(
@@ -461,7 +461,7 @@ class SourceCodeServiceTest extends ServiceTest {
         void deleteByIds_WhenIdNotExist() {
             Template template = createSavedTemplate();
 
-            sourceCodeService.deleteByTemplateIds(List.of(template.getId()));
+            sourceCodeService.deleteAllByTemplateIds(List.of(template.getId()));
 
             assertThat(sourceCodeRepository.findAllByTemplate(template)).isEmpty();
         }

--- a/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
@@ -166,7 +166,7 @@ class ThumbnailServiceTest {
             var sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "Filename 2", "Content 2", 1));
             var savedThumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
-            sut.deleteByTemplateIds(List.of(template1.getId()));
+            sut.deleteAllByTemplateIds(List.of(template1.getId()));
             var actual = thumbnailRepository.findAll();
 
             assertThat(actual).hasSize(1)
@@ -186,7 +186,7 @@ class ThumbnailServiceTest {
             var sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "Filename 2", "Content 2", 1));
             var savedThumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
-            sut.deleteByTemplateIds(List.of(template1.getId(), template2.getId()));
+            sut.deleteAllByTemplateIds(List.of(template1.getId(), template2.getId()));
             var actual = thumbnailRepository.findAll();
 
             assertThat(actual).doesNotContain(savedThumbnail1, savedThumbnail2);
@@ -202,7 +202,7 @@ class ThumbnailServiceTest {
             var savedThumbnail = thumbnailRepository.save(new Thumbnail(template, sourceCode));
             var nonExistentID = 100L;
 
-            sut.deleteByTemplateIds(List.of(nonExistentID));
+            sut.deleteAllByTemplateIds(List.of(nonExistentID));
             var actual = thumbnailRepository.findAll();
 
             assertThat(actual).hasSize(1)

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -426,7 +426,7 @@ class TemplateApplicationServiceTest {
             var deleteIds = List.of(template1.getId(), template2.getId());
 
             // when
-            sut.deleteByMemberAndIds(member, deleteIds);
+            sut.deleteAllByMemberAndTemplateIds(member, deleteIds);
 
             // then
             Specification<Template> spec = new TemplateSpecification(member.getId(), null, null, null);


### PR DESCRIPTION
## ⚡️ 관련 이슈
#645

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

> [관련 PR 코멘트](https://github.com/woowacourse-teams/2024-code-zap/pull/737#discussion_r1788539392)

- 메서드명 수정
   - `deleteByMemberAndIds(Member member, List ids)` -> `deleteAllByMemberAndTemplateIds(Member member, List templateIds)`
   - 서비스 단에 모든 `deleteByTemplateIds(List templateIds)` -> `deleteAllByTemplateIds(List templateIds)`
   - 레포지토리 단에 모든 `deleteByTemplateIds(List ids)` -> `deleteAllByTemplateIds(List templateIds)`

- `@param` 추가
  - 코드 일관성을 위해 모든 JPQL에 `@param`을 추가했습니다 !

 
## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.

가끔 설정이 안되있는 경우 자동으로 param 설정이 안될 때가 있음을 방지하기 위해, 앞으로 JPQL 사용 시  `@param`을 필수로 하면 좋을 것 같아요. 

## 🍗 PR 첫 리뷰 마감 기한
10/17 10:00 (오전)
