### PR TITLE
타인의 템플릿 페이지에서 노출된 업로드 버튼 오류 수정

### DIFF
--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,9 +35,9 @@ const enableMocking = async () => {
     return;
   }
 
-  const { worker } = await import('@/mocks/settings/browser');
+  // const { worker } = await import('@/mocks/settings/browser');
 
-  await worker.start();
+  // await worker.start();
 };
 
 enableMocking().then(() => {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,9 +35,9 @@ const enableMocking = async () => {
     return;
   }
 
-  // const { worker } = await import('@/mocks/settings/browser');
+  const { worker } = await import('@/mocks/settings/browser');
 
-  // await worker.start();
+  await worker.start();
 };
 
 enableMocking().then(() => {

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -35,7 +35,7 @@ const enableMocking = async () => {
     return;
   }
 
-  // const { worker } = await import('./mocks/browser');
+  // const { worker } = await import('@/mocks/settings/browser');
 
   // await worker.start();
 };

--- a/frontend/src/mocks/handlers/category.ts
+++ b/frontend/src/mocks/handlers/category.ts
@@ -1,10 +1,12 @@
 import { http } from 'msw';
 
 import { API_URL } from '@/api';
-import { categories as mockCategoryList } from '@/mocks/fixtures/categoryList.json';
+import  categories from '@/mocks/fixtures/categoryList.json';
 import { END_POINTS } from '@/routes';
 import { Category } from '@/types';
 import { mockResponse } from '@/utils/mockResponse';
+
+const mockCategoryList = [...categories.categories];
 
 export const categoryHandlers = [
   http.get(`${API_URL}${END_POINTS.CATEGORIES}`, () =>

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -1,10 +1,10 @@
 import { Suspense } from 'react';
 import { useParams } from 'react-router-dom';
 
+import { SORTING_OPTIONS } from '@/models/templates';
 import { SearchIcon } from '@/assets/images';
 import { Flex, Input, PagingButtons, Dropdown, Heading } from '@/components';
 import { useAuth } from '@/hooks/authentication';
-import { SORTING_OPTIONS } from '@/models/templates';
 import {
   CategoryListSection,
   CategoryListSectionSkeleton,

--- a/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
+++ b/frontend/src/pages/MyTemplatesPage/MyTemplatePage.tsx
@@ -126,6 +126,7 @@ const MyTemplatePage = () => {
                 templateList={templateList}
                 isSearching={inputKeyword !== '' || inputKeyword !== searchedKeyword}
                 isEditMode={isEditMode}
+                isMine={isMine}
                 selectedList={selectedList}
                 setSelectedList={setSelectedList}
               />

--- a/frontend/src/pages/MyTemplatesPage/components/TemplateListSection/TemplateListSection.tsx
+++ b/frontend/src/pages/MyTemplatesPage/components/TemplateListSection/TemplateListSection.tsx
@@ -7,17 +7,19 @@ interface Props {
   templateList: TemplateListItem[];
   isEditMode: boolean;
   isSearching: boolean;
+  isMine: boolean;
   selectedList: number[];
   setSelectedList: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 const getGridCols = (windowWidth: number) => (windowWidth <= 1024 ? 1 : 2);
 
-const TemplateListSection = ({ templateList, isSearching, isEditMode, selectedList, setSelectedList }: Props) => {
+const TemplateListSection = ({ templateList, isSearching, isEditMode, isMine, selectedList, setSelectedList }: Props) => {
   const windowWidth = useWindowWidth();
 
   if (templateList.length === 0) {
-    return isSearching ? <NoResults>검색 결과가 없습니다.</NoResults> : <NewTemplateButton />;
+    if (!isMine || isSearching) return <NoResults>검색 결과가 없습니다.</NoResults>
+    return <NewTemplateButton />;
   }
 
   return (


### PR DESCRIPTION
## ⚡️ 관련 이슈
#973 

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

기존 타인의 템플릿에서 카테고리들 중 템플릿이 없으면 업로드 버튼이 보이고 있었습니다. 
기존 코드에서 이미 `isMine` 이라는 조건으로 edit 모드 처리를 하고 있어서 해당 조건을 사용해서 처리했습니다. 

추가적으로 모킹 수정하고 반영되지 못한 수정사항이나 sort-option 등이 몇개 있어서 같이 처리해서 올렸습니다~ 


## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.

고민 중에 있는 부분은 `MyTemplatePage` 이라는 워딩 부분인데요,,~! 

사실상 url 로 맴버 템플릿이고 본인 템플릿과 더불어 다른 사람의 템플릿을 모아보기도 가능한 기능이라 `MemberTemplatePage` 로 변경하는 것에 대해서 어떻게 생각하시는지 궁금합니다,,~~ 
폴더 명도 `MyTemplatePage` 이다보니 diff 가 많이 생길거 같아서요! 

더불어 엠플리튜드 트래킹도 `[Viewed] 내 템플릿 페이지` 로 찍히고 있어서 제가 마위의 템플릿들을 구경해도 제 페이지를 보고 있는 걸로 찍힐거 같아서 수정이 필요할거 같습니다! 


## 🍗 PR 첫 리뷰 마감 기한
12/20 12:00
