### PR TITLE
totalPages => paginationSizes 로 변경

### DIFF
--- a/frontend/src/components/PagingButtons/PagingButtons.stories.tsx
+++ b/frontend/src/components/PagingButtons/PagingButtons.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof PagingButtons> = {
   title: 'PagingButtons',
   component: PagingButtons,
   args: {
-    maxPages: 5,
+    paginationSizes: 5,
     onPageChange: () => {},
   },
 };

--- a/frontend/src/components/PagingButtons/PagingButtons.stories.tsx
+++ b/frontend/src/components/PagingButtons/PagingButtons.stories.tsx
@@ -6,7 +6,7 @@ const meta: Meta<typeof PagingButtons> = {
   title: 'PagingButtons',
   component: PagingButtons,
   args: {
-    totalPages: 6,
+    maxPages: 5,
     onPageChange: () => {},
   },
 };

--- a/frontend/src/components/PagingButtons/PagingButtons.tsx
+++ b/frontend/src/components/PagingButtons/PagingButtons.tsx
@@ -6,28 +6,25 @@ import * as S from './PagingButtons.style';
 
 interface Props {
   currentPage: number;
-  totalPages: number;
+  maxPages: number;
   onPageChange: (page: number) => void;
 }
 
-const PagingButtons = ({ currentPage, totalPages, onPageChange }: Props) => {
+const PagingButtons = ({ currentPage, maxPages, onPageChange }: Props) => {
   const getPageNumbers = () => {
-    const startPage = Math.max(1, Math.min(currentPage - 2, totalPages - 4));
-    const endPage = Math.min(totalPages, startPage + 4);
+    const startPage = Math.max(1, Math.min(currentPage - 2, currentPage + maxPages - 5));
+    const endPage = Math.min(currentPage + maxPages - 1, startPage + 4);
 
     return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
   };
 
   const handlePagingClick = (page: number, label: string) => {
-    trackMyTemplatePaging({ page, totalPages, label });
+    trackMyTemplatePaging({ page, label });
     onPageChange(page);
   };
 
   return (
     <S.PagingContainer>
-      <PagingButton page={1} disabled={currentPage === 1} onClick={handlePagingClick} label='<<' />
-      <PagingButton page={currentPage - 1} disabled={currentPage === 1} onClick={handlePagingClick} label='<' />
-
       {getPageNumbers().map((page) => (
         <PagingButton
           key={page}
@@ -37,14 +34,6 @@ const PagingButtons = ({ currentPage, totalPages, onPageChange }: Props) => {
           label={String(page)}
         />
       ))}
-
-      <PagingButton
-        page={currentPage + 1}
-        disabled={currentPage === totalPages}
-        onClick={handlePagingClick}
-        label='>'
-      />
-      <PagingButton page={totalPages} disabled={currentPage === totalPages} onClick={handlePagingClick} label='>>' />
     </S.PagingContainer>
   );
 };

--- a/frontend/src/components/PagingButtons/PagingButtons.tsx
+++ b/frontend/src/components/PagingButtons/PagingButtons.tsx
@@ -6,14 +6,14 @@ import * as S from './PagingButtons.style';
 
 interface Props {
   currentPage: number;
-  maxPages: number;
+  paginationSizes: number;
   onPageChange: (page: number) => void;
 }
 
-const PagingButtons = ({ currentPage, maxPages, onPageChange }: Props) => {
+const PagingButtons = ({ currentPage, paginationSizes, onPageChange }: Props) => {
   const getPageNumbers = () => {
-    const startPage = Math.max(1, Math.min(currentPage - 2, currentPage + maxPages - 5));
-    const endPage = Math.min(currentPage + maxPages - 1, startPage + 4);
+    const startPage = Math.max(1, Math.min(currentPage - 2, currentPage + paginationSizes - 5));
+    const endPage = Math.min(currentPage + paginationSizes - 1, startPage + 4);
 
     return Array.from({ length: endPage - startPage + 1 }, (_, i) => startPage + i);
   };

--- a/frontend/src/components/PagingButtons/PagingButtons.tsx
+++ b/frontend/src/components/PagingButtons/PagingButtons.tsx
@@ -25,6 +25,7 @@ const PagingButtons = ({ currentPage, paginationSizes, onPageChange }: Props) =>
 
   return (
     <S.PagingContainer>
+      <PagingButton page={currentPage - 1} disabled={currentPage === 1} onClick={handlePagingClick} label='<' />
       {getPageNumbers().map((page) => (
         <PagingButton
           key={page}
@@ -34,6 +35,7 @@ const PagingButtons = ({ currentPage, paginationSizes, onPageChange }: Props) =>
           label={String(page)}
         />
       ))}
+      <PagingButton page={currentPage + 1} disabled={paginationSizes === 1} onClick={handlePagingClick} label='>' />
     </S.PagingContainer>
   );
 };
@@ -48,7 +50,9 @@ interface PagingButtonProps {
 
 const PagingButton = ({ page, isActive, disabled, onClick, label }: PagingButtonProps) => (
   <S.PagingButton isActive={isActive} disabled={disabled || isActive} onClick={() => onClick(page ?? 1, label)}>
-    <Text.Small color={isActive ? theme.color.light.white : theme.color.light.secondary_500}>{label}</Text.Small>
+    {!disabled && (
+      <Text.Small color={isActive ? theme.color.light.white : theme.color.light.secondary_500}>{label}</Text.Small>
+    )}
   </S.PagingButton>
 );
 

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -62,7 +62,7 @@ export const templateHandlers = [
     }
 
     const totalElements = filteredTemplates.length;
-    const maxPages = Math.min(Math.ceil(totalElements / size - page + 1), 5);
+    const paginationSizes = Math.min(Math.ceil(totalElements / size - page + 1), 5);
     const startIndex = (page - 1) * size;
     const endIndex = startIndex + size;
     const paginatedTemplates = filteredTemplates.slice(startIndex, endIndex);
@@ -71,7 +71,7 @@ export const templateHandlers = [
     return HttpResponse.json({
       status: 200,
       templates: paginatedTemplates,
-      maxPages,
+      paginationSizes,
       totalElements,
       numberOfElements,
     });

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -61,8 +61,7 @@ export const templateHandlers = [
         break;
     }
 
-    const totalElements = filteredTemplates.length;
-    const paginationSizes = Math.min(Math.ceil(totalElements / size - page + 1), 5);
+    const paginationSizes = Math.min(Math.ceil(filteredTemplates.length / size - page + 1), 5);
     const startIndex = (page - 1) * size;
     const endIndex = startIndex + size;
     const paginatedTemplates = filteredTemplates.slice(startIndex, endIndex);
@@ -72,7 +71,6 @@ export const templateHandlers = [
       status: 200,
       templates: paginatedTemplates,
       paginationSizes,
-      totalElements,
       numberOfElements,
     });
   }),

--- a/frontend/src/mocks/handlers.ts
+++ b/frontend/src/mocks/handlers.ts
@@ -62,7 +62,7 @@ export const templateHandlers = [
     }
 
     const totalElements = filteredTemplates.length;
-    const totalPages = Math.ceil(totalElements / size);
+    const maxPages = Math.min(Math.ceil(totalElements / size - page + 1), 5);
     const startIndex = (page - 1) * size;
     const endIndex = startIndex + size;
     const paginatedTemplates = filteredTemplates.slice(startIndex, endIndex);
@@ -71,7 +71,7 @@ export const templateHandlers = [
     return HttpResponse.json({
       status: 200,
       templates: paginatedTemplates,
-      totalPages,
+      maxPages,
       totalElements,
       numberOfElements,
     });

--- a/frontend/src/pages/MyLikedTemplatePage/MyLikedTemplatePage.tsx
+++ b/frontend/src/pages/MyLikedTemplatePage/MyLikedTemplatePage.tsx
@@ -36,7 +36,7 @@ const MyLikedTemplatePage = () => {
 
   const { data: templateData, isLoading, isPending, isFetching } = useLikedTemplateListQuery({ page });
   const templateList = templateData?.templates || [];
-  const maxPages = templateData?.maxPages || 0;
+  const paginationSizes = templateData?.paginationSizes || 0;
 
   if (!isMine) {
     return <ForbiddenPage />;
@@ -74,7 +74,7 @@ const MyLikedTemplatePage = () => {
 
       {templateList.length !== 0 && (
         <Flex justify='center' gap='0.5rem' margin='1rem 0' width='100%'>
-          <PagingButtons currentPage={page} maxPages={maxPages} onPageChange={handlePageChange} />
+          <PagingButtons currentPage={page} paginationSizes={paginationSizes} onPageChange={handlePageChange} />
         </Flex>
       )}
     </>

--- a/frontend/src/pages/MyLikedTemplatePage/MyLikedTemplatePage.tsx
+++ b/frontend/src/pages/MyLikedTemplatePage/MyLikedTemplatePage.tsx
@@ -36,7 +36,7 @@ const MyLikedTemplatePage = () => {
 
   const { data: templateData, isLoading, isPending, isFetching } = useLikedTemplateListQuery({ page });
   const templateList = templateData?.templates || [];
-  const totalPages = templateData?.totalPages || 0;
+  const maxPages = templateData?.maxPages || 0;
 
   if (!isMine) {
     return <ForbiddenPage />;
@@ -74,7 +74,7 @@ const MyLikedTemplatePage = () => {
 
       {templateList.length !== 0 && (
         <Flex justify='center' gap='0.5rem' margin='1rem 0' width='100%'>
-          <PagingButtons currentPage={page} totalPages={totalPages} onPageChange={handlePageChange} />
+          <PagingButtons currentPage={page} maxPages={maxPages} onPageChange={handlePageChange} />
         </Flex>
       )}
     </>

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -40,7 +40,7 @@ const MyTemplatePage = () => {
     templateList,
     isTemplateListFetching,
     isTemplateListLoading,
-    totalPages,
+    maxPages,
     dropdownProps,
     keyword,
     page,
@@ -129,7 +129,7 @@ const MyTemplatePage = () => {
 
           {templateList.length !== 0 && (
             <Flex justify='center' gap='0.5rem' margin='1rem 0'>
-              <PagingButtons currentPage={page} totalPages={totalPages} onPageChange={handlePageChange} />
+              <PagingButtons currentPage={page} maxPages={maxPages} onPageChange={handlePageChange} />
             </Flex>
           )}
         </Flex>

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -40,7 +40,7 @@ const MyTemplatePage = () => {
     templateList,
     isTemplateListFetching,
     isTemplateListLoading,
-    maxPages,
+    paginationSizes,
     dropdownProps,
     keyword,
     page,
@@ -129,7 +129,7 @@ const MyTemplatePage = () => {
 
           {templateList.length !== 0 && (
             <Flex justify='center' gap='0.5rem' margin='1rem 0'>
-              <PagingButtons currentPage={page} maxPages={maxPages} onPageChange={handlePageChange} />
+              <PagingButtons currentPage={page} paginationSizes={paginationSizes} onPageChange={handlePageChange} />
             </Flex>
           )}
         </Flex>

--- a/frontend/src/pages/MyTemplatesPage/hooks/useFilteredTemplateList.ts
+++ b/frontend/src/pages/MyTemplatesPage/hooks/useFilteredTemplateList.ts
@@ -39,7 +39,7 @@ export const useFilteredTemplateList = ({ memberId: passedMemberId }: Props) => 
   });
 
   const templateList = templateData?.templates || [];
-  const totalPages = templateData?.totalPages || 0;
+  const maxPages = templateData?.maxPages || 0;
 
   useEffect(() => {
     if (queryParams.sort === sortingOption.value) {
@@ -87,7 +87,7 @@ export const useFilteredTemplateList = ({ memberId: passedMemberId }: Props) => 
     templateList,
     isTemplateListFetching,
     isTemplateListLoading,
-    totalPages,
+    maxPages,
     dropdownProps,
     keyword,
     page,

--- a/frontend/src/pages/MyTemplatesPage/hooks/useFilteredTemplateList.ts
+++ b/frontend/src/pages/MyTemplatesPage/hooks/useFilteredTemplateList.ts
@@ -39,7 +39,7 @@ export const useFilteredTemplateList = ({ memberId: passedMemberId }: Props) => 
   });
 
   const templateList = templateData?.templates || [];
-  const maxPages = templateData?.maxPages || 0;
+  const paginationSizes = templateData?.paginationSizes || 0;
 
   useEffect(() => {
     if (queryParams.sort === sortingOption.value) {
@@ -87,7 +87,7 @@ export const useFilteredTemplateList = ({ memberId: passedMemberId }: Props) => 
     templateList,
     isTemplateListFetching,
     isTemplateListLoading,
-    maxPages,
+    paginationSizes,
     dropdownProps,
     keyword,
     page,

--- a/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
+++ b/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
@@ -158,7 +158,7 @@ const TemplateList = ({
     tagIds,
   });
   const templateList = templateData?.templates || [];
-  const maxPages = templateData?.maxPages || 0;
+  const paginationSizes = templateData?.paginationSizes || 0;
 
   const windowWidth = useWindowWidth();
 
@@ -190,7 +190,7 @@ const TemplateList = ({
 
       {templateList.length !== 0 && (
         <Flex justify='center' gap='0.5rem' margin='1rem 0' width='100%'>
-          <PagingButtons currentPage={page} maxPages={maxPages} onPageChange={handlePageChange} />
+          <PagingButtons currentPage={page} paginationSizes={paginationSizes} onPageChange={handlePageChange} />
         </Flex>
       )}
     </>

--- a/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
+++ b/frontend/src/pages/TemplateExplorePage/TemplateExplorePage.tsx
@@ -158,7 +158,7 @@ const TemplateList = ({
     tagIds,
   });
   const templateList = templateData?.templates || [];
-  const totalPages = templateData?.totalPages || 0;
+  const maxPages = templateData?.maxPages || 0;
 
   const windowWidth = useWindowWidth();
 
@@ -190,7 +190,7 @@ const TemplateList = ({
 
       {templateList.length !== 0 && (
         <Flex justify='center' gap='0.5rem' margin='1rem 0' width='100%'>
-          <PagingButtons currentPage={page} totalPages={totalPages} onPageChange={handlePageChange} />
+          <PagingButtons currentPage={page} maxPages={maxPages} onPageChange={handlePageChange} />
         </Flex>
       )}
     </>

--- a/frontend/src/service/amplitude/track.ts
+++ b/frontend/src/service/amplitude/track.ts
@@ -50,14 +50,12 @@ export const trackClickTemplateShare = () => {
 
 interface PagingButtonData {
   page: number;
-  totalPages: number;
   label: string;
 }
 
-export const trackMyTemplatePaging = ({ page, totalPages, label }: PagingButtonData) => {
+export const trackMyTemplatePaging = ({ page, label }: PagingButtonData) => {
   amplitudeService.customTrack('[Click] 페이징 버튼', {
     page,
-    totalPages,
     label,
   });
 };

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2,7 +2,7 @@ import { Category, SourceCodes, Tag, TemplateListItem, TemplateVisibility } from
 
 export interface TemplateListResponse {
   templates: TemplateListItem[];
-  maxPages: number;
+  paginationSizes: number;
 }
 
 export interface TemplateUploadRequest {

--- a/frontend/src/types/api.ts
+++ b/frontend/src/types/api.ts
@@ -2,8 +2,7 @@ import { Category, SourceCodes, Tag, TemplateListItem, TemplateVisibility } from
 
 export interface TemplateListResponse {
   templates: TemplateListItem[];
-  totalPages: number;
-  totalElements: number;
+  maxPages: number;
 }
 
 export interface TemplateUploadRequest {


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #899 

## 📍주요 변경 사항
- 검색 성능을 올리기 위해 백엔드와 함께 api를 변경하였습니다. 이에 따라 totalPages와 totalElements 를 제거하고, paginationSizes를 적용하였습니다. (paginationSizes 는 **현재 페이지를 포함**하여 다음에 몇 페이지까지 있는지를 반환하는 **`number`** 입니다.)

- `<<`, `<`, `>`, `>>` 버튼 모두 삭제하였습니다.


## 🎸기타
- (관련 백엔드 api 변경 PR) #902  
- 아래와 같이 api 변경될 예정이라고 합니다.
![image (4)](https://github.com/user-attachments/assets/3295b199-785d-4a71-8a0b-e7c5531ff1b4)

- (11/13 업데이트) paginationSizes로 변수명이 변경되었습니다. 

## 🍗 PR 첫 리뷰 마감 기한
11/14 12:30
