### PR TITLE
페이지네이션 처리 시 최대 다음 페이지 수를 5개로 제한

### DIFF
--- a/backend/src/main/java/codezap/global/pagination/FixedPage.java
+++ b/backend/src/main/java/codezap/global/pagination/FixedPage.java
@@ -1,0 +1,6 @@
+package codezap.global.pagination;
+
+import java.util.List;
+
+public record FixedPage<T> (List<T> contents, int nextPages) {
+}

--- a/backend/src/main/java/codezap/global/pagination/FixedPageCounter.java
+++ b/backend/src/main/java/codezap/global/pagination/FixedPageCounter.java
@@ -1,0 +1,34 @@
+package codezap.global.pagination;
+
+import java.util.Objects;
+
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Component;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.EntityPathBase;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+@Component
+public class FixedPageCounter {
+
+    private static final int MAXIMUM_PAGE = 5;
+
+    public int countNextFixedPage(
+            JPAQueryFactory queryFactory,
+            EntityPathBase<?> entityPath,
+            Pageable pageable,
+            BooleanExpression... conditions
+    ) {
+        int maximumElementsCount = pageable.getPageSize() * MAXIMUM_PAGE;
+        long nextFixedElementCounts = Objects.requireNonNull(queryFactory
+                        .selectFrom(entityPath)
+                        .where(conditions)
+                        .offset(pageable.getOffset())
+                        .limit(maximumElementsCount)
+                        .fetch())
+                .size();
+
+        return (int) Math.ceil((double) nextFixedElementCounts / pageable.getPageSize());
+    }
+}

--- a/backend/src/main/java/codezap/global/pagination/FixedPageCounter.java
+++ b/backend/src/main/java/codezap/global/pagination/FixedPageCounter.java
@@ -1,7 +1,5 @@
 package codezap.global.pagination;
 
-import java.util.Objects;
-
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Component;
 
@@ -21,12 +19,12 @@ public class FixedPageCounter {
             BooleanExpression... conditions
     ) {
         int maximumElementsCount = pageable.getPageSize() * MAXIMUM_PAGE;
-        long nextFixedElementCounts = Objects.requireNonNull(queryFactory
-                        .selectFrom(entityPath)
-                        .where(conditions)
-                        .offset(pageable.getOffset())
-                        .limit(maximumElementsCount)
-                        .fetch())
+        long nextFixedElementCounts = queryFactory
+                .selectFrom(entityPath)
+                .where(conditions)
+                .offset(pageable.getOffset())
+                .limit(maximumElementsCount)
+                .fetch()
                 .size();
 
         return (int) Math.ceil((double) nextFixedElementCounts / pageable.getPageSize());

--- a/backend/src/main/java/codezap/likes/repository/LikesJpaRepository.java
+++ b/backend/src/main/java/codezap/likes/repository/LikesJpaRepository.java
@@ -1,10 +1,6 @@
 package codezap.likes.repository;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Query;
-import org.springframework.data.repository.query.Param;
 
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
@@ -17,11 +13,4 @@ public interface LikesJpaRepository extends JpaRepository<Likes, Long> {
     boolean existsByMemberAndTemplate(Member member, Template template);
 
     long countByTemplate(Template template);
-
-    @Query("""
-            SELECT l.template
-            FROM Likes l
-            WHERE l.member.id = :memberId AND (l.template.member.id = :memberId OR l.template.visibility = 'PUBLIC')
-            """)
-    Page<Template> findAllByMemberId(@Param(value = "memberId") Long memberId, Pageable pageable);
 }

--- a/backend/src/main/java/codezap/likes/repository/LikesRepository.java
+++ b/backend/src/main/java/codezap/likes/repository/LikesRepository.java
@@ -2,8 +2,6 @@ package codezap.likes.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import codezap.likes.domain.Likes;
@@ -36,9 +34,5 @@ public class LikesRepository {
 
     public void deleteAllByTemplateIds(List<Long> templateIds) {
         likesQueryDslRepository.deleteAllByTemplateIds(templateIds);
-    }
-
-    public Page<Template> findAllByMemberId(Long memberId, Pageable pageable) {
-        return likesJpaRepository.findAllByMemberId(memberId, pageable);
     }
 }

--- a/backend/src/main/java/codezap/likes/service/LikesService.java
+++ b/backend/src/main/java/codezap/likes/service/LikesService.java
@@ -2,11 +2,11 @@ package codezap.likes.service;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import codezap.global.pagination.FixedPage;
 import codezap.likes.domain.Likes;
 import codezap.likes.repository.LikesRepository;
 import codezap.member.domain.Member;
@@ -36,8 +36,8 @@ public class LikesService {
         return likesRepository.existsByMemberAndTemplate(member, template);
     }
 
-    public Page<Template> findAllByMemberId(Long memberId, Pageable pageable) {
-        return likesRepository.findAllByMemberId(memberId, pageable);
+    public FixedPage<Template> findAllByMemberId(Long memberId, Pageable pageable) {
+        return templateRepository.findAllLikedByMemberId(memberId, pageable);
     }
 
     @Transactional

--- a/backend/src/main/java/codezap/likes/service/LikesService.java
+++ b/backend/src/main/java/codezap/likes/service/LikesService.java
@@ -37,10 +37,6 @@ public class LikesService {
         return likesRepository.existsByMemberAndTemplate(member, template);
     }
 
-    public FixedPage<Template> findAllByMemberId(Long memberId, Pageable pageable) {
-        return templateRepository.findAllLikedByMemberId(memberId, pageable);
-    }
-
     @Transactional
     public void cancelLike(Member member, long templateId) {
         Template template = templateRepository.fetchById(templateId);

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -5,8 +5,8 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FindAllTemplatesResponse(
-        @Schema(description = "다음 페이지 개수, 최대 5개입니다.", example = "1")
-        int nextPages,
+        @Schema(description = "최대 페이지 개수, 최대 5개입니다.", example = "1")
+        int maxPages,
         @Schema(description = "템플릿 목록")
         List<FindAllTemplateItemResponse> templates
 ) {

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -5,10 +5,8 @@ import java.util.List;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FindAllTemplatesResponse(
-        @Schema(description = "전체 페이지 개수", example = "1")
-        int totalPages,
-        @Schema(description = "총 템플릿 개수", example = "134")
-        long totalElements,
+        @Schema(description = "다음 페이지 개수, 최대 5개입니다.", example = "1")
+        int nextPages,
         @Schema(description = "템플릿 목록")
         List<FindAllTemplateItemResponse> templates
 ) {

--- a/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
+++ b/backend/src/main/java/codezap/template/dto/response/FindAllTemplatesResponse.java
@@ -6,7 +6,7 @@ import io.swagger.v3.oas.annotations.media.Schema;
 
 public record FindAllTemplatesResponse(
         @Schema(description = "최대 페이지 개수, 최대 5개입니다.", example = "1")
-        int maxPages,
+        int paginationSizes,
         @Schema(description = "템플릿 목록")
         List<FindAllTemplateItemResponse> templates
 ) {

--- a/backend/src/main/java/codezap/template/repository/TemplateQueryDSLRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateQueryDSLRepository.java
@@ -33,7 +33,7 @@ public class TemplateQueryDSLRepository {
             Pageable pageable
     ) {
         List<Template> content = getTemplates(memberId, keyword, categoryId, tagIds, visibility, pageable);
-        int nextFixedPage = countNextFixedPage(pageable, memberId, keyword, categoryId, tagIds, visibility);
+        int nextFixedPage = countNextFixedPage(memberId, keyword, categoryId, tagIds, visibility, pageable);
         return new FixedPage<>(content, nextFixedPage);
     }
 
@@ -57,12 +57,12 @@ public class TemplateQueryDSLRepository {
     }
 
     private int countNextFixedPage(
-            Pageable pageable,
             Long memberId,
             String keyword,
             Long categoryId,
             List<Long> tagIds,
-            Visibility visibility
+            Visibility visibility,
+            Pageable pageable
     ) {
         return fixedPageCounter.countNextFixedPage(
                 queryFactory,

--- a/backend/src/main/java/codezap/template/repository/TemplateQueryDSLRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateQueryDSLRepository.java
@@ -45,8 +45,7 @@ public class TemplateQueryDSLRepository {
             Visibility visibility,
             Pageable pageable
     ) {
-        return queryFactory
-                .selectFrom(QTemplate.template)
+        return queryFactory.selectFrom(QTemplate.template)
                 .leftJoin(QTemplate.template.category).fetchJoin()
                 .leftJoin(QTemplate.template.member).fetchJoin()
                 .where(matchesKeyword(memberId, keyword, categoryId, tagIds, visibility))
@@ -89,8 +88,7 @@ public class TemplateQueryDSLRepository {
     }
 
     public FixedPage<Template> findAllLikedByMemberId(Long memberId, Pageable pageable) {
-        List<Template> content = queryFactory
-                .select(QLikes.likes.template)
+        List<Template> content = queryFactory.select(QLikes.likes.template)
                 .from(QLikes.likes)
                 .where(isLikedTemplateByMember(memberId))
                 .orderBy(TemplateOrderSpecifierUtils.getOrderSpecifier(pageable.getSort()))

--- a/backend/src/main/java/codezap/template/repository/TemplateQueryDSLRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateQueryDSLRepository.java
@@ -33,7 +33,7 @@ public class TemplateQueryDSLRepository {
             Pageable pageable
     ) {
         List<Template> content = getTemplates(memberId, keyword, categoryId, tagIds, visibility, pageable);
-        int nextFixedPage = countNextFixedPage(memberId, keyword, categoryId, tagIds, visibility, pageable);
+        int nextFixedPage = countMaxPageOfTemplates(memberId, keyword, categoryId, tagIds, visibility, pageable);
         return new FixedPage<>(content, nextFixedPage);
     }
 
@@ -56,7 +56,7 @@ public class TemplateQueryDSLRepository {
                 .fetch();
     }
 
-    private int countNextFixedPage(
+    private int countMaxPageOfTemplates(
             Long memberId,
             String keyword,
             Long categoryId,
@@ -98,10 +98,10 @@ public class TemplateQueryDSLRepository {
                 .limit(pageable.getPageSize())
                 .fetch();
 
-        return new FixedPage<>(content, countNextFixedPage(memberId, pageable));
+        return new FixedPage<>(content, countMaxPageOfLikeTemplates(memberId, pageable));
     }
 
-    private int countNextFixedPage(Long memberId, Pageable pageable) {
+    private int countMaxPageOfLikeTemplates(Long memberId, Pageable pageable) {
         return fixedPageCounter.countNextFixedPage(
                 queryFactory,
                 QLikes.likes,

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -28,7 +28,7 @@ public class TemplateRepository {
         return templateJpaRepository.findByMemberId(id);
     }
 
-    public Page<Template> findAll(
+    public FixedPage<Template> findAll(
             Long memberId, String keyword, Long categoryId, List<Long> tagIds, Visibility visibility, Pageable pageable
     ) {
         return templateQueryDSLRepository.findTemplates(memberId, keyword, categoryId, tagIds, visibility, pageable);

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -2,12 +2,12 @@ package codezap.template.repository;
 
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Repository;
 
 import codezap.global.exception.CodeZapException;
 import codezap.global.exception.ErrorCode;
+import codezap.global.pagination.FixedPage;
 import codezap.template.domain.Template;
 import codezap.template.domain.Visibility;
 import lombok.RequiredArgsConstructor;
@@ -32,6 +32,10 @@ public class TemplateRepository {
             Long memberId, String keyword, Long categoryId, List<Long> tagIds, Visibility visibility, Pageable pageable
     ) {
         return templateQueryDSLRepository.findTemplates(memberId, keyword, categoryId, tagIds, visibility, pageable);
+    }
+
+    public FixedPage<Template> findAllLikedByMemberId(Long memberId, Pageable pageable) {
+        return templateQueryDSLRepository.findAllLikedByMemberId(memberId, pageable);
     }
 
     public boolean existsByCategoryId(Long categoryId) {

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -56,6 +56,10 @@ public class TemplateService {
         return templateRepository.findAll(memberId, keyword, categoryId, tagIds, visibility, pageable);
     }
 
+    public FixedPage<Template> findAllByMemberId(Long memberId, Pageable pageable) {
+        return templateRepository.findAllLikedByMemberId(memberId, pageable);
+    }
+
     @Transactional
     public Template update(
             Member member,

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -3,7 +3,6 @@ package codezap.template.service;
 import java.util.HashSet;
 import java.util.List;
 
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -11,6 +10,7 @@ import org.springframework.transaction.annotation.Transactional;
 import codezap.category.domain.Category;
 import codezap.global.exception.CodeZapException;
 import codezap.global.exception.ErrorCode;
+import codezap.global.pagination.FixedPage;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
 import codezap.template.domain.Visibility;
@@ -45,7 +45,7 @@ public class TemplateService {
         return templateRepository.findByMemberId(memberId);
     }
 
-    public Page<Template> findAllBy(
+    public FixedPage<Template> findAllBy(
             Long memberId,
             String keyword,
             Long categoryId,

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -121,7 +121,7 @@ public class TemplateApplicationService {
     }
 
     public FindAllTemplatesResponse findAllByLiked(Long memberId, Pageable pageable) {
-        FixedPage<Template> likeTemplate = likesService.findAllByMemberId(memberId, pageable);
+        FixedPage<Template> likeTemplate = templateService.findAllByMemberId(memberId, pageable);
         return makeAllTemplatesResponse(likeTemplate, (template -> true));
     }
 

--- a/backend/src/test/java/codezap/global/pagination/FixedPageCounterTest.java
+++ b/backend/src/test/java/codezap/global/pagination/FixedPageCounterTest.java
@@ -1,0 +1,55 @@
+package codezap.global.pagination;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import jakarta.persistence.EntityManager;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.jdbc.Sql;
+
+import com.querydsl.jpa.impl.JPAQueryFactory;
+
+import codezap.global.querydsl.QueryDSLConfig;
+import codezap.global.rds.DataSourceConfig;
+import codezap.template.domain.QTemplate;
+
+@DataJpaTest
+@Import({DataSourceConfig.class, QueryDSLConfig.class, FixedPageCounter.class})
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+@Sql(scripts = "classpath:search.sql", executionPhase = Sql.ExecutionPhase.BEFORE_TEST_METHOD)
+class FixedPageCounterTest {
+
+    @Autowired
+    private EntityManager em;
+
+    private JPAQueryFactory queryFactory;
+    private FixedPageCounter fixedPageCounter;
+
+    @BeforeEach
+    void setUp() {
+        queryFactory = new JPAQueryFactory(em);
+        fixedPageCounter = new FixedPageCounter();
+    }
+
+    @Test
+    @DisplayName("페이지가 10개까지 있어도, 최대 5페이지까지만 카운팅")
+    void countNextFixedPage_WithPageSize10() {
+        PageRequest pageRequest = PageRequest.of(0, 1);
+        QTemplate template = QTemplate.template;
+
+        int nextFixedPage = fixedPageCounter.countNextFixedPage(
+                queryFactory,
+                template,
+                pageRequest
+        );
+
+        assertThat(nextFixedPage).isEqualTo(5);
+    }
+}

--- a/backend/src/test/java/codezap/global/pagination/FixedPageCounterTest.java
+++ b/backend/src/test/java/codezap/global/pagination/FixedPageCounterTest.java
@@ -39,7 +39,7 @@ class FixedPageCounterTest {
     }
 
     @Test
-    @DisplayName("페이지가 10개까지 있어도, 최대 5페이지까지만 카운팅")
+    @DisplayName("페이지가 7개까지 있어도, 최대 5페이지까지만 카운팅")
     void countNextFixedPage_WithPageSize10() {
         PageRequest pageRequest = PageRequest.of(0, 1);
         QTemplate template = QTemplate.template;

--- a/backend/src/test/java/codezap/global/pagination/FixedPageCounterTest.java
+++ b/backend/src/test/java/codezap/global/pagination/FixedPageCounterTest.java
@@ -52,4 +52,19 @@ class FixedPageCounterTest {
 
         assertThat(nextFixedPage).isEqualTo(5);
     }
+
+    @Test
+    @DisplayName("데이터가 최대 페이지보다 적을 경우, 1페이지 반환")
+    void countNextFixedPage_WithPageSize1() {
+        PageRequest pageRequest = PageRequest.of(0, 10);
+        QTemplate template = QTemplate.template;
+
+        int nextFixedPage = fixedPageCounter.countNextFixedPage(
+                queryFactory,
+                template,
+                pageRequest
+        );
+
+        assertThat(nextFixedPage).isEqualTo(1);
+    }
 }

--- a/backend/src/test/java/codezap/global/repository/RepositoryTest.java
+++ b/backend/src/test/java/codezap/global/repository/RepositoryTest.java
@@ -14,6 +14,7 @@ import org.springframework.stereotype.Repository;
 
 import codezap.global.DatabaseIsolation;
 import codezap.global.auditing.JpaAuditingConfiguration;
+import codezap.global.pagination.FixedPageCounter;
 import codezap.global.querydsl.QueryDSLConfig;
 import codezap.global.rds.DataSourceConfig;
 import codezap.template.repository.TemplateSearchExpressionProvider;
@@ -29,7 +30,9 @@ import codezap.template.repository.strategy.LikeSearchStrategy;
         QueryDSLConfig.class,
         TemplateSearchExpressionProvider.class,
         LikeSearchStrategy.class,
-        FullTextSearchSearchStrategy.class})
+        FullTextSearchSearchStrategy.class,
+        FixedPageCounter.class
+})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 public @interface RepositoryTest {
 }

--- a/backend/src/test/java/codezap/likes/repository/LikesRepositoryTest.java
+++ b/backend/src/test/java/codezap/likes/repository/LikesRepositoryTest.java
@@ -10,8 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
@@ -199,38 +197,6 @@ class LikesRepositoryTest {
                     () -> assertThat(likesRepository.countByTemplate(template1)).isEqualTo(0),
                     () -> assertThat(likesRepository.countByTemplate(template2)).isEqualTo(0)
             );
-        }
-    }
-
-    @Nested
-    @DisplayName("회원이 좋아요한 템플릿 조회 테스트")
-    class FindAllByMemberId {
-
-        @Test
-        @DisplayName("성공: 다른 사람의 private은 제외, 내 private은 포함")
-        void findAllByMemberId() {
-            // given
-            Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
-
-            Category category = categoryRepository.save(CategoryFixture.get(member));
-            Category otherCategory = categoryRepository.save(CategoryFixture.get(otherMember));
-
-            Template myPublicTemplate = templateRepository.save(TemplateFixture.get(member, category));
-            Template myPrivateTemplate = templateRepository.save(TemplateFixture.getPrivate(member, category));
-            Template otherPublicTemplate = templateRepository.save(TemplateFixture.get(otherMember, otherCategory));
-            Template otherPrivateTemplate = templateRepository.save(TemplateFixture.getPrivate(otherMember, otherCategory));
-
-            likesRepository.save(new Likes(myPublicTemplate, member));
-            likesRepository.save(new Likes(myPrivateTemplate, member));
-            likesRepository.save(new Likes(otherPublicTemplate, member));
-            likesRepository.save(new Likes(otherPrivateTemplate, member));
-
-            // when
-            Page<Template> actual = likesRepository.findAllByMemberId(member.getId(), PageRequest.of(0, 5));
-
-            // then
-            assertThat(actual).containsExactlyInAnyOrder(myPublicTemplate, myPrivateTemplate, otherPublicTemplate);
         }
     }
 }

--- a/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
+++ b/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 
 import codezap.category.domain.Category;
@@ -18,6 +17,7 @@ import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.ServiceTest;
+import codezap.global.pagination.FixedPage;
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
@@ -202,10 +202,10 @@ class LikesServiceTest extends ServiceTest {
             likesRepository.save(new Likes(template3, member1));
 
             // when
-            Page<Template> actual = likesService.findAllByMemberId(member1.getId(), PageRequest.of(0, 5));
+            FixedPage<Template> actual = templateRepository.findAllLikedByMemberId(member1.getId(), PageRequest.of(0, 5));
 
             // then
-            assertThat(actual).containsExactlyInAnyOrder(template1, template3);
+            assertThat(actual.contents()).containsExactlyInAnyOrder(template1, template3);
         }
     }
 }

--- a/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
+++ b/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
@@ -177,31 +177,4 @@ class LikesServiceTest extends ServiceTest {
             );
         }
     }
-
-    @Nested
-    @DisplayName("좋아요한 템플릿 조회")
-    class FindAllByMemberId {
-
-        @Test
-        @DisplayName("성공")
-        void findAllByMemberId() {
-            // given
-            Member member1 = memberRepository.save(MemberFixture.getFirstMember());
-            Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category1 = categoryRepository.save(CategoryFixture.get(member1));
-            Category category2 = categoryRepository.save(CategoryFixture.get(member2));
-            Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
-            Template template2 = templateRepository.save(TemplateFixture.get(member1, category1));
-            Template template3 = templateRepository.save(TemplateFixture.get(member2, category2));
-            likesRepository.save(new Likes(template1, member1));
-            likesRepository.save(new Likes(template2, member2));
-            likesRepository.save(new Likes(template3, member1));
-
-            // when
-            FixedPage<Template> actual = templateRepository.findAllLikedByMemberId(member1.getId(), PageRequest.of(0, 5));
-
-            // then
-            assertThat(actual.contents()).containsExactlyInAnyOrder(template1, template3);
-        }
-    }
 }

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -267,7 +267,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.nextPages").value(1));
+                    .andExpect(jsonPath("$.maxPages").value(1));
         }
 
         @Test
@@ -287,7 +287,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.nextPages").value(1));
+                    .andExpect(jsonPath("$.maxPages").value(1));
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse() {
@@ -617,7 +617,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.nextPages").value(1));
+                    .andExpect(jsonPath("$.maxPages").value(1));
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse(Member member) {

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -267,7 +267,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.maxPages").value(1));
+                    .andExpect(jsonPath("$.paginationSizes").value(1));
         }
 
         @Test
@@ -287,7 +287,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.maxPages").value(1));
+                    .andExpect(jsonPath("$.paginationSizes").value(1));
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse() {
@@ -617,7 +617,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.maxPages").value(1));
+                    .andExpect(jsonPath("$.paginationSizes").value(1));
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse(Member member) {

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -259,7 +259,7 @@ class TemplateControllerTest extends MockMvcTest {
             FindAllTemplateItemResponse findAllTemplateItemResponse = getFindAllTemplateItemResponse();
 
             when(templateApplicationService.findAllBy(any(), any(), any(), any(), any(), any())).thenReturn(
-                    new FindAllTemplatesResponse(1, 1, List.of(findAllTemplateItemResponse)));
+                    new FindAllTemplatesResponse(1, List.of(findAllTemplateItemResponse)));
 
             // when & then
             mvc.perform(get("/templates")
@@ -267,8 +267,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.totalPages").value(1))
-                    .andExpect(jsonPath("$.totalElements").value(1));
+                    .andExpect(jsonPath("$.nextPages").value(1));
         }
 
         @Test
@@ -280,7 +279,7 @@ class TemplateControllerTest extends MockMvcTest {
             when(credentialManager.hasCredential(any())).thenReturn(false);
             when(credentialManager.getCredential(any())).thenReturn(null);
             when(templateApplicationService.findAllBy(any(), any(), any(), any(), any())).thenReturn(
-                    new FindAllTemplatesResponse(1, 1, List.of(findAllTemplateItemResponse)));
+                    new FindAllTemplatesResponse(1, List.of(findAllTemplateItemResponse)));
 
             // when & then
             mvc.perform(get("/templates")
@@ -288,8 +287,7 @@ class TemplateControllerTest extends MockMvcTest {
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.totalPages").value(1))
-                    .andExpect(jsonPath("$.totalElements").value(1));
+                    .andExpect(jsonPath("$.nextPages").value(1));
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse() {
@@ -613,14 +611,13 @@ class TemplateControllerTest extends MockMvcTest {
             FindAllTemplateItemResponse findAllTemplateItemResponse = getFindAllTemplateItemResponse(member);
 
             when(templateApplicationService.findAllByLiked(any(), any()))
-                    .thenReturn(new FindAllTemplatesResponse(1, 1, List.of(findAllTemplateItemResponse)));
+                    .thenReturn(new FindAllTemplatesResponse(1, List.of(findAllTemplateItemResponse)));
 
             mvc.perform(get("/templates/like")
                             .contentType(MediaType.APPLICATION_JSON))
                     .andExpect(status().isOk())
                     .andExpect(jsonPath("$.templates.size()").value(1))
-                    .andExpect(jsonPath("$.totalPages").value(1))
-                    .andExpect(jsonPath("$.totalElements").value(1));
+                    .andExpect(jsonPath("$.nextPages").value(1));
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse(Member member) {

--- a/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.domain.PageRequest;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
@@ -15,7 +16,10 @@ import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.exception.CodeZapException;
+import codezap.global.pagination.FixedPage;
 import codezap.global.repository.RepositoryTest;
+import codezap.likes.domain.Likes;
+import codezap.likes.repository.LikesRepository;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
 import codezap.template.domain.Template;
@@ -29,6 +33,8 @@ class TemplateRepositoryTest {
     private MemberRepository memberRepository;
     @Autowired
     private CategoryRepository categoryRepository;
+    @Autowired
+    private LikesRepository likesRepository;
 
     @Test
     @DisplayName("카테고리 id로 템플릿 존재 여부 확인 ")
@@ -89,6 +95,38 @@ class TemplateRepositoryTest {
         void findByMemberIdWhenNotExistsMember() {
             Long notSavedId = 1L;
             assertThat(templateRepository.findByMemberId(notSavedId)).isEmpty();
+        }
+    }
+
+    @Nested
+    @DisplayName("회원이 좋아요한 템플릿 조회 테스트")
+    class FindAllByMemberId {
+
+        @Test
+        @DisplayName("성공: 다른 사람의 private은 제외, 내 private은 포함")
+        void findAllByMemberId() {
+            // given
+            Member member = memberRepository.save(MemberFixture.getFirstMember());
+            Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
+
+            Category category = categoryRepository.save(CategoryFixture.get(member));
+            Category otherCategory = categoryRepository.save(CategoryFixture.get(otherMember));
+
+            Template myPublicTemplate = templateRepository.save(TemplateFixture.get(member, category));
+            Template myPrivateTemplate = templateRepository.save(TemplateFixture.getPrivate(member, category));
+            Template otherPublicTemplate = templateRepository.save(TemplateFixture.get(otherMember, otherCategory));
+            Template otherPrivateTemplate = templateRepository.save(TemplateFixture.getPrivate(otherMember, otherCategory));
+
+            likesRepository.save(new Likes(myPublicTemplate, member));
+            likesRepository.save(new Likes(myPrivateTemplate, member));
+            likesRepository.save(new Likes(otherPublicTemplate, member));
+            likesRepository.save(new Likes(otherPrivateTemplate, member));
+
+            // when
+            FixedPage<Template> actual = templateRepository.findAllLikedByMemberId(member.getId(), PageRequest.of(0, 5));
+
+            // then
+            assertThat(actual.contents()).containsExactlyInAnyOrder(myPublicTemplate, myPrivateTemplate, otherPublicTemplate);
         }
     }
 }

--- a/backend/src/test/java/codezap/template/repository/TemplateSearchRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateSearchRepositoryTest.java
@@ -14,7 +14,6 @@ import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Repository;
 import org.springframework.test.context.jdbc.Sql;
@@ -23,9 +22,10 @@ import org.springframework.test.context.jdbc.Sql.ExecutionPhase;
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
 import codezap.global.auditing.JpaAuditingConfiguration;
+import codezap.global.pagination.FixedPage;
+import codezap.global.pagination.FixedPageCounter;
 import codezap.global.querydsl.QueryDSLConfig;
 import codezap.global.rds.DataSourceConfig;
-import codezap.global.repository.RepositoryTest;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
 import codezap.tag.domain.Tag;
@@ -36,12 +36,15 @@ import codezap.template.repository.strategy.FullTextSearchSearchStrategy;
 import codezap.template.repository.strategy.LikeSearchStrategy;
 
 @DataJpaTest(includeFilters = @ComponentScan.Filter(type = FilterType.ANNOTATION, classes = Repository.class), useDefaultFilters = false)
-@Import({JpaAuditingConfiguration.class,
+@Import({
+        JpaAuditingConfiguration.class,
         DataSourceConfig.class,
         QueryDSLConfig.class,
         TemplateSearchExpressionProvider.class,
         LikeSearchStrategy.class,
-        FullTextSearchSearchStrategy.class})
+        FullTextSearchSearchStrategy.class,
+        FixedPageCounter.class,
+})
 @AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
 @Sql(scripts = "classpath:search.sql", executionPhase = ExecutionPhase.BEFORE_TEST_CLASS)
 class TemplateSearchRepositoryTest {
@@ -59,7 +62,7 @@ class TemplateSearchRepositoryTest {
     @DisplayName("검색 테스트: 회원 ID로 템플릿 조회 성공")
     void testFindByMemberId() {
         Member member1 = memberRepository.fetchById(1L);
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 member1.getId(),
                 null,
                 null,
@@ -68,8 +71,8 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(2),
-                () -> assertThat(result.getContent())
+                () -> assertThat(result.contents()).hasSize(2),
+                () -> assertThat(result.contents())
                         .allMatch(template -> template.getMember().getId().equals(member1.getId()))
         );
     }
@@ -78,7 +81,7 @@ class TemplateSearchRepositoryTest {
     @DisplayName("검색 테스트: 키워드로 템플릿 조회 성공")
     void testFindByKeyword() {
         String keyword = "Template";
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 null,
                 keyword,
                 null,
@@ -87,10 +90,10 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent())
+                () -> assertThat(result.contents())
                         .allMatch(template -> template.getTitle().contains(keyword)
                                 || template.getDescription().contains(keyword)),
-                () -> assertThat(result.getContent()).hasSize(4)
+                () -> assertThat(result.contents()).hasSize(4)
         );
     }
 
@@ -98,7 +101,7 @@ class TemplateSearchRepositoryTest {
     @DisplayName("검색 테스트: 카테고리 ID로 템플릿 조회 성공")
     void testFindByCategoryId() {
         Category category1 = categoryRepository.fetchById(1L);
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 null,
                 null,
                 category1.getId(),
@@ -107,8 +110,8 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(2),
-                () -> assertThat(result.getContent())
+                () -> assertThat(result.contents()).hasSize(2),
+                () -> assertThat(result.contents())
                         .allMatch(template -> template.getCategory().getId().equals(category1.getId()))
         );
     }
@@ -119,7 +122,7 @@ class TemplateSearchRepositoryTest {
         Tag tag1 = tagRepository.fetchById(1L);
         Tag tag2 = tagRepository.fetchById(2L);
         List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 null,
                 null,
                 null,
@@ -128,12 +131,12 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent())
+                () -> assertThat(result.contents())
                         .containsExactlyInAnyOrder(
                                 templateRepository.fetchById(1L),
                                 templateRepository.fetchById(2L),
                                 templateRepository.fetchById(3L)),
-                () -> assertThat(result.getContent()).hasSize(3)
+                () -> assertThat(result.contents()).hasSize(3)
         );
     }
 
@@ -142,7 +145,7 @@ class TemplateSearchRepositoryTest {
     void testFindBySingleTagId() {
         Tag tag2 = tagRepository.fetchById(2L);
         List<Long> tagIds = List.of(tag2.getId());
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 null,
                 null,
                 null,
@@ -151,19 +154,19 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent())
+                () -> assertThat(result.contents())
                         .containsExactlyInAnyOrder(
                                 templateRepository.fetchById(1L),
                                 templateRepository.fetchById(2L),
                                 templateRepository.fetchById(3L)),
-                () -> assertThat(result.getContent()).hasSize(3)
+                () -> assertThat(result.contents()).hasSize(3)
         );
     }
 
     @Test
     @DisplayName("검색 테스트: 공개 범위로 템플릿 조회 성공")
     void testFindByVisibility() {
-        Page<Template> actual = templateRepository.findAll(
+        FixedPage<Template> actual = templateRepository.findAll(
                 null,
                 null,
                 null,
@@ -171,7 +174,7 @@ class TemplateSearchRepositoryTest {
                 Visibility.PRIVATE,
                 PageRequest.of(0, 10));
 
-        assertThat(actual.getContent()).hasSize(1)
+        assertThat(actual.contents()).hasSize(1)
                 .containsExactlyInAnyOrder(templateRepository.fetchById(4L));
     }
 
@@ -180,7 +183,7 @@ class TemplateSearchRepositoryTest {
     void testFindByMemberIdAndKeyword() {
         Member member1 = memberRepository.fetchById(1L);
         String keyword = "Template";
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 member1.getId(),
                 keyword,
                 null,
@@ -189,8 +192,8 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(2),
-                () -> assertThat(result.getContent())
+                () -> assertThat(result.contents()).hasSize(2),
+                () -> assertThat(result.contents())
                         .allMatch(template -> template.getMember().getId().equals(member1.getId())
                                 && (template.getTitle().contains(keyword)
                                 || template.getDescription().contains(keyword)))
@@ -202,7 +205,7 @@ class TemplateSearchRepositoryTest {
     void testFindByMemberIdAndCategoryId() {
         Member member1 = memberRepository.fetchById(1L);
         Category category1 = categoryRepository.fetchById(1L);
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 member1.getId(),
                 null,
                 category1.getId(),
@@ -211,9 +214,9 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(1),
-                () -> assertThat(result.getContent().get(0).getMember().getId()).isEqualTo(member1.getId()),
-                () -> assertThat(result.getContent().get(0).getCategory().getId()).isEqualTo(category1.getId())
+                () -> assertThat(result.contents()).hasSize(1),
+                () -> assertThat(result.contents().get(0).getMember().getId()).isEqualTo(member1.getId()),
+                () -> assertThat(result.contents().get(0).getCategory().getId()).isEqualTo(category1.getId())
         );
     }
 
@@ -224,7 +227,7 @@ class TemplateSearchRepositoryTest {
         Tag tag1 = tagRepository.fetchById(1L);
         Tag tag2 = tagRepository.fetchById(2L);
         List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 member1.getId(),
                 null,
                 null,
@@ -233,8 +236,8 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(2),
-                () -> assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
+                () -> assertThat(result.contents()).hasSize(2),
+                () -> assertThat(result.contents()).containsExactlyInAnyOrder(templateRepository.fetchById(1L),
                         templateRepository.fetchById(2L))
         );
     }
@@ -243,7 +246,7 @@ class TemplateSearchRepositoryTest {
     @DisplayName("검색 테스트: 회원 ID와 공개 범위로 템플릿 조회 성공")
     void testFindByMemberIdAndVisibility() {
         Member member1 = memberRepository.fetchById(2L);
-        Page<Template> actual = templateRepository.findAll(
+        FixedPage<Template> actual = templateRepository.findAll(
                 member1.getId(),
                 null,
                 null,
@@ -251,7 +254,7 @@ class TemplateSearchRepositoryTest {
                 Visibility.PUBLIC,
                 PageRequest.of(0, 10));
 
-        assertThat(actual.getContent()).hasSize(1)
+        assertThat(actual.contents()).hasSize(1)
                 .containsExactlyInAnyOrder(templateRepository.fetchById(3L));
     }
 
@@ -264,7 +267,7 @@ class TemplateSearchRepositoryTest {
         Tag tag2 = tagRepository.fetchById(2L);
         String keyword = "Template";
         List<Long> tagIds = Arrays.asList(tag1.getId(), tag2.getId());
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 member1.getId(),
                 keyword,
                 category1.getId(),
@@ -273,15 +276,15 @@ class TemplateSearchRepositoryTest {
                 PageRequest.of(0, 10));
 
         assertAll(
-                () -> assertThat(result.getContent()).hasSize(1),
-                () -> assertThat(result.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
+                () -> assertThat(result.contents()).hasSize(1),
+                () -> assertThat(result.contents()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
         );
     }
 
     @Test
     @DisplayName("검색 테스트: 검색 결과가 없는 경우 빈 리스트 반환 성공")
     void testFindWithNoResults() {
-        Page<Template> result = templateRepository.findAll(
+        FixedPage<Template> result = templateRepository.findAll(
                 null,
                 "없지롱",
                 null,
@@ -289,6 +292,6 @@ class TemplateSearchRepositoryTest {
                 null,
                 PageRequest.of(0, 10));
 
-        assertThat(result.getContent()).isEmpty();
+        assertThat(result.contents()).isEmpty();
     }
 }

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -13,7 +13,6 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 
@@ -23,6 +22,7 @@ import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.DatabaseIsolation;
 import codezap.global.exception.CodeZapException;
+import codezap.global.pagination.FixedPage;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
 import codezap.tag.domain.Tag;
@@ -103,9 +103,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getMember().getId().equals(member1.getId()))
                     .toArray(Template[]::new));
         }
@@ -136,9 +136,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getTitle().contains(keyword) || template.getDescription().contains(keyword))
                     .toArray(Template[]::new));
         }
@@ -153,9 +153,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getCategory().getId().equals(category1.getId()))
                     .toArray(Template[]::new));
         }
@@ -170,15 +170,15 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertAll(
-                    () -> assertThat(actual.getContent())
+                    () -> assertThat(actual.contents())
                             .containsExactlyInAnyOrder(
                                     templateRepository.fetchById(1L),
                                     templateRepository.fetchById(2L),
                                     templateRepository.fetchById(3L)),
-                    () -> assertThat(actual.getContent()).hasSize(3)
+                    () -> assertThat(actual.contents()).hasSize(3)
             );
         }
 
@@ -192,14 +192,14 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertAll(
-                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(
+                    () -> assertThat(actual.contents()).containsExactlyInAnyOrder(
                             templateRepository.fetchById(1L),
                             templateRepository.fetchById(2L),
                             templateRepository.fetchById(3L)),
-                    () -> assertThat(actual.getContent()).hasSize(3)
+                    () -> assertThat(actual.contents()).hasSize(3)
             );
         }
 
@@ -213,9 +213,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = Visibility.PUBLIC;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getVisibility().equals(visibility))
                     .toArray(Template[]::new));
         }
@@ -230,9 +230,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getMember().getId().equals(member1.getId())
                             && (template.getTitle().contains(keyword) || template.getDescription().contains(keyword)))
                     .toArray(Template[]::new));
@@ -248,9 +248,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getMember().getId().equals(member1.getId()) && template.getCategory()
                             .getId().equals(category1.getId()))
                     .toArray(Template[]::new));
@@ -266,11 +266,11 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(2),
-                    () -> assertThat(actual.getContent())
+                    () -> assertThat(actual.contents()).hasSize(2),
+                    () -> assertThat(actual.contents())
                             .containsExactlyInAnyOrder(
                                     templateRepository.fetchById(1L),
                                     templateRepository.fetchById(2L))
@@ -287,9 +287,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = Visibility.PUBLIC;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).containsExactlyInAnyOrder(templates.stream()
+            assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
                     .filter(template -> template.getMember().getId().equals(member2.getId())
                             && template.getVisibility().equals(visibility))
                     .toArray(Template[]::new));
@@ -305,11 +305,11 @@ class TemplateSearchServiceTest {
             Visibility visibility = Visibility.PUBLIC;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(1),
-                    () -> assertThat(actual.getContent()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
+                    () -> assertThat(actual.contents()).hasSize(1),
+                    () -> assertThat(actual.contents()).containsExactlyInAnyOrder(templateRepository.fetchById(1L))
             );
         }
 
@@ -323,9 +323,9 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(0, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
-            assertThat(actual.getContent()).isEmpty();
+            assertThat(actual.contents()).isEmpty();
         }
     }
 
@@ -352,14 +352,13 @@ class TemplateSearchServiceTest {
             Visibility visibility = null;
             Pageable pageable = PageRequest.of(1, 10);
 
-            Page<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
+            FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertAll(
-                    () -> assertThat(actual.getContent()).hasSize(5),
-                    () -> assertThat(actual.getContent().get(0).getId()).isEqualTo(11L)
+                    () -> assertThat(actual.contents()).hasSize(5),
+                    () -> assertThat(actual.contents().get(0).getId()).isEqualTo(11L)
             );
         }
-
     }
 
     private void saveInitialData() {

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -10,7 +10,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
@@ -21,6 +20,7 @@ import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
+import codezap.global.pagination.FixedPage;
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
 import codezap.template.domain.Template;
@@ -152,7 +152,7 @@ class TemplateServiceTest extends ServiceTest {
 
             List<Template> templates = sut.findAllBy(null, "", null, null, null,
                             PageRequest.of(0, 10, Sort.by(Direction.DESC, "likesCount")))
-                    .getContent();
+                    .contents();
 
             assertThat(templates).containsExactly(
                     templateRepository.fetchById(3L),
@@ -279,10 +279,10 @@ class TemplateServiceTest extends ServiceTest {
             var template2 = templateRepository.save(TemplateFixture.get(member, category));
 
             sut.deleteByMemberAndIds(member, List.of(template1.getId()));
-            Page<Template> actual = sut.findAllBy(member.getId(), null, null, null, null,
+            FixedPage<Template> actual = sut.findAllBy(member.getId(), null, null, null, null,
                     PageRequest.of(0, 10));
 
-            assertThat(actual.getContent()).hasSize(1)
+            assertThat(actual.contents()).hasSize(1)
                     .containsExactly(template2);
         }
 
@@ -297,10 +297,10 @@ class TemplateServiceTest extends ServiceTest {
             var template4 = templateRepository.save(TemplateFixture.get(member, category));
 
             sut.deleteByMemberAndIds(member, List.of(template1.getId(), template4.getId()));
-            Page<Template> actual = sut.findAllBy(member.getId(), null, null, null, null,
+            FixedPage<Template> actual = sut.findAllBy(member.getId(), null, null, null, null,
                     PageRequest.of(0, 10));
 
-            assertThat(actual.getContent()).hasSize(2)
+            assertThat(actual.contents()).hasSize(2)
                     .containsExactly(template2, template3);
         }
 

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -191,6 +191,34 @@ class TemplateServiceTest extends ServiceTest {
         }
     }
 
+
+    @Nested
+    @DisplayName("좋아요한 템플릿 조회")
+    class FindAllByMemberId {
+
+        @Test
+        @DisplayName("성공")
+        void findAllByMemberId() {
+            // given
+            Member member1 = memberRepository.save(MemberFixture.getFirstMember());
+            Member member2 = memberRepository.save(MemberFixture.getSecondMember());
+            Category category1 = categoryRepository.save(CategoryFixture.get(member1));
+            Category category2 = categoryRepository.save(CategoryFixture.get(member2));
+            Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            Template template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            Template template3 = templateRepository.save(TemplateFixture.get(member2, category2));
+            likesRepository.save(new Likes(template1, member1));
+            likesRepository.save(new Likes(template2, member2));
+            likesRepository.save(new Likes(template3, member1));
+
+            // when
+            FixedPage<Template> actual = templateRepository.findAllLikedByMemberId(member1.getId(), PageRequest.of(0, 5));
+
+            // then
+            assertThat(actual.contents()).containsExactlyInAnyOrder(template1, template3);
+        }
+    }
+
     @Nested
     @DisplayName("템플릿 수정")
     class UpdateTemplate {

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -530,8 +530,8 @@ class TemplateApplicationServiceTest extends ServiceTest {
             actualSourceCodeLeft.addAll(sourceCodeRepository.findAllByTemplate(template3));
 
             assertAll(
-                    () -> assertThat(actualTemplatesLeft).containsExactly(template3),
-                    () -> assertThat(actualTemplatesLeft).doesNotContain(template1, template2),
+                    () -> assertThat(actualTemplatesLeft.contents()).containsExactly(template3),
+                    () -> assertThat(actualTemplatesLeft.contents()).doesNotContain(template1, template2),
                     () -> assertThat(actualSourceCodeLeft).containsExactly(sourceCode3),
                     () -> assertThat(actualSourceCodeLeft).doesNotContain(sourceCode1, sourceCode2)
             );

--- a/backend/src/test/resources/search.sql
+++ b/backend/src/test/resources/search.sql
@@ -15,6 +15,9 @@ VALUES (1, '2024-09-27 08:43:08.752936', '2024-09-27 08:43:08.752936', '몰리',
 INSERT INTO member (id, created_at, modified_at, name, password, salt)
 VALUES (2, '2024-09-27 08:43:08.757482', '2024-09-27 08:43:08.757482', '몰리2', 'password1234', 'salt2');
 
+INSERT INTO member (id, created_at, modified_at, name, password, salt)
+VALUES (3, '2024-09-27 08:43:08.757482', '2024-09-27 08:43:08.757482', '몰리3', 'password1234', 'salt2');
+
 -- Category 삽입
 INSERT INTO category (id, created_at, is_default, member_id, modified_at, name)
 VALUES (1, '2024-09-27 08:43:08.760511', false, 1, '2024-09-27 08:43:08.760511', 'Category 1');
@@ -41,6 +44,16 @@ VALUES (3, 1, '2024-09-27 08:43:08.790778', 'Description 1', 2, '2024-09-27 08:4
 
 INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title, visibility)
 VALUES (4, 2, '2024-09-27 08:43:08.790780', 'Description 1', 2, '2024-09-27 08:43:08.790780', 'Template 1', 'PRIVATE');
+
+INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title, visibility)
+VALUES (5, 2, '2024-09-27 08:43:08.790780', 'Description 1', 3, '2024-09-27 08:43:08.790780', '템플릿1', 'PUBLIC');
+
+INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title, visibility)
+VALUES (6, 2, '2024-09-27 08:43:08.790780', 'Description 1', 3, '2024-09-27 08:43:08.790780', '템플릿2', 'PUBLIC');
+
+INSERT INTO template (id, category_id, created_at, description, member_id, modified_at, title, visibility)
+VALUES (7, 2, '2024-09-27 08:43:08.790780', 'Description 1', 3, '2024-09-27 08:43:08.790780', '템플릿3', 'PUBLIC');
+
 
 -- Source Code 삽입
 INSERT INTO source_code (id, content, created_at, filename, modified_at, ordinal, template_id)
@@ -90,7 +103,7 @@ WHERE table_name = 'template'
   AND index_name = 'idx_template_fulltext';
 
 -- 없다면 전문 검색 인덱스 생성
-SET @createIndex = IF(@indexExists = 0, 'CREATE FULLTEXT INDEX idx_template_fulltext ON template (title, description);', 'SELECT 1');
+SET @createIndex = IF(@indexExists = 0, 'CREATE FULLTEXT INDEX idx_template_fulltext ON template (title, description) with parser ngram;', 'SELECT 1');
 PREPARE stmt FROM @createIndex;
 EXECUTE stmt;
 DEALLOCATE PREPARE stmt;


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #899

## 📍주요 변경 사항
1. 목록 조회에서 페이지네이션이 들어갈 경우, Page 반환타입은 전체 페이지와 요소 갯수를 반환합니다.
그 과정에서 전체 로우를 풀스캔하기 때문에 비효율적입니다.

(조회 조건에 해당되는 컬럼이 100만건이라면 100만 로우를 전체 카운팅)

현재 페이지네이션 바가 5개까지 나타나기 때문에 전체 로우를 카운팅하지 않고 현재 페이지 포함 5개 페이지까지가 있는지 반환합니다.
```
예) 
조건에 맞는 전체 페이지가 10개인 경우: nextPages는 5개 
조건에 맞는 전체 페이지가 1개인 경우: nextPages는 1개 
```

2. `내가 좋아요한 템플릿 목록 조회 API`에서 동일한 페이지네이션 바가 사용되기 때문에 `템플릿 목록 조회 API`와 동일하게 5개까지만 반환하는 처리를 하였습니다.
그 과정에서 `내가 좋아요한 "템플릿" 목록 조회` 레포지토리 메서드를 template 패키지로 이동하였습니다. (이전 담당자와 상의 완, 참고바람~~)

## 🎸기타
> 관련 논의 디스커션 참고: [템플릿 목록 응답의 전체 템플릿 수의 필요성에 대해 이야기해봐요](https://github.com/woowacourse-teams/2024-code-zap/discussions/778)

+) Repository 단 테스트 시에 관련 Config 들을 Import해야하는데 @TemplateSearchRepositoryTest와 @RepositoryTest의 @Import가 중복으로 수정되네욥ㅠ 이번 PR에서 변경사항이 많이 잡힐 것 같아 따로 PR 올릴게욥

## 🍗 PR 첫 리뷰 마감 기한
11/11 18:00
