### PR TITLE
검색시 발생하는 500 에러 해결

### DIFF
--- a/backend/src/main/java/codezap/template/repository/strategy/FullTextSearchSearchStrategy.java
+++ b/backend/src/main/java/codezap/template/repository/strategy/FullTextSearchSearchStrategy.java
@@ -39,6 +39,8 @@ public class FullTextSearchSearchStrategy implements SearchStrategy {
     private String parseKeyword(String trimmedKeyword) {
         String[] parsedKeywords = trimmedKeyword.split(" ");
         return Arrays.stream(parsedKeywords)
+                .map(keyword -> keyword.replaceAll("[^a-zA-Z0-9가-힣]", ""))
+                .filter(keyword -> !keyword.isEmpty())
                 .map(keyword -> "+" + keyword)
                 .collect(Collectors.joining(" "));
     }

--- a/backend/src/main/java/codezap/template/repository/strategy/FullTextSearchSearchStrategy.java
+++ b/backend/src/main/java/codezap/template/repository/strategy/FullTextSearchSearchStrategy.java
@@ -4,6 +4,7 @@ import static codezap.template.domain.QSourceCode.sourceCode;
 import static codezap.template.domain.QTemplate.template;
 
 import java.util.Arrays;
+import java.util.regex.Pattern;
 import java.util.stream.Collectors;
 
 import org.springframework.stereotype.Component;
@@ -21,6 +22,7 @@ public class FullTextSearchSearchStrategy implements SearchStrategy {
     private static final int FULL_TEXT_FIELD_SECOND_ORDER = 1;
     private static final int FULL_TEXT_KEYWORD_ORDER = 2;
     private static final int NO_MATCHED_SCORE = 0;
+    private static final Pattern INVALID_CHAR_PATTERN = Pattern.compile("[^a-zA-Z0-9가-힣]");
 
     @Override
     public BooleanExpression matchedKeyword(String trimmedKeyword) {
@@ -39,7 +41,7 @@ public class FullTextSearchSearchStrategy implements SearchStrategy {
     private String parseKeyword(String trimmedKeyword) {
         String[] parsedKeywords = trimmedKeyword.split(" ");
         return Arrays.stream(parsedKeywords)
-                .map(keyword -> keyword.replaceAll("[^a-zA-Z0-9가-힣]", ""))
+                .map(keyword -> INVALID_CHAR_PATTERN.matcher(keyword).replaceAll(""))
                 .filter(keyword -> !keyword.isEmpty())
                 .map(keyword -> "+" + keyword)
                 .collect(Collectors.joining(" "));

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -130,7 +130,7 @@ class TemplateSearchServiceTest {
 
         @ParameterizedTest
         @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
-        @ValueSource(strings = {"안녕", "+안녕", "안+녕", " 안녕"})
+        @ValueSource(strings = {"안녕", "+안녕", "안+녕", " 안녕", "안녕+", "안녕-", "-안녕"})
         void findAllSuccessByKeyword(String keyword) {
             Long memberId = null;
             Long categoryId = null;

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -11,6 +11,8 @@ import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.data.domain.PageRequest;
@@ -126,11 +128,11 @@ class TemplateSearchServiceTest {
                     .hasMessage("Pageable을 필수로 작성해야 합니다.");
         }
 
-        @Test
+        @ParameterizedTest
         @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
-        void findAllSuccessByKeyword() {
+        @ValueSource(strings = {"안녕", "+안녕", "안+녕", " 안녕"})
+        void findAllSuccessByKeyword(String keyword) {
             Long memberId = null;
-            String keyword = "안녕";
             Long categoryId = null;
             List<Long> tagIds = null;
             Visibility visibility = null;
@@ -139,7 +141,7 @@ class TemplateSearchServiceTest {
             FixedPage<Template> actual = sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable);
 
             assertThat(actual.contents()).containsExactlyInAnyOrder(templates.stream()
-                    .filter(template -> template.getTitle().contains(keyword) || template.getDescription().contains(keyword))
+                    .filter(template -> template.getTitle().contains("안녕") || template.getDescription().contains("안녕"))
                     .toArray(Template[]::new));
         }
 

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -161,7 +161,7 @@ class TemplateSearchServiceTest {
         }
 
         @Test
-        @DisplayName("검색 기능: 공개 범위로 템플릿 목록 조회 성공")
+        @DisplayName("검색 기능: 복수 태그 ID로 템플릿 목록 조회 성공")
         void findAllSuccessByTagIds() {
             Long memberId = null;
             String keyword = null;


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #962 

## 📍주요 변경 사항
- 검색 키워드 앞 또는 뒤에 특수문자가 붙으면 500 에러가 발생합니다.
- ex) '+test', '-리스트', '이름-' 등등
- 키워드에 특수 문자가 있는 경우, 특수 문자를 제거하고 검색하도록 변경하였습니다.

## 🎸기타
> 토요일 전에 운영 환경에 배포되어야 할 것 같아서 최대한 빠른 리뷰 부탁드립니다.

## 🍗 PR 첫 리뷰 마감 기한
12/13 16:00
