### PR TITLE
모든 ServiceTest가 Base 클래스를 상속받도록 통일

### DIFF
--- a/backend/src/test/java/codezap/auth/service/AuthServiceTest.java
+++ b/backend/src/test/java/codezap/auth/service/AuthServiceTest.java
@@ -11,25 +11,18 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.HttpHeaders;
 
 import codezap.auth.dto.LoginAndCredentialDto;
 import codezap.auth.dto.request.LoginRequest;
 import codezap.auth.dto.response.LoginResponse;
 import codezap.auth.provider.CredentialProvider;
-import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.fixture.MemberFixture;
-import codezap.member.repository.MemberRepository;
 
-@SpringBootTest
-@DatabaseIsolation
-public class AuthServiceTest {
-
-    @Autowired
-    private MemberRepository memberRepository;
+public class AuthServiceTest extends ServiceTest {
 
     @Autowired
     private CredentialProvider credentialProvider;

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -5,14 +5,11 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import jakarta.transaction.Transactional;
-
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import codezap.category.domain.Category;
 import codezap.category.dto.request.CreateCategoryRequest;
@@ -20,31 +17,16 @@ import codezap.category.dto.request.UpdateCategoryRequest;
 import codezap.category.dto.response.CreateCategoryResponse;
 import codezap.category.dto.response.FindAllCategoriesResponse;
 import codezap.category.dto.response.FindCategoryResponse;
-import codezap.category.repository.CategoryRepository;
-import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.fixture.MemberFixture;
-import codezap.member.repository.MemberRepository;
 import codezap.template.domain.Template;
-import codezap.template.repository.TemplateRepository;
 
-@SpringBootTest
-@DatabaseIsolation
-@Transactional
-class CategoryServiceTest {
+class CategoryServiceTest extends ServiceTest {
 
     @Autowired
     private CategoryService sut;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private TemplateRepository templateRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
 
     @Nested
     @DisplayName("카테고리 생성 테스트")

--- a/backend/src/test/java/codezap/global/ServiceTest.java
+++ b/backend/src/test/java/codezap/global/ServiceTest.java
@@ -2,6 +2,7 @@ package codezap.global;
 
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
 
 import codezap.category.repository.CategoryRepository;
 import codezap.likes.repository.LikesRepository;
@@ -14,6 +15,7 @@ import codezap.template.repository.ThumbnailRepository;
 
 @SpringBootTest
 @DatabaseIsolation
+@Transactional
 public class ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
+++ b/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
@@ -10,19 +10,15 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
-import codezap.global.DatabaseIsolation;
 import codezap.global.ServiceTest;
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
 
-@SpringBootTest
-@DatabaseIsolation
 class LikesServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -9,34 +9,19 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.TemplateFixture;
-import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.dto.request.SignupRequest;
 import codezap.member.dto.response.FindMemberResponse;
 import codezap.member.fixture.MemberFixture;
-import codezap.member.repository.MemberRepository;
 import codezap.template.domain.Template;
-import codezap.template.repository.TemplateRepository;
 
-@SpringBootTest
-@DatabaseIsolation
-class MemberServiceTest {
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private TemplateRepository templateRepository;
+class MemberServiceTest extends ServiceTest {
 
     @Autowired
     private MemberService memberService;

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.transaction.annotation.Transactional;
 
 import codezap.category.domain.Category;
 import codezap.fixture.CategoryFixture;
@@ -28,8 +27,6 @@ import codezap.tag.dto.response.FindTagResponse;
 import codezap.template.domain.Template;
 import codezap.template.domain.TemplateTag;
 
-
-@Transactional
 class TagServiceTest extends ServiceTest {
 
     @Autowired

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -22,6 +22,7 @@ import codezap.category.repository.CategoryRepository;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -22,7 +22,6 @@ import codezap.category.repository.CategoryRepository;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.DatabaseIsolation;
-import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -10,48 +10,26 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
-import org.springframework.transaction.annotation.Transactional;
 
 import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
-import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.likes.domain.Likes;
-import codezap.likes.repository.LikesRepository;
 import codezap.member.domain.Member;
-import codezap.member.repository.MemberRepository;
 import codezap.template.domain.Template;
 import codezap.template.domain.Visibility;
 import codezap.template.dto.request.CreateSourceCodeRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
-import codezap.template.repository.TemplateRepository;
 
-@SpringBootTest
-@DatabaseIsolation
-@Transactional
-class TemplateServiceTest {
-
-    @Autowired
-    private TemplateRepository templateRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-
-    @Autowired
-    private LikesRepository likesRepository;
+class TemplateServiceTest extends ServiceTest {
 
     @Autowired
     private TemplateService sut;

--- a/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
@@ -10,43 +10,20 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 
 import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.SourceCodeFixture;
 import codezap.fixture.TemplateFixture;
-import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
-import codezap.member.repository.MemberRepository;
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
-import codezap.template.repository.SourceCodeRepository;
-import codezap.template.repository.TemplateRepository;
-import codezap.template.repository.ThumbnailRepository;
 
-@SpringBootTest
-@DatabaseIsolation
-class ThumbnailServiceTest {
-
-    @Autowired
-    private MemberRepository memberRepository;
-
-    @Autowired
-    private CategoryRepository categoryRepository;
-
-    @Autowired
-    private TemplateRepository templateRepository;
-
-    @Autowired
-    private SourceCodeRepository sourceCodeRepository;
-
-    @Autowired
-    private ThumbnailRepository thumbnailRepository;
+class ThumbnailServiceTest extends ServiceTest {
 
     @Autowired
     private ThumbnailService sut;

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -10,8 +10,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.stream.Stream;
 
-import jakarta.transaction.Transactional;
-
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,21 +17,17 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.domain.Specification;
 
 import codezap.category.domain.Category;
-import codezap.category.repository.CategoryRepository;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
-import codezap.global.DatabaseIsolation;
+import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
 import codezap.likes.domain.Likes;
-import codezap.likes.repository.LikesRepository;
 import codezap.member.domain.Member;
-import codezap.member.repository.MemberRepository;
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
@@ -43,30 +37,12 @@ import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateSourceCodeRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 import codezap.template.dto.response.FindAllTemplateItemResponse;
-import codezap.template.repository.SourceCodeRepository;
-import codezap.template.repository.TemplateRepository;
 import codezap.template.repository.TemplateSpecification;
-import codezap.template.repository.ThumbnailRepository;
 
-@SpringBootTest
-@DatabaseIsolation
-@Transactional
-class TemplateApplicationServiceTest {
+class TemplateApplicationServiceTest extends ServiceTest {
 
     @Autowired
     TemplateApplicationService sut;
-    @Autowired
-    MemberRepository memberRepository;
-    @Autowired
-    TemplateRepository templateRepository;
-    @Autowired
-    SourceCodeRepository sourceCodeRepository;
-    @Autowired
-    CategoryRepository categoryRepository;
-    @Autowired
-    ThumbnailRepository thumbnailRepository;
-    @Autowired
-    LikesRepository likesRepository;
 
     @Nested
     @DisplayName("템플릿 생성")


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #650

## 📍주요 변경 사항
> 저번 ServiceTest 작성 시 나눠서 작업하느라 ServiceTest를 상속받은 것도 있고 아닌 것도 있어서 관리하기 편하도록 통일 시켰습니다~!

## 🍗 PR 첫 리뷰 마감 기한
10/18 18:00
