### PR TITLE
운영 환경, 메서드 로그 전략 변경

### DIFF
--- a/backend/src/main/java/codezap/global/logger/MDCFilter.java
+++ b/backend/src/main/java/codezap/global/logger/MDCFilter.java
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 @Order(1)
 public class MDCFilter implements Filter {
 
-    private final String CORRELATION_ID = "correlationId";
+    private static final String CORRELATION_ID = "correlationId";
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)

--- a/backend/src/main/java/codezap/global/logger/MethodExecutionTimeAspect.java
+++ b/backend/src/main/java/codezap/global/logger/MethodExecutionTimeAspect.java
@@ -33,7 +33,7 @@ public class MethodExecutionTimeAspect {
         String methodName = joinPoint.getSignature()
                 .getName();
 
-        log.info("{}.{} 실행 {}ms", className, methodName, executionTimeMillis);
+        log.debug("{}.{} 실행 {}ms", className, methodName, executionTimeMillis);
 
         return result;
     }

--- a/backend/src/main/resources/logger/logback-spring-prod.xml
+++ b/backend/src/main/resources/logger/logback-spring-prod.xml
@@ -12,6 +12,10 @@
         <appender-ref ref="console-appender"/>
     </logger>
 
+    <logger name="codezap" level="INFO">
+        <appender-ref ref="info-appender"/>
+    </logger>
+
     <root level="WARN">
         <appender-ref ref="warn-appender"/>
         <appender-ref ref="error-appender"/>


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #952

## 📍주요 변경 사항
직전 회의 때 논의했던 내용으로 사용자의 로그 추적을 쉽게 하기 위해 로그 전략을 수정했습니다.

> 회의에 참여하지 못하셨던 분은 이슈 참고하시면 좋을 것 같슴다!

- 운영 환경 로깅에서 codezap 로깅 레벨도 info로 낮춤
- MethodExecutionTimeAspect를 debug로 낮츰
- 상수 하나에 static 키워드가 빠져있어 수정


## 🍗 PR 첫 리뷰 마감 기한
12/07 22:00
