### PR TITLE
모바일 환경의 SourceCode 폰트 사이즈 변경

### DIFF
--- a/frontend/src/components/AuthorInfo/AuthorInfo.style.ts
+++ b/frontend/src/components/AuthorInfo/AuthorInfo.style.ts
@@ -26,13 +26,10 @@ export const EllipsisTextWrapper = styled.span`
   display: block;
 
   min-width: 0;
+  max-width: 15.625rem;
 
   text-overflow: ellipsis;
   white-space: nowrap;
-
-  @media (max-width: 1376px) {
-    max-width: 15.625rem;
-  }
 
   @media (max-width: 768px) {
     max-width: 8.125rem;

--- a/frontend/src/components/SourceCode/SourceCode.tsx
+++ b/frontend/src/components/SourceCode/SourceCode.tsx
@@ -39,8 +39,15 @@ const SourceCode = ({ mode = 'detailView', language, content, handleContentChang
       height={mode === 'thumbnailView' ? '10rem' : '100%'}
       minHeight={mode === 'edit' ? '10rem' : undefined}
       maxHeight={mode === 'edit' ? '40rem' : undefined}
-      style={{ width: '100%', fontSize: '1rem' }}
       css={{
+        width: '100%',
+        fontSize: '1rem',
+        '@media (max-width: 430px)': {
+          fontSize: '0.65rem',
+          '.cm-scroller': {
+            padding: '0px !important',
+          },
+        },
         minHeight: '160px',
         backgroundColor: `rgba(0, 0, 0, 0.1)`,
         '.cm-scroller': {


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #642 

## 📍주요 변경 사항
1. 모바일 환경의 SourceCode 폰트 사이즈 변경합니다.

## 🍗 PR 첫 리뷰 마감 기한
zapppp
