### PR TITLE
msw 핸들러 추가 및 msw 실행 스크립트 추가

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -7,6 +7,7 @@
     "test": "jest",
     "e2e": "playwright test",
     "e2e:ui": "playwright test --ui",
+    "msw": "APP_ENV=msw webpack-dev-server --open --config webpack.dev.js",
     "dev": "webpack-dev-server --config webpack.dev.js --open",
     "tsc": "tsc --noEmit",
     "build": "webpack --mode production --config webpack.prod.js",

--- a/frontend/src/index.tsx
+++ b/frontend/src/index.tsx
@@ -31,13 +31,13 @@ Sentry.init({
 const root = ReactDOM.createRoot(document.getElementById('root') as HTMLElement);
 
 const enableMocking = async () => {
-  if (process.env.NODE_ENV !== 'development') {
+  if (process.env.APP_ENV !== 'msw') {
     return;
   }
 
-  // const { worker } = await import('./mocks/browser');
+  const { worker } = await import('@/mocks/settings/browser');
 
-  // await worker.start();
+  await worker.start();
 };
 
 enableMocking().then(() => {

--- a/frontend/src/mocks/handlers/authentication.ts
+++ b/frontend/src/mocks/handlers/authentication.ts
@@ -21,9 +21,6 @@ export const authenticationHandler = [
   http.post(`${API_URL}${END_POINTS.LOGOUT}`, () =>
     mockResponse({
       status: 204,
-      body: {
-        statusText: 'AUTHORIZED',
-      },
     }),
   ),
 

--- a/frontend/src/mocks/handlers/like.ts
+++ b/frontend/src/mocks/handlers/like.ts
@@ -6,6 +6,18 @@ import { END_POINTS } from '@/routes';
 import { mockResponse } from '@/utils/mockResponse';
 
 export const likeHandlers = [
+  http.get(`${API_URL}${END_POINTS.LIKED_TEMPLATES}`, () => {
+    const template = mockTemplateList.templates.filter((temp) => temp.isLiked === true);
+
+    return mockResponse({
+      status: 200, 
+      body: {
+        paginationSizes: 1,
+        templates: template
+      }
+    })
+  }),
+  
   http.post(`${API_URL}${END_POINTS.LIKES}/:templateId`, (req) => {
     const { templateId } = req.params;
     const template = mockTemplateList.templates.find((temp) => temp.id.toString() === templateId);

--- a/frontend/src/mocks/handlers/template.ts
+++ b/frontend/src/mocks/handlers/template.ts
@@ -92,7 +92,7 @@ export const templateHandlers = [
     });
   }),
 
-  http.post(`${API_URL}${END_POINTS.TEMPLATES_EXPLORE}`, async () => mockResponse({ status: 201 })),
+  http.post(`${API_URL}${END_POINTS.TEMPLATES_EXPLORE}`, async () => mockResponse({ status: 201, headers: { 'Location': '/templates/1' } })),
 
   http.post(`${API_URL}${END_POINTS.TEMPLATES_EXPLORE}/:id`, async () => mockResponse({ status: 200 })),
 

--- a/frontend/src/utils/mockResponse.ts
+++ b/frontend/src/utils/mockResponse.ts
@@ -10,6 +10,10 @@ interface Props<T> {
 }
 
 export const mockResponse = <T>({ status, body, errorBody, headers }: Props<T>) => {
+  if (status === 204) {
+    return new HttpResponse(null, { status, headers });
+  }
+
   if (status >= 200 && status <= 299) {
     return HttpResponse.json({ ...body }, { status, headers });
   }

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -4,6 +4,9 @@ const Dotenv = require('dotenv-webpack');
 
 const common = require('./webpack.common.js');
 
+const apiEnv = process.env.APP_ENV || 'development';
+const envFilePath = `.env.${apiEnv}`;
+
 module.exports = () => {
   return merge(common, {
     mode: 'development',
@@ -14,7 +17,7 @@ module.exports = () => {
     plugins: [
       new HotModuleReplacementPlugin(),
       new Dotenv({
-        path: './.env.development',
+        path: `./${envFilePath}`,
       }),
     ],
     module: {

--- a/frontend/webpack.dev.js
+++ b/frontend/webpack.dev.js
@@ -4,7 +4,7 @@ const Dotenv = require('dotenv-webpack');
 
 const common = require('./webpack.common.js');
 
-const apiEnv = process.env.APP_ENV || 'development';
+const apiEnv = process.env.APP_ENV ?? 'development';
 const envFilePath = `.env.${apiEnv}`;
 
 module.exports = () => {


### PR DESCRIPTION
## ⚡️ 관련 이슈
#975 

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

**1. msw 핸들러 추가 및 보수 진행**
- mockResponse 보수 
: 기존에 작업한 mockResponse 로 로그아웃을 진행할 때 500이 뜨는 버그가 있었습니다. 찾아보니 204를 보내면서 바디를 함께 주고 있어서 조건식에 204일때 처리를 따로 진행했습니다. 

- 좋아요한 템플릿 리스트 보는 핸들러 추가 
: 의도한건지 모르겠지만,, 좋아요한 템플릿 리스트 보는 핸들러가 없어서 짜봤습니다. 자꾸 들어가면 없어서 404가 뜨길래 거슬려서,, 

- 파일 업로드 이후 Location 추가 
: 템플릿 업로드 이후 prod 환경에서는 백엔드에서 전달 받은 location을 사용하여 페이지 이동을 하는데 모킹에서도 비슷하게 구현하고 싶어서 `location` 을 걸어주었습니다. 그런데 아무래도 아직 어설픈 모킹이다보니 새로 생성된 페이지가 아니라 일단 1번으로 이동되게했습니다. 
이후에 모킹쪽을 조금 더 자세히 보고 유지보수할 수 있지 않을까... 


**2. msw 자동 실행 스크립트 추가** 

제 사수이자 대리이자 부장이자 CTO 이신 마위께서 자꾸 일거리를 주셔서 이 야밤에 작업을 했습니다.. 
이제 msw 실행 주석을 지울 필요 없이 실행 명령어에서 `npm run msw` 를 실행하시면 자동으로 msw 환경으로 사용하실 수 있습니다. 
아 env 업데이트가 필요합니다. 자세한 사항은 카톡으로,,,

다만 의문인건 원래 dev로 실행하면 CORS 나는게 맞는건지,,,? 


## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.


## 🍗 PR 첫 리뷰 마감 기한
12/20 12:00
