### PR TITLE
사용자 이름 ellipsis 처리 및 모바일 환경일 때 템플릿 카드의 시간 숨김

### DIFF
--- a/frontend/src/components/AuthorInfo/AuthorInfo.style.ts
+++ b/frontend/src/components/AuthorInfo/AuthorInfo.style.ts
@@ -29,4 +29,12 @@ export const EllipsisTextWrapper = styled.span`
 
   text-overflow: ellipsis;
   white-space: nowrap;
+
+  @media (max-width: 1376px) {
+    max-width: 15.625rem;
+  }
+
+  @media (max-width: 768px) {
+    max-width: 8.125rem;
+  }
 `;

--- a/frontend/src/components/TemplateCard/TemplateCard.style.ts
+++ b/frontend/src/components/TemplateCard/TemplateCard.style.ts
@@ -85,3 +85,13 @@ export const NoWrapTextWrapper = styled.div`
 export const BlankDescription = styled.div`
   height: 1rem;
 `;
+
+export const TimeContainer = styled.div`
+  display: flex;
+  gap: 0.25rem;
+  align-items: center;
+
+  @media (max-width: 768px) {
+    display: none;
+  }
+`;

--- a/frontend/src/components/TemplateCard/TemplateCard.tsx
+++ b/frontend/src/components/TemplateCard/TemplateCard.tsx
@@ -47,12 +47,12 @@ const TemplateCard = ({ template }: Props) => {
               <AuthorInfo memberName={member.name} />
             </Link>
 
-            <Flex align='center' gap='0.25rem'>
+            <S.TimeContainer>
               <ClockIcon width={ICON_SIZE.X_SMALL} color={theme.color.light.secondary_600} />
               <S.NoWrapTextWrapper>
                 <Text.Small color={theme.color.light.secondary_600}>{formatRelativeTime(modifiedAt)}</Text.Small>
               </S.NoWrapTextWrapper>
-            </Flex>
+            </S.TimeContainer>
           </Flex>
           <Flex align='center' justify='flex-end' flex='0 0 auto'>
             <LikeCounter likesCount={template.likesCount} isLiked={template.isLiked} />


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #642 

## 📍주요 변경 사항
1. 사용자 이름 ellipsis 처리
2. 모바일 환경일 때 템플릿 카드의 시간 숨김
 - 사용자 이름이 너무 길때, 이름을 너무 줄일 수는 없어서 시간을 숨기도록 했습니다.


## 🍗 PR 첫 리뷰 마감 기한
zappp
