### PR TITLE
index의 중복 적용된 Suspense, ErrorBoundary 제거

### DIFF
--- a/frontend/src/components/Layout/Layout.tsx
+++ b/frontend/src/components/Layout/Layout.tsx
@@ -1,10 +1,10 @@
 import { ErrorBoundary } from '@sentry/react';
 import { QueryErrorResetBoundary } from '@tanstack/react-query';
-import { useEffect, useRef } from 'react';
+import { Suspense, useEffect, useRef } from 'react';
 import { Outlet, useLocation } from 'react-router-dom';
 
 import { ApiError, HTTP_STATUS } from '@/api/Error';
-import { Footer, Header, ScrollTopButton } from '@/components';
+import { Footer, Header, LoadingBall, ScrollTopButton } from '@/components';
 import { useHeaderHeight } from '@/hooks';
 import { ForbiddenPage, NotFoundPage } from '@/pages';
 
@@ -13,7 +13,6 @@ import * as S from './Layout.style';
 const Layout = () => {
   const headerRef = useRef<HTMLDivElement>(null);
   const { setHeaderHeight } = useHeaderHeight();
-  const location = useLocation();
 
   useEffect(() => {
     if (headerRef.current) {
@@ -27,23 +26,11 @@ const Layout = () => {
       <S.Wrapper>
         <QueryErrorResetBoundary>
           {({ reset }) => (
-            <ErrorBoundary
-              fallback={(fallbackProps) => {
-                const error = fallbackProps.error;
-
-                if (error instanceof ApiError) {
-                  if (error.statusCode === HTTP_STATUS.FORBIDDEN) {
-                    return <ForbiddenPage resetError={fallbackProps.resetError} error={error} />;
-                  }
-                }
-
-                return <NotFoundPage {...fallbackProps} />;
-              }}
-              onReset={reset}
-              key={location.pathname}
-            >
-              <Outlet />
-            </ErrorBoundary>
+            <GlobalErrorBoundary reset={reset}>
+              <GlobalSuspense>
+                <Outlet />
+              </GlobalSuspense>
+            </GlobalErrorBoundary>
           )}
         </QueryErrorResetBoundary>
       </S.Wrapper>
@@ -54,3 +41,39 @@ const Layout = () => {
 };
 
 export default Layout;
+
+const GlobalSuspense = ({ children }: { children: JSX.Element }) => (
+  <Suspense
+    fallback={
+      <div style={{ height: '100vh' }}>
+        <LoadingBall />
+      </div>
+    }
+  >
+    {children}
+  </Suspense>
+);
+
+const GlobalErrorBoundary = ({ children, reset }: { children: JSX.Element; reset: () => void }) => {
+  const location = useLocation();
+
+  return (
+    <ErrorBoundary
+      fallback={(fallbackProps) => {
+        const error = fallbackProps.error;
+
+        if (error instanceof ApiError) {
+          if (error.statusCode === HTTP_STATUS.FORBIDDEN) {
+            return <ForbiddenPage resetError={fallbackProps.resetError} error={error} />;
+          }
+        }
+
+        return <NotFoundPage {...fallbackProps} />;
+      }}
+      onReset={reset}
+      key={location.pathname}
+    >
+      {children}
+    </ErrorBoundary>
+  );
+};

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,4 +1,3 @@
-import { ErrorBoundary } from '@sentry/react';
 import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
@@ -6,6 +5,7 @@ import { Layout } from '@/components';
 import RouteGuard from '@/routes/RouteGuard';
 import { ROUTE_END_POINT } from '@/routes/endPoints';
 
+/* eslint-disable react-refresh/only-export-components */
 const LandingPage = lazy(() => import('@/pages/LandingPage/LandingPage'));
 const TemplatePage = lazy(() => import('@/pages/TemplatePage/TemplatePage'));
 const TemplateUploadPage = lazy(() => import('@/pages/TemplateUploadPage/TemplateUploadPage'));
@@ -26,19 +26,13 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTE_END_POINT.MEMBERS_TEMPLATES,
-        element: (
-          <ErrorBoundary fallback={<NotFoundPage />}>
-            <MyTemplatePage />
-          </ErrorBoundary>
-        ),
+        element: <MyTemplatePage />,
       },
       {
         path: ROUTE_END_POINT.MEMBERS_LIKED_TEMPLATES,
         element: (
           <RouteGuard isLoginRequired redirectTo={ROUTE_END_POINT.LOGIN}>
-            <ErrorBoundary fallback={<NotFoundPage />}>
-              <MyLikedTemplatePage />
-            </ErrorBoundary>
+            <MyLikedTemplatePage />
           </RouteGuard>
         ),
       },

--- a/frontend/src/routes/router.tsx
+++ b/frontend/src/routes/router.tsx
@@ -1,8 +1,8 @@
 import { ErrorBoundary } from '@sentry/react';
-import { lazy, Suspense } from 'react';
+import { lazy } from 'react';
 import { createBrowserRouter } from 'react-router-dom';
 
-import { Layout, LoadingBall } from '@/components';
+import { Layout } from '@/components';
 import RouteGuard from '@/routes/RouteGuard';
 import { ROUTE_END_POINT } from '@/routes/endPoints';
 
@@ -16,38 +16,13 @@ const TemplateExplorePage = lazy(() => import('@/pages/TemplateExplorePage/Templ
 const MyTemplatePage = lazy(() => import('@/pages/MyTemplatesPage/MyTemplatePage'));
 const MyLikedTemplatePage = lazy(() => import('@/pages/MyLikedTemplatePage/MyLikedTemplatePage'));
 
-const CustomSuspense = ({ children }: { children: JSX.Element }) => (
-  <Suspense
-    fallback={
-      <div style={{ height: '100vh' }}>
-        <LoadingBall />
-      </div>
-    }
-  >
-    {children}
-  </Suspense>
-);
-
 const router = createBrowserRouter([
   {
-    errorElement: (
-      <CustomSuspense>
-        <NotFoundPage />
-      </CustomSuspense>
-    ),
-    element: (
-      <CustomSuspense>
-        <Layout />
-      </CustomSuspense>
-    ),
+    element: <Layout />,
     children: [
       {
         path: ROUTE_END_POINT.HOME,
-        element: (
-          <CustomSuspense>
-            <LandingPage />
-          </CustomSuspense>
-        ),
+        element: <LandingPage />,
       },
       {
         path: ROUTE_END_POINT.MEMBERS_TEMPLATES,
@@ -69,27 +44,17 @@ const router = createBrowserRouter([
       },
       {
         path: ROUTE_END_POINT.TEMPLATES_EXPLORE,
-        element: (
-          <CustomSuspense>
-            <TemplateExplorePage />
-          </CustomSuspense>
-        ),
+        element: <TemplateExplorePage />,
       },
       {
         path: ROUTE_END_POINT.TEMPLATE,
-        element: (
-          <CustomSuspense>
-            <TemplatePage />
-          </CustomSuspense>
-        ),
+        element: <TemplatePage />,
       },
       {
         path: ROUTE_END_POINT.TEMPLATES_UPLOAD,
         element: (
           <RouteGuard isLoginRequired redirectTo={ROUTE_END_POINT.LOGIN}>
-            <CustomSuspense>
-              <TemplateUploadPage />
-            </CustomSuspense>
+            <TemplateUploadPage />
           </RouteGuard>
         ),
       },
@@ -97,9 +62,7 @@ const router = createBrowserRouter([
         path: ROUTE_END_POINT.SIGNUP,
         element: (
           <RouteGuard isLoginRequired={false} redirectTo={ROUTE_END_POINT.HOME}>
-            <CustomSuspense>
-              <SignupPage />
-            </CustomSuspense>
+            <SignupPage />
           </RouteGuard>
         ),
       },
@@ -107,19 +70,13 @@ const router = createBrowserRouter([
         path: ROUTE_END_POINT.LOGIN,
         element: (
           <RouteGuard isLoginRequired={false} redirectTo={ROUTE_END_POINT.HOME}>
-            <CustomSuspense>
-              <LoginPage />
-            </CustomSuspense>
+            <LoginPage />
           </RouteGuard>
         ),
       },
       {
         path: '*',
-        element: (
-          <CustomSuspense>
-            <NotFoundPage />
-          </CustomSuspense>
-        ),
+        element: <NotFoundPage />,
       },
     ],
   },


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #439 

## 📍주요 변경 사항
- `routes.ts`에 중복 적용되어있던 `CustomSuspense`와 `ErrorBoundary`를 제거하고 `Layout`에 적용하였습니다.
- 컴포넌트 명을 각각 `GlobalSuspense`와 `GlobalErrorBoundary`로 변경하였습니다.

## 🍗 PR 첫 리뷰 마감 기한
11/29 20:00
