### PR TITLE
태그가 중복 저장되는 버그 해결

### DIFF
--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -69,7 +69,7 @@ class TagServiceTest extends ServiceTest {
         }
 
         @Test
-        @DisplayName("성공: 저장하려는 태그에 중복이 있는 경우 하나만")
+        @DisplayName("성공: 저장하려는 태그에 중복이 있는 경우 하나만 생성")
         void createTags_WhenDuplicatedTemplateTag() {
             // given
             Template template = createSavedTemplate();

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -69,6 +69,23 @@ class TagServiceTest extends ServiceTest {
         }
 
         @Test
+        @DisplayName("성공: 저장하려는 태그에 중복이 있는 경우 하나만")
+        void createTags_WhenDuplicatedTemplateTag() {
+            // given
+            Template template = createSavedTemplate();
+            String tagName = "tag1";
+            List<String> tagNames = Arrays.asList(tagName, tagName);
+
+            // when
+            sut.createTags(template, tagNames);
+
+            // then
+            List<String> savedTemplateTagNames = getSavedTemplateTagNames(template);
+            assertThat(savedTemplateTagNames).hasSize(1)
+                    .containsExactly(tagName);
+        }
+
+        @Test
         @DisplayName("성공: 이미 있는 태그이지만 이 템플릿의 태그가 아닌 경우 템플릿 태그만 추가")
         void createTags_WhenExistTagContains() {
             // given


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #921

## 📍주요 변경 사항
1. 기존 로직은 태그 저장 시에 기존에 존재하는 태그만 체크합니다. 새로 저장하려는 태그에 중복이 있는 경우 모두 저장됩니다. 따라서 태그 이름에 제거 후 저장하도록 변경하였습니다.
2. 태그 저장 메서드가 복잡하여 메서드를 추출하였습니다. 


## 🎸기타

1. TemplateTagService와 TagService의 분리가 필요해보입니다.


## 🍗 PR 첫 리뷰 마감 기한
11/17 18:00
