### PR TITLE
태그 검색 조건 or로 변경

### DIFF
--- a/backend/src/main/java/codezap/template/repository/TemplateSpecification.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateSpecification.java
@@ -103,10 +103,8 @@ public class TemplateSpecification implements Specification<Template> {
         }
         Subquery<Long> subquery = query.subquery(Long.class);
         Root<TemplateTag> subRoot = subquery.from(TemplateTag.class);
-        subquery.select(subRoot.get("template").get("id")).where(subRoot.get("tag").get("id").in(tagIds))
-                .groupBy(subRoot.get("template").get("id"))
-                .having(criteriaBuilder.equal(criteriaBuilder.countDistinct(subRoot.get("tag").get("id")),
-                        tagIds.size()));
+        subquery.select(subRoot.get("template").get("id"))
+                .where(subRoot.get("tag").get("id").in(tagIds));
 
         predicates.add(root.get("id").in(subquery));
     }

--- a/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
@@ -90,7 +90,7 @@ class TemplateSearchJpaRepositoryTest {
     }
 
     @Test
-    @DisplayName("검색 테스트: 태그 ID 목록으로 템플릿 조회, 모든 태그를 가진 템플릿만 조회 성공")
+    @DisplayName("검색 테스트: 태그 ID 목록으로 템플릿 조회, 태그 중 하나라도 가진 템플릿 전체 조회 성공")
     void testFindByTagIds() {
         Tag tag1 = tagRepository.fetchById(1L);
         Tag tag2 = tagRepository.fetchById(2L);
@@ -102,8 +102,9 @@ class TemplateSearchJpaRepositoryTest {
                 () -> assertThat(result.getContent())
                         .containsExactlyInAnyOrder(
                                 templateRepository.fetchById(1L),
-                                templateRepository.fetchById(2L)),
-                () -> assertThat(result.getContent()).hasSize(2)
+                                templateRepository.fetchById(2L),
+                                templateRepository.fetchById(3L)),
+                () -> assertThat(result.getContent()).hasSize(3)
         );
     }
 

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -177,8 +177,9 @@ class TemplateSearchServiceTest {
                     () -> assertThat(actual.getContent())
                             .containsExactlyInAnyOrder(
                                     templateRepository.fetchById(1L),
-                                    templateRepository.fetchById(2L)),
-                    () -> assertThat(actual.getContent()).hasSize(2)
+                                    templateRepository.fetchById(2L),
+                                    templateRepository.fetchById(3L)),
+                    () -> assertThat(actual.getContent()).hasSize(3)
             );
         }
 
@@ -188,7 +189,7 @@ class TemplateSearchServiceTest {
             Long memberId = null;
             String keyword = null;
             Long categoryId = null;
-            List<Long> tagIds = List.of(tag2.getId());
+            List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #829

## 📍주요 변경 사항
> 태그 검색 조건을 and에서 or로 변경하였습니다.


## 🍗 PR 첫 리뷰 마감 기한
10/21 23:59
