### PR TITLE
ZAP PR 생성 시 리뷰 메시지 변경

### DIFF
--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -18,7 +18,9 @@ jobs:
         PR_TITLE="${{ github.event.pull_request.title }}"
         PR_URL="${{ github.event.pull_request.html_url }}"
         REVIEWERS='${{ toJson(github.event.pull_request.requested_reviewers.*.login) }}'
+        LABELS='${{ toJson(github.event.pull_request.labels.*.name) }}'
         echo "REVIEWERS: $REVIEWERS"
+        echo "LABELS: $LABELS"
         
         parse_slack_ids() {
             echo "$SLACK_IDS" | jq -r 'to_entries | map("\(.key):\(.value)") | .[]'
@@ -41,6 +43,11 @@ jobs:
         
         if [ ! -z "$mentions" ]; then
           message="$mentions 님, 새로운 PR이 생성되었습니다: <$PR_URL|$PR_TITLE>"
+          
+          if echo "$LABELS" | jq -e 'contains(["zap"])' > /dev/null; then
+            message=":rotating_light: 긴급 PR입니다. 빠른 리뷰 부탁드립니다!:rotating_light:\n$message"
+          fi
+          
           curl -X POST -H 'Content-type: application/json' \
             --data "{\"text\":\"$message\"}" \
             "$SLACK_WEBHOOK_URL"
@@ -48,4 +55,3 @@ jobs:
         else
           echo "No reviewers to notify"
         fi
-


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #802 

## 📍주요 변경 사항
> github action에서 PR 생성 시 리뷰하라고 슬랙 알람을 보내고 있습니다~
zap이 달린 경우 슬랙 메시지를 조금 수정했어요 참고바람


## 🍗 PR 첫 리뷰 마감 기한
10/18 18:00
