### PR TITLE
새 템플릿 업로드 시, 템플릿 순서 정렬

### DIFF
--- a/frontend/src/pages/TemplateUploadPage/TemplateUploadPage.tsx
+++ b/frontend/src/pages/TemplateUploadPage/TemplateUploadPage.tsx
@@ -11,7 +11,7 @@ import { DEFAULT_TEMPLATE_VISIBILITY, TEMPLATE_VISIBILITY } from '@/service/cons
 import { ICON_SIZE } from '@/style/styleConstants';
 import { theme } from '@/style/theme';
 import { TemplateUploadRequest } from '@/types';
-import { TemplateVisibility } from '@/types/template';
+import { SourceCodes, TemplateVisibility } from '@/types/template';
 import { getLanguageForAutoTag } from '@/utils';
 
 import * as S from './TemplateUploadPage.style';
@@ -77,10 +77,17 @@ const TemplateUploadPage = () => {
       return;
     }
 
+    const orderedSourceCodes = sourceCodes.map(
+      (sourceCode, index): SourceCodes => ({
+        ...sourceCode,
+        ordinal: index + 1,
+      }),
+    );
+
     const newTemplate: TemplateUploadRequest = {
       title,
       description,
-      sourceCodes,
+      sourceCodes: orderedSourceCodes,
       thumbnailOrdinal: 1,
       categoryId: categoryProps.currentValue.id,
       tags: tagProps.tags,


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #843 

## 📍주요 변경 사항
> 기존 템플릿 수정 페이지에만 적용되어있던 템플릿 순서 정렬 로직을 업로드 페이지에서도 적용


## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.


## 🍗 PR 첫 리뷰 마감 기한
ASAP - 버그 픽스라 빠르게 부탁드립니다.
