### PR TITLE
로그백 설정 오류로 서버가 실행되지 않는 버그 픽스 (re)

### DIFF
--- a/backend/src/main/resources/logger/file/error-appender.xml
+++ b/backend/src/main/resources/logger/file/error-appender.xml
@@ -3,7 +3,7 @@
 <included>
     <appender name="error-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/error.log</file>
+        <file>${LOG_FILE_PATH}/error.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>ERROR</level>

--- a/backend/src/main/resources/logger/file/info-appender.xml
+++ b/backend/src/main/resources/logger/file/info-appender.xml
@@ -3,7 +3,7 @@
 <included>
     <appender name="info-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/info.log</file>
+        <file>${LOG_FILE_PATH}/info.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>INFO</level>

--- a/backend/src/main/resources/logger/file/warn-appender.xml
+++ b/backend/src/main/resources/logger/file/warn-appender.xml
@@ -3,7 +3,7 @@
 <included>
     <appender name="warn-appender" class="ch.qos.logback.core.rolling.RollingFileAppender">
 
-        <file>${LOG_FILE_PATH}/${DATE_FORMAT}/warn.log</file>
+        <file>${LOG_FILE_PATH}/warn.log</file>
 
         <filter class="ch.qos.logback.classic.filter.LevelFilter">
             <level>WARN</level>


### PR DESCRIPTION
## ⚡️ 관련 이슈
#790 
#791 

## 📍주요 변경 사항
로그백 설정이 변경됩니다. 

### AS-IS
```xml
<file>${LOG_FILE_PATH}/${DATE_FORMAT}/error.log</file>
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/error.log</fileNamePattern>
```

### TO-BE
```xml
<file>${LOG_FILE_PATH}/error.log</file>
<fileNamePattern>${LOG_FILE_PATH}/%d{yyyy-MM-dd}/error.log</fileNamePattern>
```

TimeBasedRollingPolicy에서는 파일별 용량을 고려해 rolling할 수 없기 때문에, 현재 실행중인 서버의 로그와 롤링된 파일의 이름이 동일합니다. 

로그 경로와 이름이 동일하기 때문에 설정이 충돌되어 실행되지 않아요 😭

그래서 경로를 다르게 변경했습니다 😭

개발서버에서 실행 되는 거 확인했어요!!

## 🍗 PR 첫 리뷰 마감 기한
ASAP
