### PR TITLE
템플릿 카드의 클릭 가능 영역 변경 및 유저 이름 클릭 시 유저 페이지로 이동

### DIFF
--- a/frontend/src/components/AuthorInfo/AuthorInfo.style.ts
+++ b/frontend/src/components/AuthorInfo/AuthorInfo.style.ts
@@ -1,0 +1,32 @@
+import styled from '@emotion/styled';
+
+import { theme } from '@/style/theme';
+
+export const AuthorInfoContainer = styled.div`
+  cursor: pointer;
+
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+
+  box-sizing: border-box;
+  min-width: 0;
+  height: 100%;
+  padding: 3px 5px;
+
+  border-radius: 4px;
+
+  &:hover {
+    background-color: ${theme.color.light.primary_50};
+  }
+`;
+
+export const EllipsisTextWrapper = styled.span`
+  overflow: hidden;
+  display: block;
+
+  min-width: 0;
+
+  text-overflow: ellipsis;
+  white-space: nowrap;
+`;

--- a/frontend/src/components/AuthorInfo/AuthorInfo.tsx
+++ b/frontend/src/components/AuthorInfo/AuthorInfo.tsx
@@ -1,0 +1,20 @@
+import { PersonIcon } from '@/assets/images';
+import { Text } from '@/components';
+import { theme } from '@/style/theme';
+
+import * as S from './AuthorInfo.style';
+
+interface Props {
+  memberName: string;
+}
+
+const AuthorInfo = ({ memberName }: Props) => (
+  <S.AuthorInfoContainer>
+    <PersonIcon width={17} height={17} color={theme.color.light.primary_500} />
+    <S.EllipsisTextWrapper>
+      <Text.Small color={theme.color.light.primary_500}>{memberName}</Text.Small>
+    </S.EllipsisTextWrapper>
+  </S.AuthorInfoContainer>
+);
+
+export default AuthorInfo;

--- a/frontend/src/components/TemplateCard/TemplateCard.style.ts
+++ b/frontend/src/components/TemplateCard/TemplateCard.style.ts
@@ -85,22 +85,3 @@ export const NoWrapTextWrapper = styled.div`
 export const BlankDescription = styled.div`
   height: 1rem;
 `;
-
-export const AuthorInfoContainer = styled.div`
-  cursor: pointer;
-
-  display: flex;
-  gap: 0.25rem;
-  align-items: center;
-
-  box-sizing: border-box;
-  min-width: 0;
-  height: 100%;
-  padding: 3px 5px;
-
-  border-radius: 4px;
-
-  &:hover {
-    background-color: ${theme.color.light.primary_50};
-  }
-`;

--- a/frontend/src/components/TemplateCard/TemplateCard.style.ts
+++ b/frontend/src/components/TemplateCard/TemplateCard.style.ts
@@ -3,8 +3,6 @@ import styled from '@emotion/styled';
 import { theme } from '@/style/theme';
 
 export const TemplateCardContainer = styled.div`
-  cursor: pointer;
-
   display: flex;
   flex-direction: column;
   gap: 1rem;
@@ -95,5 +93,14 @@ export const AuthorInfoContainer = styled.div`
   gap: 0.25rem;
   align-items: center;
 
+  box-sizing: border-box;
   min-width: 0;
+  height: 100%;
+  padding: 3px 5px;
+
+  border-radius: 4px;
+
+  &:hover {
+    background-color: ${theme.color.light.primary_50};
+  }
 `;

--- a/frontend/src/components/TemplateCard/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard/TemplateCard.tsx
@@ -1,6 +1,6 @@
 import { Link } from 'react-router-dom';
 
-import { ClockIcon, PersonIcon, PrivateIcon } from '@/assets/images';
+import { ClockIcon, PrivateIcon } from '@/assets/images';
 import { Button, Flex, LikeCounter, TagButton, Text, SourceCodeViewer } from '@/components';
 import { useToggle } from '@/hooks';
 import { END_POINTS } from '@/routes';
@@ -10,6 +10,7 @@ import { theme } from '@/style/theme';
 import type { Tag, TemplateListItem } from '@/types';
 import { formatRelativeTime } from '@/utils/formatRelativeTime';
 
+import AuthorInfo from '../AuthorInfo/AuthorInfo';
 import * as S from './TemplateCard.style';
 
 interface Props {
@@ -43,12 +44,7 @@ const TemplateCard = ({ template }: Props) => {
             {isPrivate && <PrivateIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.secondary_600} />}
 
             <Link to={END_POINTS.memberTemplates(member.id)}>
-              <S.AuthorInfoContainer>
-                <PersonIcon width={17} height={17} color={theme.color.light.primary_500} />
-                <S.EllipsisTextWrapper>
-                  <Text.Small color={theme.color.light.primary_500}>{member.name}</Text.Small>
-                </S.EllipsisTextWrapper>
-              </S.AuthorInfoContainer>
+              <AuthorInfo memberName={member.name} />
             </Link>
 
             <Flex align='center' gap='0.25rem'>

--- a/frontend/src/components/TemplateCard/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard/TemplateCard.tsx
@@ -1,4 +1,4 @@
-import { useNavigate } from 'react-router-dom';
+import { Link } from 'react-router-dom';
 
 import { ClockIcon, PersonIcon, PrivateIcon } from '@/assets/images';
 import { Button, Flex, LikeCounter, TagButton, Text, SourceCodeViewer } from '@/components';
@@ -17,7 +17,6 @@ interface Props {
 }
 
 const TemplateCard = ({ template }: Props) => {
-  const navigate = useNavigate();
   const { title, description, thumbnail, tags, modifiedAt, member, visibility } = template;
   const [showAllTagList, toggleShowAllTagList] = useToggle();
   const isPrivate = visibility === VISIBILITY_PRIVATE;
@@ -27,10 +26,6 @@ const TemplateCard = ({ template }: Props) => {
   ) => {
     e.preventDefault();
     e.stopPropagation();
-  };
-
-  const handleAuthorClick = () => {
-    navigate(END_POINTS.memberTemplates(member.id));
   };
 
   const handleAllTagList = (
@@ -47,12 +42,14 @@ const TemplateCard = ({ template }: Props) => {
           <Flex gap='0.75rem' flex='1' style={{ minWidth: '0' }}>
             {isPrivate && <PrivateIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.secondary_600} />}
 
-            <S.AuthorInfoContainer onClick={handleAuthorClick} style={{ cursor: 'pointer' }}>
-              <PersonIcon color={theme.color.light.primary_500} />
-              <S.EllipsisTextWrapper style={{ width: '100%' }}>
-                <Text.Small color={theme.color.light.primary_500}>{member.name}</Text.Small>
-              </S.EllipsisTextWrapper>
-            </S.AuthorInfoContainer>
+            <Link to={END_POINTS.memberTemplates(member.id)}>
+              <S.AuthorInfoContainer>
+                <PersonIcon width={17} height={17} color={theme.color.light.primary_500} />
+                <S.EllipsisTextWrapper>
+                  <Text.Small color={theme.color.light.primary_500}>{member.name}</Text.Small>
+                </S.EllipsisTextWrapper>
+              </S.AuthorInfoContainer>
+            </Link>
 
             <Flex align='center' gap='0.25rem'>
               <ClockIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.secondary_600} />
@@ -66,22 +63,26 @@ const TemplateCard = ({ template }: Props) => {
           </Flex>
         </Flex>
 
-        <S.EllipsisTextWrapper>
-          <Text.XLarge color={theme.color.light.secondary_900} weight='bold'>
-            {title}
-          </Text.XLarge>
-        </S.EllipsisTextWrapper>
+        <Link to={END_POINTS.template(template.id)}>
+          <S.EllipsisTextWrapper>
+            <Text.XLarge color={theme.color.light.secondary_900} weight='bold'>
+              {title}
+            </Text.XLarge>
+          </S.EllipsisTextWrapper>
 
-        <S.EllipsisTextWrapper>
-          {description ? (
-            <Text.Medium color={theme.color.light.secondary_600}>{description}</Text.Medium>
-          ) : (
-            <S.BlankDescription />
-          )}
-        </S.EllipsisTextWrapper>
+          <S.EllipsisTextWrapper>
+            {description ? (
+              <Text.Medium color={theme.color.light.secondary_600}>{description}</Text.Medium>
+            ) : (
+              <S.BlankDescription />
+            )}
+          </S.EllipsisTextWrapper>
+        </Link>
       </Flex>
 
-      <SourceCodeViewer mode='thumbnailView' filename={thumbnail.filename} content={thumbnail.content} />
+      <Link to={END_POINTS.template(template.id)}>
+        <SourceCodeViewer mode='thumbnailView' filename={thumbnail.filename} content={thumbnail.content} />
+      </Link>
 
       <Flex justify='space-between' onClick={blockMovingToDetailPage}>
         <S.TagListContainer>

--- a/frontend/src/pages/MyTemplatesPage/components/TemplateGrid/TemplateGrid.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TemplateGrid/TemplateGrid.tsx
@@ -1,8 +1,6 @@
 import { useEffect } from 'react';
-import { Link } from 'react-router-dom';
 
 import { TemplateCard } from '@/components';
-import { END_POINTS } from '@/routes/endPoints';
 import { TemplateListItem } from '@/types';
 
 import * as S from './TemplateGrid.style';
@@ -44,9 +42,7 @@ const TemplateGrid = ({ templateList, isEditMode, selectedList, setSelectedList,
             </S.NonInteractiveWrapper>
           </S.TemplateCardWrapper>
         ) : (
-          <Link to={END_POINTS.template(template.id)} key={template.id}>
-            <TemplateCard template={template} />
-          </Link>
+          <TemplateCard key={template.id} template={template} />
         ),
       )}
     </S.TemplateContainer>

--- a/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
+++ b/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
@@ -1,7 +1,6 @@
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
 import { useEffect } from 'react';
 import { ErrorBoundary } from 'react-error-boundary';
-import { Link } from 'react-router-dom';
 
 import { SORTING_OPTIONS } from '@/api';
 import { ArrowUpIcon, SearchIcon } from '@/assets/images';
@@ -180,9 +179,7 @@ const TemplateList = ({
           {!isLoading && (
             <S.TemplateExplorePageContainer cols={getGridCols(windowWidth)}>
               {templateList.map((template) => (
-                <Link to={`/templates/${template.id}`} key={template.id}>
-                  <TemplateCard template={template} />
-                </Link>
+                <TemplateCard key={template.id} template={template} />
               ))}
             </S.TemplateExplorePageContainer>
           )}

--- a/frontend/src/pages/TemplatePage/TemplatePage.style.ts
+++ b/frontend/src/pages/TemplatePage/TemplatePage.style.ts
@@ -1,7 +1,6 @@
 import styled from '@emotion/styled';
 
 import { Button } from '@/components';
-import { theme } from '@/style/theme';
 
 export const MainContainer = styled.main`
   display: flex;
@@ -49,23 +48,4 @@ export const DeleteButton = styled(Button)`
 
 export const PrivateWrapper = styled.div`
   flex-shrink: 0;
-`;
-
-export const AuthorInfoContainer = styled.div`
-  cursor: pointer;
-
-  display: flex;
-  gap: 0.25rem;
-  align-items: center;
-
-  box-sizing: border-box;
-  min-width: 0;
-  height: 1.5rem;
-  padding: 3px 5px;
-
-  border-radius: 4px;
-
-  &:hover {
-    background-color: ${theme.color.light.primary_50};
-  }
 `;

--- a/frontend/src/pages/TemplatePage/TemplatePage.style.ts
+++ b/frontend/src/pages/TemplatePage/TemplatePage.style.ts
@@ -1,6 +1,7 @@
 import styled from '@emotion/styled';
 
 import { Button } from '@/components';
+import { theme } from '@/style/theme';
 
 export const MainContainer = styled.main`
   display: flex;
@@ -57,5 +58,14 @@ export const AuthorInfoContainer = styled.div`
   gap: 0.25rem;
   align-items: center;
 
+  box-sizing: border-box;
   min-width: 0;
+  height: 1.5rem;
+  padding: 3px 5px;
+
+  border-radius: 4px;
+
+  &:hover {
+    background-color: ${theme.color.light.primary_50};
+  }
 `;

--- a/frontend/src/pages/TemplatePage/TemplatePage.tsx
+++ b/frontend/src/pages/TemplatePage/TemplatePage.tsx
@@ -1,7 +1,7 @@
 import { useTheme } from '@emotion/react';
 import { Link, useParams } from 'react-router-dom';
 
-import { ClockIcon, PersonIcon, PrivateIcon } from '@/assets/images';
+import { ClockIcon, PrivateIcon } from '@/assets/images';
 import {
   Button,
   Flex,
@@ -15,6 +15,7 @@ import {
   NonmemberAlerter,
   LoadingFallback,
 } from '@/components';
+import AuthorInfo from '@/components/AuthorInfo/AuthorInfo';
 import { useToggle } from '@/hooks';
 import { useAuth } from '@/hooks/authentication';
 import { TemplateEditPage } from '@/pages';
@@ -132,19 +133,7 @@ const TemplatePage = () => {
 
                 <Flex gap='0.5rem' align='center' justify='space-between'>
                   <Link to={END_POINTS.memberTemplates(template.member.id)}>
-                    <S.AuthorInfoContainer>
-                      <PersonIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.primary_500} />
-                      <div
-                        style={{
-                          overflow: 'hidden',
-                          textOverflow: 'ellipsis',
-                          whiteSpace: 'nowrap',
-                          flex: 1,
-                        }}
-                      >
-                        <Text.Small color={theme.color.light.primary_500}>{template.member.name}</Text.Small>
-                      </div>
-                    </S.AuthorInfoContainer>
+                    <AuthorInfo memberName={template.member.name} />
                   </Link>
 
                   <Flex align='center' gap='0.125rem'>

--- a/frontend/src/pages/TemplatePage/TemplatePage.tsx
+++ b/frontend/src/pages/TemplatePage/TemplatePage.tsx
@@ -1,5 +1,5 @@
 import { useTheme } from '@emotion/react';
-import { useNavigate, useParams } from 'react-router-dom';
+import { Link, useParams } from 'react-router-dom';
 
 import { ClockIcon, PersonIcon, PrivateIcon } from '@/assets/images';
 import {
@@ -29,7 +29,6 @@ import { useTemplate, useLike } from './hooks';
 import * as S from './TemplatePage.style';
 
 const TemplatePage = () => {
-  const navigate = useNavigate();
   const { id } = useParams<{ id: string }>();
 
   useTrackPageViewed({ eventName: '[Viewed] 템플릿 조회 페이지', eventProps: { templateId: id } });
@@ -71,12 +70,6 @@ const TemplatePage = () => {
 
     toggleLike();
     trackLikeButton({ isLiked, likesCount, templateId: id as string });
-  };
-
-  const handleAuthorClick = () => {
-    if (template?.member?.id) {
-      navigate(END_POINTS.memberTemplates(template.member.id));
-    }
   };
 
   if (!template) {
@@ -138,20 +131,22 @@ const TemplatePage = () => {
                 </Flex>
 
                 <Flex gap='0.5rem' align='center' justify='space-between'>
-                  <S.AuthorInfoContainer onClick={handleAuthorClick} style={{ cursor: 'pointer' }}>
-                    <PersonIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.primary_500} />
+                  <Link to={END_POINTS.memberTemplates(template.member.id)}>
+                    <S.AuthorInfoContainer>
+                      <PersonIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.primary_500} />
+                      <div
+                        style={{
+                          overflow: 'hidden',
+                          textOverflow: 'ellipsis',
+                          whiteSpace: 'nowrap',
+                          flex: 1,
+                        }}
+                      >
+                        <Text.Small color={theme.color.light.primary_500}>{template.member.name}</Text.Small>
+                      </div>
+                    </S.AuthorInfoContainer>
+                  </Link>
 
-                    <div
-                      style={{
-                        overflow: 'hidden',
-                        textOverflow: 'ellipsis',
-                        whiteSpace: 'nowrap',
-                        flex: 1,
-                      }}
-                    >
-                      <Text.Small color={theme.color.light.primary_500}>{template.member.name}</Text.Small>
-                    </div>
-                  </S.AuthorInfoContainer>
                   <Flex align='center' gap='0.125rem'>
                     <ClockIcon width={ICON_SIZE.SMALL} color={theme.color.light.secondary_600} />
                     <Text.Small color={theme.color.light.secondary_600}>


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #642 

## 📍주요 변경 사항
1. 템플릿 카드의 클릭 가능 영역이 변경되었습니다.
 - 유저 이름 클릭 시, 해당 유저의 템플릿 페이지로 이동
 - 템플릿 제목, 설명, 소스코드만 클릭 가능하도록 변경

2. 유저 이름 hover 스타일이 변경되었습니다.
3. AuthorInfo 컴포넌트를 분리하였습니다.

## 🍗 PR 첫 리뷰 마감 기한
10/24 23:00