### PR TITLE
Amplitude 초기 설정 및 핵심 기능(업로드) 트래킹

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "code-zap",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "code-zap",
-      "version": "1.1.3",
+      "version": "1.1.4",
       "license": "ISC",
       "dependencies": {
+        "@amplitude/analytics-browser": "^2.11.7",
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
         "@sentry/react": "^8.22.0",
@@ -82,6 +83,82 @@
       "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.0.tgz",
       "integrity": "sha512-Ff9+ksdQQB3rMncgqDK78uLznstjyfIf2Arnh22pW8kBpLs6rpKDwgnZT46hin5Hl1WzazzK64DOrhSwYpS7bQ==",
       "dev": true
+    },
+    "node_modules/@amplitude/analytics-browser": {
+      "version": "2.11.7",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-browser/-/analytics-browser-2.11.7.tgz",
+      "integrity": "sha512-tbBeMA2n1JQJlHGEa1LQ7XrSGPM4YKrNdFKV+gDCzqOixx4wBwwYCxN33lVwCpJvCPAjtYonkAO2dq9d78U7Pw==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.3.3",
+        "@amplitude/analytics-core": "^2.5.2",
+        "@amplitude/analytics-remote-config": "^0.4.0",
+        "@amplitude/analytics-types": "^2.8.2",
+        "@amplitude/plugin-autocapture-browser": "^1.0.2",
+        "@amplitude/plugin-page-view-tracking-browser": "^2.3.3",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-client-common": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-client-common/-/analytics-client-common-2.3.3.tgz",
+      "integrity": "sha512-HOvD2A8DH0y2LATrQ0AhFSOCk6yZayebu4+UsEBT76Q7EEYtnc59WMCRRIi5Zv6OqHpOvABumF7g3HmL6ehTYA==",
+      "dependencies": {
+        "@amplitude/analytics-connector": "^1.4.8",
+        "@amplitude/analytics-core": "^2.5.2",
+        "@amplitude/analytics-types": "^2.8.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-connector": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-connector/-/analytics-connector-1.5.0.tgz",
+      "integrity": "sha512-T8mOYzB9RRxckzhL0NTHwdge9xuFxXEOplC8B1Y3UX3NHa3BLh7DlBUZlCOwQgMc2nxDfnSweDL5S3bhC+W90g=="
+    },
+    "node_modules/@amplitude/analytics-core": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-core/-/analytics-core-2.5.2.tgz",
+      "integrity": "sha512-4ojYUL7LA+qrlaz1n1nxpsbpgS1k6DOrQ3fBiQOuDJE8Av0aZfylDksFPnZvD1+MMdIm/ONkVAYfEaW3x/uH3Q==",
+      "dependencies": {
+        "@amplitude/analytics-types": "^2.8.2",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-remote-config": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-remote-config/-/analytics-remote-config-0.4.1.tgz",
+      "integrity": "sha512-BYl6kQ9qjztrCACsugpxO+foLaQIC0aSEzoXEAb/gwOzInmqkyyI+Ub+aWTBih4xgB/lhWlOcidWHAmNiTJTNw==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": ">=1 <3",
+        "@amplitude/analytics-core": ">=1 <3",
+        "@amplitude/analytics-types": ">=1 <3",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/analytics-types": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/@amplitude/analytics-types/-/analytics-types-2.8.2.tgz",
+      "integrity": "sha512-SWFXIMxhFm1/k3PUvxvYLY1iwzS28yd9A6pa5pEnrbaAZwM+E/24ucxs59VGp1N5qlIsvF0aVGSoKzN4ydh4eA=="
+    },
+    "node_modules/@amplitude/plugin-autocapture-browser": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-autocapture-browser/-/plugin-autocapture-browser-1.0.3.tgz",
+      "integrity": "sha512-XUQWUAw9VqtJPlmOyWjnhsEspyVakd9LuSjVNtLjhwlWv+f/yZM1AAQVUdq/Os1+b5OptSgJQ2pPfRJJHZDXTw==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": ">=1 <3",
+        "@amplitude/analytics-types": "^2.8.2",
+        "rxjs": "^7.8.1",
+        "tslib": "^2.4.1"
+      }
+    },
+    "node_modules/@amplitude/plugin-page-view-tracking-browser": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/@amplitude/plugin-page-view-tracking-browser/-/plugin-page-view-tracking-browser-2.3.3.tgz",
+      "integrity": "sha512-tGDt7aU/okGHH38sxZvBckRXBw2btkw+wJz/PmIFIQdD7/7EMVnTtXgZJTokE+fqfxCx79F2ojEHp37xgVSxpg==",
+      "dependencies": {
+        "@amplitude/analytics-client-common": "^2.3.3",
+        "@amplitude/analytics-types": "^2.8.2",
+        "tslib": "^2.4.1"
+      }
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.3.0",
@@ -18247,6 +18324,14 @@
         "queue-microtask": "^1.2.2"
       }
     },
+    "node_modules/rxjs": {
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
+      "dependencies": {
+        "tslib": "^2.1.0"
+      }
+    },
     "node_modules/safe-array-concat": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/safe-array-concat/-/safe-array-concat-1.1.2.tgz",
@@ -20431,8 +20516,7 @@
     "node_modules/tslib": {
       "version": "2.6.3",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.3.tgz",
-      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ==",
-      "dev": true
+      "integrity": "sha512-xNvxJEOUiWPGhUuUdQgAJPKOOJfGnIyKySOc09XkKsgdUV/3E2zvwZYdejjmRgPCgcym1juLH3226yA7sEFJKQ=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,6 +22,7 @@
   ],
   "license": "ISC",
   "dependencies": {
+    "@amplitude/analytics-browser": "^2.11.7",
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
     "@sentry/react": "^8.22.0",

--- a/frontend/src/components/Header/Header.tsx
+++ b/frontend/src/components/Header/Header.tsx
@@ -10,6 +10,7 @@ import { usePressESC } from '@/hooks/usePressESC';
 import { useScrollDisable } from '@/hooks/useScrollDisable';
 import { useLogoutMutation } from '@/queries/authentication/useLogoutMutation';
 import { END_POINTS } from '@/routes';
+import { trackClickNewTemplate } from '@/service/amplitude';
 
 import { theme } from '../../style/theme';
 import * as S from './Header.style';
@@ -39,6 +40,8 @@ const Header = ({ headerRef }: { headerRef: React.RefObject<HTMLDivElement> }) =
   }
 
   const handleTemplateUploadButton = () => {
+    trackClickNewTemplate();
+
     if (!isLogin) {
       failAlert('로그인을 해주세요.');
 

--- a/frontend/src/components/PagingButtons/PagingButtons.tsx
+++ b/frontend/src/components/PagingButtons/PagingButtons.tsx
@@ -1,4 +1,5 @@
 import { Text } from '@/components';
+import { trackMyTemplatePaging } from '@/service/amplitude/track';
 import { theme } from '@/style/theme';
 
 import * as S from './PagingButtons.style';
@@ -17,23 +18,33 @@ const PagingButtons = ({ currentPage, totalPages, onPageChange }: Props) => {
     return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
   };
 
+  const handlePagingClick = (page: number, label: string) => {
+    trackMyTemplatePaging({ page, totalPages, label });
+    onPageChange(page);
+  };
+
   return (
     <S.PagingContainer>
-      <PagingButton page={1} disabled={currentPage === 1} onClick={onPageChange} label='<<' />
-      <PagingButton page={currentPage - 1} disabled={currentPage === 1} onClick={onPageChange} label='<' />
+      <PagingButton page={1} disabled={currentPage === 1} onClick={handlePagingClick} label='<<' />
+      <PagingButton page={currentPage - 1} disabled={currentPage === 1} onClick={handlePagingClick} label='<' />
 
       {getPageNumbers().map((page) => (
         <PagingButton
           key={page}
           page={page}
           isActive={page === currentPage}
-          onClick={onPageChange}
+          onClick={handlePagingClick}
           label={String(page)}
         />
       ))}
 
-      <PagingButton page={currentPage + 1} disabled={currentPage === totalPages} onClick={onPageChange} label='>' />
-      <PagingButton page={totalPages} disabled={currentPage === totalPages} onClick={onPageChange} label='>>' />
+      <PagingButton
+        page={currentPage + 1}
+        disabled={currentPage === totalPages}
+        onClick={handlePagingClick}
+        label='>'
+      />
+      <PagingButton page={totalPages} disabled={currentPage === totalPages} onClick={handlePagingClick} label='>>' />
     </S.PagingContainer>
   );
 };
@@ -42,12 +53,12 @@ interface PagingButtonProps {
   page?: number;
   isActive?: boolean;
   disabled?: boolean;
-  onClick: (page: number) => void;
+  onClick: (page: number, label: string) => void;
   label: string;
 }
 
 const PagingButton = ({ page, isActive, disabled, onClick, label }: PagingButtonProps) => (
-  <S.PagingButton isActive={isActive} disabled={disabled || isActive} onClick={() => onClick(page ?? 1)}>
+  <S.PagingButton isActive={isActive} disabled={disabled || isActive} onClick={() => onClick(page ?? 1, label)}>
     <Text.Small color={isActive ? theme.color.light.white : theme.color.light.secondary_500}>{label}</Text.Small>
   </S.PagingButton>
 );

--- a/frontend/src/components/SourceCodeViewer/SourceCodeViewer.tsx
+++ b/frontend/src/components/SourceCodeViewer/SourceCodeViewer.tsx
@@ -2,6 +2,7 @@ import { ChevronIcon } from '@/assets/images';
 import { SourceCode, Text } from '@/components';
 import { useToggle } from '@/hooks';
 import { useToast } from '@/hooks/useToast';
+import { trackClickCopyClipBoard } from '@/service/amplitude/track';
 import { theme } from '@/style/theme';
 import { getLanguageByFilename } from '@/utils';
 
@@ -23,6 +24,7 @@ const SourceCodeViewer = ({ mode = 'detailView', filename = '', content, sourceC
   const copyCode = (content: string) => () => {
     navigator.clipboard.writeText(content);
     infoAlert('코드가 복사되었습니다!');
+    trackClickCopyClipBoard();
   };
 
   return (

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -9,6 +9,7 @@ import { AuthProvider, HeaderProvider, ToastProvider } from '@/contexts';
 
 import { ScreenReaderOnly } from './components/index';
 import router from './routes/router';
+import { AmplitudeInitializer } from './service/amplitude';
 import GlobalStyles from './style/GlobalStyles';
 import { theme } from './style/theme';
 
@@ -46,13 +47,15 @@ enableMocking().then(() => {
       <QueryClientProvider client={queryClient}>
         <ThemeProvider theme={theme}>
           <AuthProvider>
-            <ToastProvider>
-              <HeaderProvider>
-                <GlobalStyles />
-                <RouterProvider router={router} />
-                <ScreenReaderOnly />
-              </HeaderProvider>
-            </ToastProvider>
+            <AmplitudeInitializer>
+              <ToastProvider>
+                <HeaderProvider>
+                  <GlobalStyles />
+                  <RouterProvider router={router} />
+                  <ScreenReaderOnly />
+                </HeaderProvider>
+              </ToastProvider>
+            </AmplitudeInitializer>
           </AuthProvider>
         </ThemeProvider>
       </QueryClientProvider>

--- a/frontend/src/pages/LandingPage/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage/LandingPage.tsx
@@ -8,6 +8,7 @@ import { Button, Flex, Heading, Text } from '@/components';
 import { ToastContext } from '@/contexts';
 import { useCustomContext } from '@/hooks';
 import { useAuth } from '@/hooks/authentication';
+import { useTrackPageViewed } from '@/service/amplitude';
 import { ICON_SIZE } from '@/style/styleConstants';
 import { theme } from '@/style/theme';
 import { SourceCodes } from '@/types';
@@ -16,6 +17,8 @@ import { getLanguageByFilename } from '@/utils';
 import * as S from './LandingPage.style';
 
 const LandingPage = () => {
+  useTrackPageViewed({ eventName: '[Viewed] 랜딩 페이지' });
+
   const { isLogin } = useAuth();
 
   return (

--- a/frontend/src/pages/LoginPage/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage/LoginPage.tsx
@@ -4,11 +4,14 @@ import { EyeIcon, ZapzapLogo } from '@/assets/images';
 import { Button, Flex, Input, Text } from '@/components';
 import { useToggle } from '@/hooks';
 import { END_POINTS } from '@/routes';
+import { useTrackPageViewed } from '@/service/amplitude';
 
 import { useLoginForm } from './hooks';
 import * as S from './LoginPage.style';
 
 const LoginPage = () => {
+  useTrackPageViewed({ eventName: '[Viewed] 로그인 페이지' });
+
   const [showPassword, handlePasswordToggle] = useToggle();
   const { name, password, errors, handleNameChange, handlePasswordChange, isFormValid, handleSubmit } = useLoginForm();
 

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -4,6 +4,7 @@ import { SORTING_OPTIONS } from '@/api';
 import { SearchIcon } from '@/assets/images';
 import { Flex, Input, PagingButtons, Dropdown, ScrollTopButton } from '@/components';
 import { useAuth } from '@/hooks/authentication';
+import { useTrackPageViewed } from '@/service/amplitude';
 
 import {
   TopBanner,
@@ -19,6 +20,8 @@ import { useSelectAndDeleteTemplateList, useFilteredTemplateList } from './hooks
 import * as S from './MyTemplatePage.style';
 
 const MyTemplatePage = () => {
+  useTrackPageViewed({ eventName: '[Viewed] 내 템플릿 페이지' });
+
   const {
     memberInfo: { name },
   } = useAuth();

--- a/frontend/src/pages/SignupPage/SignupPage.tsx
+++ b/frontend/src/pages/SignupPage/SignupPage.tsx
@@ -3,11 +3,14 @@ import { Link } from 'react-router-dom';
 import { EyeIcon, ZapzapLogo } from '@/assets/images';
 import { Button, Flex, Input, Text } from '@/components';
 import { useToggle } from '@/hooks';
+import { useTrackPageViewed } from '@/service/amplitude';
 
 import { useSignupForm } from './hooks';
 import * as S from './SignupPage.style';
 
 const SignupPage = () => {
+  useTrackPageViewed({ eventName: '[Viewed] 회원가입 페이지' });
+
   const [showPassword, handlePasswordToggle] = useToggle();
   const [showPasswordConfirm, handlePasswordConfirmToggle] = useToggle();
 

--- a/frontend/src/pages/TemplateEditPage/TemplateEditPage.tsx
+++ b/frontend/src/pages/TemplateEditPage/TemplateEditPage.tsx
@@ -7,6 +7,7 @@ import { useCategory } from '@/hooks/category';
 import { useTag, useSourceCode } from '@/hooks/template';
 import { useToast } from '@/hooks/useToast';
 import { useTemplateEditMutation } from '@/queries/templates';
+import { useTrackPageViewed } from '@/service/amplitude';
 import { DEFAULT_TEMPLATE_VISIBILITY, TEMPLATE_VISIBILITY } from '@/service/constants';
 import { ICON_SIZE } from '@/style/styleConstants';
 import { theme } from '@/style/theme';
@@ -22,6 +23,8 @@ interface Props {
 }
 
 const TemplateEditPage = ({ template, toggleEditButton }: Props) => {
+  useTrackPageViewed({ eventName: '[Viewed] 템플릿 편집 페이지' });
+
   const categoryProps = useCategory(template.category);
 
   const [title, handleTitleChange] = useInput(template.title);
@@ -79,6 +82,7 @@ const TemplateEditPage = ({ template, toggleEditButton }: Props) => {
       ...sourceCode,
       ordinal: index + 1,
     }));
+
     const createSourceCodes = orderedSourceCodes.filter((sourceCode) => !sourceCode.id);
     const updateSourceCodes = orderedSourceCodes.filter((sourceCode) => sourceCode.id);
 

--- a/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
+++ b/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
@@ -18,6 +18,7 @@ import {
 } from '@/components';
 import { useDebounce, useDropdown, useInput, useWindowWidth } from '@/hooks';
 import { useTemplateExploreQuery } from '@/queries/templates';
+import { useTrackPageViewed } from '@/service/amplitude';
 import { SortingOption } from '@/types';
 import { scroll } from '@/utils';
 
@@ -26,6 +27,8 @@ import * as S from './TemplateExplorePage.style';
 const getGridCols = (windowWidth: number) => (windowWidth <= 1024 ? 1 : 2);
 
 const TemplateExplorePage = () => {
+  useTrackPageViewed({ eventName: '[Viewed] 구경가기 페이지' });
+
   const [page, setPage] = useState<number>(1);
   const [keyword, handleKeywordChange] = useInput('');
 

--- a/frontend/src/pages/TemplatePage/TemplatePage.tsx
+++ b/frontend/src/pages/TemplatePage/TemplatePage.tsx
@@ -18,6 +18,7 @@ import {
 import { useToggle } from '@/hooks';
 import { useAuth } from '@/hooks/authentication';
 import { TemplateEditPage } from '@/pages';
+import { trackLikeButton } from '@/service/amplitude/track';
 import { VISIBILITY_PRIVATE } from '@/service/constants';
 import { ICON_SIZE } from '@/style/styleConstants';
 import { formatRelativeTime } from '@/utils';
@@ -64,6 +65,7 @@ const TemplatePage = () => {
     }
 
     toggleLike();
+    trackLikeButton({ isLiked, likesCount, templateId: id as string });
   };
 
   if (!template) {

--- a/frontend/src/pages/TemplatePage/TemplatePage.tsx
+++ b/frontend/src/pages/TemplatePage/TemplatePage.tsx
@@ -18,6 +18,7 @@ import {
 import { useToggle } from '@/hooks';
 import { useAuth } from '@/hooks/authentication';
 import { TemplateEditPage } from '@/pages';
+import { useTrackPageViewed } from '@/service/amplitude';
 import { trackLikeButton } from '@/service/amplitude/track';
 import { VISIBILITY_PRIVATE } from '@/service/constants';
 import { ICON_SIZE } from '@/style/styleConstants';
@@ -28,6 +29,8 @@ import * as S from './TemplatePage.style';
 
 const TemplatePage = () => {
   const { id } = useParams<{ id: string }>();
+
+  useTrackPageViewed({ eventName: '[Viewed] 템플릿 조회 페이지', eventProps: { templateId: id } });
   const theme = useTheme();
   const [isNonmemberAlerterOpen, toggleNonmemberAlerter] = useToggle();
 

--- a/frontend/src/pages/TemplateUploadPage/TemplateUploadPage.tsx
+++ b/frontend/src/pages/TemplateUploadPage/TemplateUploadPage.tsx
@@ -7,6 +7,7 @@ import { useCategory } from '@/hooks/category';
 import { useSourceCode, useTag } from '@/hooks/template';
 import { useToast } from '@/hooks/useToast';
 import { useTemplateUploadMutation } from '@/queries/templates';
+import { trackClickTemplateSave, usePageViewed } from '@/service/amplitude';
 import { DEFAULT_TEMPLATE_VISIBILITY, TEMPLATE_VISIBILITY } from '@/service/constants';
 import { ICON_SIZE } from '@/style/styleConstants';
 import { theme } from '@/style/theme';
@@ -17,6 +18,8 @@ import { getLanguageForAutoTag } from '@/utils';
 import * as S from './TemplateUploadPage.style';
 
 const TemplateUploadPage = () => {
+  usePageViewed({ eventName: '[Viewed] 템플릿 업로드 페이지' });
+
   const navigate = useCustomNavigate();
   const { failAlert } = useToast();
 
@@ -87,7 +90,15 @@ const TemplateUploadPage = () => {
       visibility,
     };
 
-    await uploadTemplate(newTemplate);
+    const response = await uploadTemplate(newTemplate);
+
+    if (response.ok) {
+      trackClickTemplateSave({
+        templateTitle: title,
+        sourceCodeCount: sourceCodes.length,
+        visibility,
+      });
+    }
   };
 
   return (

--- a/frontend/src/pages/TemplateUploadPage/TemplateUploadPage.tsx
+++ b/frontend/src/pages/TemplateUploadPage/TemplateUploadPage.tsx
@@ -7,7 +7,7 @@ import { useCategory } from '@/hooks/category';
 import { useSourceCode, useTag } from '@/hooks/template';
 import { useToast } from '@/hooks/useToast';
 import { useTemplateUploadMutation } from '@/queries/templates';
-import { trackClickTemplateSave, usePageViewed } from '@/service/amplitude';
+import { trackClickTemplateSave, useTrackPageViewed } from '@/service/amplitude';
 import { DEFAULT_TEMPLATE_VISIBILITY, TEMPLATE_VISIBILITY } from '@/service/constants';
 import { ICON_SIZE } from '@/style/styleConstants';
 import { theme } from '@/style/theme';
@@ -18,7 +18,7 @@ import { getLanguageForAutoTag } from '@/utils';
 import * as S from './TemplateUploadPage.style';
 
 const TemplateUploadPage = () => {
-  usePageViewed({ eventName: '[Viewed] 템플릿 업로드 페이지' });
+  useTrackPageViewed({ eventName: '[Viewed] 템플릿 업로드 페이지' });
 
   const navigate = useCustomNavigate();
   const { failAlert } = useToast();

--- a/frontend/src/service/amplitude/AmplitudeInitializer.tsx
+++ b/frontend/src/service/amplitude/AmplitudeInitializer.tsx
@@ -14,6 +14,11 @@ const AmplitudeInitializer = ({ children }: React.PropsWithChildren) => {
   const prevName = useRef<string | undefined>(undefined);
 
   useEffect(() => {
+    // localhost, 개발 서버 환경일 때는 init X
+    if (process.env.APP_ENV === 'dev') {
+      return;
+    }
+
     // Amplitude가 처음 초기화될 때 (여러 번 init 되는 것을 방지)
     if (isAmplitudeInitialized.current === false) {
       if (name) {

--- a/frontend/src/service/amplitude/AmplitudeInitializer.tsx
+++ b/frontend/src/service/amplitude/AmplitudeInitializer.tsx
@@ -1,0 +1,54 @@
+import * as amplitude from '@amplitude/analytics-browser';
+import { useEffect, useRef } from 'react';
+
+import { useAuth } from '@/hooks/authentication';
+
+const amplitudeApiKey = process.env.AMPLITUDE_API_KEY ?? '';
+
+const AmplitudeInitializer = ({ children }: React.PropsWithChildren) => {
+  const {
+    memberInfo: { name },
+  } = useAuth();
+
+  const isAmplitudeInitialized = useRef(false);
+  const prevName = useRef<string | undefined>(undefined);
+
+  useEffect(() => {
+    // Amplitude가 처음 초기화될 때 (여러 번 init 되는 것을 방지)
+    if (isAmplitudeInitialized.current === false) {
+      if (name) {
+        amplitude.init(amplitudeApiKey, name, {
+          defaultTracking: {
+            pageViews: false,
+          },
+          minIdLength: 1,
+        });
+      } else {
+        amplitude.init(amplitudeApiKey, undefined, {
+          defaultTracking: {
+            pageViews: false,
+          },
+          minIdLength: 1,
+        });
+      }
+
+      isAmplitudeInitialized.current = true;
+
+      // name이 이전 값과 다를 때 (로그인 유저가 달라짐)
+    } else if (prevName.current !== name && name !== undefined) {
+      amplitude.init(amplitudeApiKey, name, {
+        defaultTracking: {
+          pageViews: false,
+        },
+        minIdLength: 1,
+      });
+    }
+
+    // 이전 name 값을 업데이트
+    prevName.current = name;
+  }, [name]);
+
+  return <>{children}</>;
+};
+
+export default AmplitudeInitializer;

--- a/frontend/src/service/amplitude/getBrowser.ts
+++ b/frontend/src/service/amplitude/getBrowser.ts
@@ -1,0 +1,30 @@
+export const getBrowser = () => {
+  const browsers = [
+    'Chrome',
+    'Opera',
+    'WebTV',
+    'Whale',
+    'Beonex',
+    'Chimera',
+    'NetPositive',
+    'Phoenix',
+    'Firefox',
+    'Safari',
+    'SkipStone',
+    'Netscape',
+    'Mozilla',
+  ];
+
+  const userAgent = window.navigator.userAgent.toLowerCase();
+  //TODO: 모바일 환경 실험 필요
+
+  if (userAgent.includes('edg')) {
+    return 'Edge';
+  }
+
+  if (userAgent.includes('trident') || userAgent.includes('msie')) {
+    return 'Internet Explorer';
+  }
+
+  return browsers.find((browser) => userAgent.includes(browser.toLowerCase())) || 'Other';
+};

--- a/frontend/src/service/amplitude/index.ts
+++ b/frontend/src/service/amplitude/index.ts
@@ -1,2 +1,9 @@
 // Initializer components
 export { default as AmplitudeInitializer } from './AmplitudeInitializer';
+
+// track methods
+export { AmplitudeService, trackClickNewTemplate, trackClickTemplateSave } from './track';
+export { usePageViewed } from './usePageViewed';
+
+// utils
+export { getBrowser } from './getBrowser';

--- a/frontend/src/service/amplitude/index.ts
+++ b/frontend/src/service/amplitude/index.ts
@@ -3,7 +3,7 @@ export { default as AmplitudeInitializer } from './AmplitudeInitializer';
 
 // track methods
 export { AmplitudeService, trackClickNewTemplate, trackClickTemplateSave } from './track';
-export { usePageViewed } from './usePageViewed';
+export { useTrackPageViewed } from './useTrackPageViewed';
 
 // utils
 export { getBrowser } from './getBrowser';

--- a/frontend/src/service/amplitude/index.ts
+++ b/frontend/src/service/amplitude/index.ts
@@ -1,0 +1,2 @@
+// Initializer components
+export { default as AmplitudeInitializer } from './AmplitudeInitializer';

--- a/frontend/src/service/amplitude/track.ts
+++ b/frontend/src/service/amplitude/track.ts
@@ -57,3 +57,19 @@ export const trackMyTemplatePaging = ({ page, totalPages, label }: PagingButtonD
     label,
   });
 };
+
+interface LickButtonData {
+  isLiked: boolean;
+  likesCount: number;
+  templateId: string;
+}
+
+export const trackLikeButton = ({ isLiked, likesCount, templateId }: LickButtonData) => {
+  const like = isLiked ? '좋아요 취소' : '좋아요';
+
+  amplitudeService.customTrack('[Click] 좋아요 버튼', {
+    like,
+    likesCount,
+    templateId,
+  });
+};

--- a/frontend/src/service/amplitude/track.ts
+++ b/frontend/src/service/amplitude/track.ts
@@ -43,3 +43,17 @@ export const trackClickTemplateSave = ({ templateTitle, sourceCodeCount, visibil
 export const trackClickCopyClipBoard = () => {
   amplitudeService.customTrack('[Click] 클립보드 복사 버튼');
 };
+
+interface PagingButtonData {
+  page: number;
+  totalPages: number;
+  label: string;
+}
+
+export const trackMyTemplatePaging = ({ page, totalPages, label }: PagingButtonData) => {
+  amplitudeService.customTrack('[Click] 페이징 버튼', {
+    page,
+    totalPages,
+    label,
+  });
+};

--- a/frontend/src/service/amplitude/track.ts
+++ b/frontend/src/service/amplitude/track.ts
@@ -1,0 +1,35 @@
+import * as amplitude from '@amplitude/analytics-browser';
+
+import { getBrowser } from './getBrowser';
+
+export class AmplitudeService {
+  private env: string;
+  private browser: string;
+
+  constructor() {
+    this.env = process.env.NODE_ENV ?? '';
+    this.browser = getBrowser();
+  }
+
+  customTrack(eventName: string, eventProps: Record<string, unknown> = {}) {
+    amplitude.track(eventName, {
+      environment: this.env,
+      browser: this.browser,
+      ...eventProps,
+    });
+  }
+}
+
+const amplitudeService = new AmplitudeService();
+
+export const trackClickNewTemplate = () => {
+  amplitudeService.customTrack('[Click] 새 템플릿 업로드 버튼');
+};
+
+export const trackClickTemplateSave = () => {
+  amplitudeService.customTrack('[Click] 템플릿 저장 버튼');
+};
+
+export const trackClickCopyClipBoard = () => {
+  amplitudeService.customTrack('[Click] 클립보드 복사 버튼');
+};

--- a/frontend/src/service/amplitude/track.ts
+++ b/frontend/src/service/amplitude/track.ts
@@ -26,8 +26,18 @@ export const trackClickNewTemplate = () => {
   amplitudeService.customTrack('[Click] 새 템플릿 업로드 버튼');
 };
 
-export const trackClickTemplateSave = () => {
-  amplitudeService.customTrack('[Click] 템플릿 저장 버튼');
+interface TemplateUploadData {
+  templateTitle: string;
+  sourceCodeCount: number;
+  visibility: string;
+}
+
+export const trackClickTemplateSave = ({ templateTitle, sourceCodeCount, visibility }: TemplateUploadData) => {
+  amplitudeService.customTrack('[Click] 템플릿 저장 버튼', {
+    templateTitle,
+    sourceCodeCount,
+    visibility,
+  });
 };
 
 export const trackClickCopyClipBoard = () => {

--- a/frontend/src/service/amplitude/usePageViewed.ts
+++ b/frontend/src/service/amplitude/usePageViewed.ts
@@ -1,0 +1,19 @@
+import { useEffect } from 'react';
+
+import { AmplitudeService } from './track';
+
+interface Props {
+  eventName: string;
+  eventProps?: Record<string, unknown>;
+}
+
+/**
+ * browser, env를 제외한 eventProps를 제공해주세요
+ */
+export const usePageViewed = ({ eventName, eventProps }: Props) => {
+  const amplitudeService = new AmplitudeService();
+
+  useEffect(() => {
+    amplitudeService.customTrack(eventName, eventProps ?? {});
+  }, []);
+};

--- a/frontend/src/service/amplitude/useTrackPageViewed.ts
+++ b/frontend/src/service/amplitude/useTrackPageViewed.ts
@@ -10,7 +10,7 @@ interface Props {
 /**
  * browser, env를 제외한 eventProps를 제공해주세요
  */
-export const usePageViewed = ({ eventName, eventProps }: Props) => {
+export const useTrackPageViewed = ({ eventName, eventProps }: Props) => {
   const amplitudeService = new AmplitudeService();
 
   useEffect(() => {


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #259 

## 📍주요 변경 사항
- Amplitude를 설치 및 초기 설정을 하고 track 메서드를 커스텀 했습니다.
- 핵심 기능 중 하나인 템플릿 업로드 유저 플로우를 트래킹하는 작업을 만들어보았습니다.
  1. Header의 새 템플릿 버튼에 클릭 이벤트 track
  2. 템플릿 업로드 페이지가 보였을 때, 이벤트 track
  3. 템플릿 저장 버튼 클릭 이벤트 track
    - 추가로 해당 이벤트에 title, 소스코드 갯수, visibility를 추가 정보로 제공했습니다.
  
위의 설정으로 제가 생각하고 있는 정보는 다음과 같습니다.
- 템플릿 업로드 페이지에 들어온 순간 ~ 저장까지의 걸리는 시간
- 업로드 페이지에 들어왔지만 저장 버튼 안 누름 -> 유저 이탈
- 한 템플릿으로 업로드하는 소스 코드 갯수
- 템플릿의 visibility에 대한 갯수 데이터

- 관련 환경변수가 추가되었습니다. 로컬 실행에 필요하다면 따로 공유 드릴게요. codepipeline에도 추가해야합니다.
- Amplitude 계정은 codezap2024 구글 계정입니다.

## 🎸기타
1. Amplitude 선택 이유는 노션으로 공유하겠습니다.
2. Amplitude 사용법은 저도 배우면서 한 지라, 공식 문서 및 해당 링크를 참고해주세요.
https://amplitude.com/docs/sdks/analytics/browser/browser-sdk-2


## 🍗 PR 첫 리뷰 마감 기한
10/22 11:59
다만 최대한 빨리 해당 기능을 운영서버에 띄우는게 좋을 것 같아 `zap` 태그 달아놓겠습니다.
