### PR TITLE
상세 조회에서 다른 사람의 비공개 템플릿 확인 시 예외 처리

### DIFF
--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -105,6 +105,8 @@ public interface SpringDocTemplateController {
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공")
     @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1/login", errorCases = {
             @ErrorCase(description = "해당하는 ID 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
+    })
+    @ApiErrorResponse(status = HttpStatus.FORBIDDEN, instance = "/templates/1", errorCases = {
             @ErrorCase(description = "다른 사람의 private 템플릿인 경우", exampleMessage = "해당 템플릿은 비공개 템플릿입니다."),
     })
     ResponseEntity<FindTemplateResponse> findTemplateById(Member member, Long id);

--- a/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
+++ b/backend/src/main/java/codezap/template/controller/SpringDocTemplateController.java
@@ -105,6 +105,7 @@ public interface SpringDocTemplateController {
     @ApiResponse(responseCode = "200", description = "템플릿 단건 조회 성공")
     @ApiErrorResponse(status = HttpStatus.BAD_REQUEST, instance = "/templates/1/login", errorCases = {
             @ErrorCase(description = "해당하는 ID 값인 템플릿이 없는 경우", exampleMessage = "식별자 1에 해당하는 템플릿이 존재하지 않습니다."),
+            @ErrorCase(description = "다른 사람의 private 템플릿인 경우", exampleMessage = "해당 템플릿은 비공개 템플릿입니다."),
     })
     ResponseEntity<FindTemplateResponse> findTemplateById(Member member, Long id);
 

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -19,8 +19,6 @@ import org.hibernate.annotations.Formula;
 
 import codezap.category.domain.Category;
 import codezap.global.auditing.BaseTimeEntity;
-import codezap.global.exception.CodeZapException;
-import codezap.global.exception.ErrorCode;
 import codezap.member.domain.Member;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -77,19 +75,11 @@ public class Template extends BaseTimeEntity {
         this.visibility = visibility;
     }
 
-    public void validateAuthorization(Member member) {
-        if (!matchMember(member)) {
-            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿에 대한 권한이 없습니다.");
-        }
-    }
-
     public boolean matchMember(Member member) {
         return getMember().equals(member);
     }
 
-    public void ensureNotPrivateTemplate() {
-        if (visibility == Visibility.PRIVATE) {
-            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿은 비공개 템플릿입니다.");
-        }
+    public boolean isPrivate() {
+        return visibility == Visibility.PRIVATE;
     }
 }

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -67,11 +67,7 @@ public class Template extends BaseTimeEntity {
     }
 
     public Template(Member member, String title, String description, Category category, Visibility visibility) {
-        this.member = member;
-        this.title = title;
-        this.description = description;
-        this.category = category;
-        this.visibility = visibility;
+        this(null, member, title, description, category, null, 0L, visibility);
     }
 
     public void updateTemplate(String title, String description, Category category, Visibility visibility) {

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -91,7 +91,7 @@ public class Template extends BaseTimeEntity {
         return getMember().equals(member);
     }
 
-    public void validateForbiddenPrivate() {
+    public void ensureNotPrivateTemplate() {
         if (visibility == Visibility.PRIVATE) {
             throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿은 비공개 템플릿입니다.");
         }

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -76,7 +76,7 @@ public class Template extends BaseTimeEntity {
     }
 
     public boolean matchMember(Member member) {
-        return getMember().equals(member);
+        return this.member.equals(member);
     }
 
     public boolean isPrivate() {

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -14,6 +14,7 @@ import jakarta.persistence.Id;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.OneToMany;
 
+import org.hibernate.annotations.ColumnDefault;
 import org.hibernate.annotations.Formula;
 
 import codezap.category.domain.Category;
@@ -57,6 +58,7 @@ public class Template extends BaseTimeEntity {
     private Long likesCount;
 
     @Column(nullable = false)
+    @ColumnDefault("'PUBLIC'")
     @Enumerated(EnumType.STRING)
     private Visibility visibility;
 

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -82,8 +82,18 @@ public class Template extends BaseTimeEntity {
     }
 
     public void validateAuthorization(Member member) {
-        if (!getMember().equals(member)) {
+        if (!matchMember(member)) {
             throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿에 대한 권한이 없습니다.");
+        }
+    }
+
+    public boolean matchMember(Member member) {
+        return getMember().equals(member);
+    }
+
+    public void validateForbiddenPrivate() {
+        if (visibility == Visibility.PRIVATE) {
+            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿은 비공개 템플릿입니다.");
         }
     }
 }

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -66,7 +66,9 @@ public class TemplateService {
             Category category
     ) {
         Template template = templateRepository.fetchById(templateId);
-        template.validateAuthorization(member);
+        if (!template.matchMember(member)) {
+            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿에 대한 권한이 없습니다.");
+        }
         template.updateTemplate(
                 updateTemplateRequest.title(),
                 updateTemplateRequest.description(),
@@ -86,7 +88,9 @@ public class TemplateService {
 
     private void deleteById(Member member, Long id) {
         Template template = templateRepository.fetchById(id);
-        template.validateAuthorization(member);
+        if (!template.matchMember(member)) {
+            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿에 대한 권한이 없습니다.");
+        }
         templateRepository.deleteById(id);
     }
 }

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -59,7 +59,7 @@ public class TemplateApplicationService {
 
     public FindTemplateResponse findById(Long id) {
         Template template = templateService.getById(id);
-        template.validateForbiddenPrivate();
+        template.ensureNotPrivateTemplate();
         List<Tag> tags = tagService.findAllByTemplate(template);
         List<SourceCode> sourceCodes = sourceCodeService.findAllByTemplate(template);
         return FindTemplateResponse.of(template, sourceCodes, tags, false);
@@ -68,7 +68,7 @@ public class TemplateApplicationService {
     public FindTemplateResponse findById(Long id, Member loginMember) {
         Template template = templateService.getById(id);
         if(!template.matchMember(loginMember)) {
-            template.validateForbiddenPrivate();
+            template.ensureNotPrivateTemplate();
         }
         List<Tag> tags = tagService.findAllByTemplate(template);
         List<SourceCode> sourceCodes = sourceCodeService.findAllByTemplate(template);

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -59,6 +59,7 @@ public class TemplateApplicationService {
 
     public FindTemplateResponse findById(Long id) {
         Template template = templateService.getById(id);
+        template.validateForbiddenPrivate();
         List<Tag> tags = tagService.findAllByTemplate(template);
         List<SourceCode> sourceCodes = sourceCodeService.findAllByTemplate(template);
         return FindTemplateResponse.of(template, sourceCodes, tags, false);
@@ -66,6 +67,9 @@ public class TemplateApplicationService {
 
     public FindTemplateResponse findById(Long id, Member loginMember) {
         Template template = templateService.getById(id);
+        if(!template.matchMember(loginMember)) {
+            template.validateForbiddenPrivate();
+        }
         List<Tag> tags = tagService.findAllByTemplate(template);
         List<SourceCode> sourceCodes = sourceCodeService.findAllByTemplate(template);
         boolean isLiked = likesService.isLiked(loginMember, template);

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -11,6 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import codezap.category.domain.Category;
 import codezap.category.service.CategoryService;
+import codezap.global.exception.CodeZapException;
+import codezap.global.exception.ErrorCode;
 import codezap.likes.service.LikedChecker;
 import codezap.likes.service.LikesService;
 import codezap.member.domain.Member;
@@ -59,7 +61,9 @@ public class TemplateApplicationService {
 
     public FindTemplateResponse findById(Long id) {
         Template template = templateService.getById(id);
-        template.ensureNotPrivateTemplate();
+        if (template.isPrivate()) {
+            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿은 비공개 템플릿입니다.");
+        }
         List<Tag> tags = tagService.findAllByTemplate(template);
         List<SourceCode> sourceCodes = sourceCodeService.findAllByTemplate(template);
         return FindTemplateResponse.of(template, sourceCodes, tags, false);
@@ -67,8 +71,8 @@ public class TemplateApplicationService {
 
     public FindTemplateResponse findById(Long id, Member loginMember) {
         Template template = templateService.getById(id);
-        if(!template.matchMember(loginMember)) {
-            template.ensureNotPrivateTemplate();
+        if (!template.matchMember(loginMember) && template.isPrivate()) {
+            throw new CodeZapException(ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿은 비공개 템플릿입니다.");
         }
         List<Tag> tags = tagService.findAllByTemplate(template);
         List<SourceCode> sourceCodes = sourceCodeService.findAllByTemplate(template);

--- a/backend/src/main/java/codezap/template/service/facade/TemplateOwnershipChecker.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateOwnershipChecker.java
@@ -1,0 +1,9 @@
+package codezap.template.service.facade;
+
+import codezap.template.domain.Template;
+
+@FunctionalInterface
+public interface TemplateOwnershipChecker {
+
+    boolean isOwner(Template template);
+}

--- a/backend/src/test/java/codezap/template/domain/TemplateTest.java
+++ b/backend/src/test/java/codezap/template/domain/TemplateTest.java
@@ -1,0 +1,102 @@
+package codezap.template.domain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+import codezap.category.domain.Category;
+import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
+import codezap.global.exception.CodeZapException;
+import codezap.global.exception.ErrorCode;
+import codezap.member.domain.Member;
+
+class TemplateTest {
+
+    @Nested
+    @DisplayName("권한 확인")
+    class ValidateAuthorization {
+
+        @Test
+        @DisplayName("성공")
+        void validateAuthorizationSuccess() {
+            Member member = MemberFixture.getFirstMember();
+            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
+
+            assertThatCode(() -> template.validateAuthorization(member))
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: 다른 사용자일 경우 예외 발생")
+        void validateAuthorizationFail() {
+            Member member = MemberFixture.getFirstMember();
+            Member otherMember = MemberFixture.getSecondMember();
+            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
+
+            assertThatThrownBy(() -> template.validateAuthorization(otherMember))
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("해당 템플릿에 대한 권한이 없습니다.")
+                    .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
+
+    @Nested
+    @DisplayName("멤버 확인")
+    class MatchMember {
+
+        @Test
+        @DisplayName("성공: 같은 사용자일 경우 true")
+        void matchMemberSuccess() {
+            Member member = MemberFixture.getFirstMember();
+            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
+
+            boolean actual = template.matchMember(member);
+
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 다른 사용자일 경우 false")
+        void matchMemberFail() {
+            Member member = MemberFixture.getFirstMember();
+            Member otherMember = MemberFixture.getSecondMember();
+            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
+
+            boolean actual = template.matchMember(otherMember);
+
+            assertThat(actual).isFalse();
+        }
+    }
+
+    @Nested
+    @DisplayName("Private 템플릿 확인")
+    class ValidateForbiddenPrivate {
+
+        @Test
+        @DisplayName("성공")
+        void validateForbiddenPrivateSuccess() {
+            Member member = MemberFixture.getFirstMember();
+            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
+
+            assertThatCode(template::validateForbiddenPrivate)
+                    .doesNotThrowAnyException();
+        }
+
+        @Test
+        @DisplayName("성공: private 템플릿일 경우 예외 발생")
+        void validateForbiddenPrivateFail() {
+            Member member = MemberFixture.getFirstMember();
+            Template template = TemplateFixture.getPrivate(member, Category.createDefaultCategory(member));
+
+            assertThatThrownBy(template::validateForbiddenPrivate)
+                    .isInstanceOf(CodeZapException.class)
+                    .hasMessage("해당 템플릿은 비공개 템플릿입니다.")
+                    .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN_ACCESS);
+        }
+    }
+}

--- a/backend/src/test/java/codezap/template/domain/TemplateTest.java
+++ b/backend/src/test/java/codezap/template/domain/TemplateTest.java
@@ -75,25 +75,25 @@ class TemplateTest {
 
     @Nested
     @DisplayName("Private 템플릿 확인")
-    class ValidateForbiddenPrivate {
+    class EnsureNotPrivateTemplate {
 
         @Test
         @DisplayName("성공")
-        void validateForbiddenPrivateSuccess() {
+        void ensureNotPrivateTemplateSuccess() {
             Member member = MemberFixture.getFirstMember();
             Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
 
-            assertThatCode(template::validateForbiddenPrivate)
+            assertThatCode(template::ensureNotPrivateTemplate)
                     .doesNotThrowAnyException();
         }
 
         @Test
         @DisplayName("성공: private 템플릿일 경우 예외 발생")
-        void validateForbiddenPrivateFail() {
+        void ensureNotPrivateTemplateFail() {
             Member member = MemberFixture.getFirstMember();
             Template template = TemplateFixture.getPrivate(member, Category.createDefaultCategory(member));
 
-            assertThatThrownBy(template::validateForbiddenPrivate)
+            assertThatThrownBy(template::ensureNotPrivateTemplate)
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("해당 템플릿은 비공개 템플릿입니다.")
                     .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN_ACCESS);

--- a/backend/src/test/java/codezap/template/domain/TemplateTest.java
+++ b/backend/src/test/java/codezap/template/domain/TemplateTest.java
@@ -1,8 +1,6 @@
 package codezap.template.domain;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatCode;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
@@ -11,39 +9,9 @@ import org.junit.jupiter.api.Test;
 import codezap.category.domain.Category;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
-import codezap.global.exception.CodeZapException;
-import codezap.global.exception.ErrorCode;
 import codezap.member.domain.Member;
 
 class TemplateTest {
-
-    @Nested
-    @DisplayName("권한 확인")
-    class ValidateAuthorization {
-
-        @Test
-        @DisplayName("성공")
-        void validateAuthorizationSuccess() {
-            Member member = MemberFixture.getFirstMember();
-            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
-
-            assertThatCode(() -> template.validateAuthorization(member))
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("성공: 다른 사용자일 경우 예외 발생")
-        void validateAuthorizationFail() {
-            Member member = MemberFixture.getFirstMember();
-            Member otherMember = MemberFixture.getSecondMember();
-            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
-
-            assertThatThrownBy(() -> template.validateAuthorization(otherMember))
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("해당 템플릿에 대한 권한이 없습니다.")
-                    .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN_ACCESS);
-        }
-    }
 
     @Nested
     @DisplayName("멤버 확인")
@@ -74,29 +42,30 @@ class TemplateTest {
     }
 
     @Nested
-    @DisplayName("Private 템플릿 확인")
-    class EnsureNotPrivateTemplate {
+    @DisplayName("공개 범위 확인")
+    class IsPrivate {
 
         @Test
-        @DisplayName("성공")
-        void ensureNotPrivateTemplateSuccess() {
-            Member member = MemberFixture.getFirstMember();
-            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
-
-            assertThatCode(template::ensureNotPrivateTemplate)
-                    .doesNotThrowAnyException();
-        }
-
-        @Test
-        @DisplayName("성공: private 템플릿일 경우 예외 발생")
-        void ensureNotPrivateTemplateFail() {
+        @DisplayName("성공: 비공개 템플릿일 경우 true")
+        void isPrivateTrue() {
             Member member = MemberFixture.getFirstMember();
             Template template = TemplateFixture.getPrivate(member, Category.createDefaultCategory(member));
 
-            assertThatThrownBy(template::ensureNotPrivateTemplate)
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("해당 템플릿은 비공개 템플릿입니다.")
-                    .extracting("errorCode").isEqualTo(ErrorCode.FORBIDDEN_ACCESS);
+            boolean actual = template.isPrivate();
+
+            assertThat(actual).isTrue();
+        }
+
+        @Test
+        @DisplayName("성공: 공개 템플릿일 경우 false")
+        void isPrivateFalse() {
+            Member member = MemberFixture.getFirstMember();
+            Member otherMember = MemberFixture.getSecondMember();
+            Template template = TemplateFixture.get(member, Category.createDefaultCategory(member));
+
+            boolean actual = template.isPrivate();
+
+            assertThat(actual).isFalse();
         }
     }
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
#739

## 📍주요 변경 사항
- 단건 조회 시 다른 사람의 비공개 템플릿 조회일 경우 예외 발생
   - ErrorCode.FORBIDDEN_ACCESS, "해당 템플릿은 비공개 템플릿입니다."
- DB에서 템플릿 기본 값을 PUBLIC으로 설정

## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.


## 🍗 PR 첫 리뷰 마감 기한
10/23 10:00

해당 PR은 내일 릴리즈 전에 올라가야할 것 같습니다~ 빠른 리뷰 부탁드려요 !