### PR TITLE
full text index 한글 필드에 대해 n-gram parser 적용

### DIFF
--- a/backend/src/main/resources/db/migration/V8__replace_ft_parser.sql
+++ b/backend/src/main/resources/db/migration/V8__replace_ft_parser.sql
@@ -1,0 +1,2 @@
+ALTER TABLE template DROP INDEX idx_template_fulltext;
+ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description) WITH PARSER ngram;

--- a/backend/src/test/java/codezap/fixture/TemplateFixture.java
+++ b/backend/src/test/java/codezap/fixture/TemplateFixture.java
@@ -7,10 +7,10 @@ import codezap.template.domain.Visibility;
 
 public class TemplateFixture {
     public static Template get(Member member, Category category) {
-        return new Template(member, "Template 1", "Description 1", category);
+        return new Template(member, "안녕", "Description 1", category);
     }
 
     public static Template getPrivate(Member member, Category category) {
-        return new Template(member, "Template 1", "Description 1", category, Visibility.PRIVATE);
+        return new Template(member, "안녕하세요", "Description 1", category, Visibility.PRIVATE);
     }
 }

--- a/backend/src/test/java/codezap/global/DatabaseCleaner.java
+++ b/backend/src/test/java/codezap/global/DatabaseCleaner.java
@@ -33,7 +33,7 @@ public class DatabaseCleaner extends AbstractTestExecutionListener {
 
     private void createIfNotExistFullTextIndex(JdbcTemplate jdbcTemplate) {
         if (!indexExists(jdbcTemplate, "template", "idx_template_fulltext")) {
-            jdbcTemplate.execute("ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description)");
+            jdbcTemplate.execute("ALTER TABLE template ADD FULLTEXT INDEX idx_template_fulltext (title, description) WITH PARSER ngram");
         }
         if (!indexExists(jdbcTemplate, "source_code", "idx_source_code_fulltext")) {
             jdbcTemplate.execute("ALTER TABLE source_code ADD FULLTEXT INDEX idx_source_code_fulltext (content, filename)");

--- a/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateSearchJpaRepositoryTest.java
@@ -228,7 +228,7 @@ class TemplateSearchJpaRepositoryTest {
     @DisplayName("검색 테스트: 검색 결과가 없는 경우 빈 리스트 반환 성공")
     void testFindWithNoResults() {
         Specification<Template> spec = new TemplateSpecification(
-                null, "NonexistentKeyword", null, null, null
+                null, "없지롱", null, null, null
         );
         Page<Template> result = templateRepository.findAll(spec, PageRequest.of(0, 10));
 

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -130,7 +130,7 @@ class TemplateSearchServiceTest {
         @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
         void findAllSuccessByKeyword() {
             Long memberId = null;
-            String keyword = "Template";
+            String keyword = "안녕";
             Long categoryId = null;
             List<Long> tagIds = null;
             Visibility visibility = null;
@@ -139,8 +139,7 @@ class TemplateSearchServiceTest {
             Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
-                    .filter(template -> template.getTitle().contains(keyword) || template.getDescription()
-                            .contains(keyword))
+                    .filter(template -> template.getTitle().contains(keyword) || template.getDescription().contains(keyword))
                     .toArray(Template[]::new));
         }
 
@@ -300,7 +299,7 @@ class TemplateSearchServiceTest {
         @DisplayName("검색 기능: 모든 검색 기준으로 템플릿 목록 조회 성공")
         void findAllSuccessWithAllCriteria() {
             Long memberId = member1.getId();
-            String keyword = "Template";
+            String keyword = "안녕하세요";
             Long categoryId = category1.getId();
             List<Long> tagIds = List.of(tag1.getId(), tag2.getId());
             Visibility visibility = Visibility.PUBLIC;
@@ -318,7 +317,7 @@ class TemplateSearchServiceTest {
         @DisplayName("검색 기능: 검색 결과가 없는 경우 빈 리스트 반환 성공")
         void findAllSuccessWithNoResults() {
             Long memberId = null;
-            String keyword = "NonExistentKeyword";
+            String keyword = "설명";
             Long categoryId = null;
             List<Long> tagIds = null;
             Visibility visibility = null;


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #719 

## 📍주요 변경 사항
한글 키워드 검색 시에 템플릿이 "안녕하세요" 이고 키워드가 "안녕하"였다면 검색이 불가능했습니다.
검색 인덱스에 n-gram parser를 적용하여 부분 일치 검색이 가능하도록 변경합니다.

source_code의 filename, content는 영어이기 때문에 변경하지 않습니다.

#### n-gram parser란?
NGram은 주어진 텍스트를 N개의 연속된 단위로 쪼개는 방법입니다.
한글은 조사/어미 변화가 많고 형태소 분석이 복잡하기 때문에 영어처럼 기본 파서를 활용하면 위 사례처럼 검색이 불가능합니다.

`검색하다 → 검색해요, 검색합니다, 검색했어요, 검색하니까` ➡️ 단순 정확 매칭으로는 "검색하다"를 찾을 때 위의 변형들을 찾지 못함
보통 필드가 중국어, 일본어, 한국어(CJK)라면 ngram을 사용해서 처리한다고 하네용 참고!

## 🍗 PR 첫 리뷰 마감 기한
00/00 00:00
