### PR TITLE
운영 환경에서 Swagger 문서 및 API 차단

### DIFF
--- a/backend/src/main/java/codezap/global/swagger/SpringDocConfiguration.java
+++ b/backend/src/main/java/codezap/global/swagger/SpringDocConfiguration.java
@@ -40,14 +40,11 @@ public class SpringDocConfiguration {
                 .servers(
                         List.of(
                                 new Server()
-                                        .url("https://api.code-zap.com")
-                                        .description("운영 서버"),
+                                        .url("http://localhost:8080")
+                                        .description("로컬 서버"),
                                 new Server()
                                         .url("https://dev.code-zap.com")
-                                        .description("개발 서버"),
-                                new Server()
-                                        .url("http://localhost:8080")
-                                        .description("로컬 서버")
+                                        .description("개발 서버")
                         )
                 )
                 .addSecurityItem(new SecurityRequirement().addList("쿠키 인증 토큰"));

--- a/backend/src/main/resources/application-swagger.yml
+++ b/backend/src/main/resources/application-swagger.yml
@@ -3,6 +3,6 @@ springdoc:
   default-produces-media-type: application/json
   swagger-ui:
     path: /swagger-ui.html
-    enabled: true
+    enabled: ${SWAGGER_ENABLED}
     supportedSubmitMethods: get
     display-request-duration: false


### PR DESCRIPTION
## ⚡️ 관련 이슈
#858

## 📍주요 변경 사항
운영 환경에서 API 문서 접근 및 테스트가 불가능하도록 변경해요. 

개발 및 운영 환경의 환경 변수를 추가합니다. 

```
# dev
SWAGGER_ENABLED=true

# prod
SWAGGER_ENABLED=false
```


## 🍗 PR 첫 리뷰 마감 기한
12/05 13:01
