### PR TITLE
태그 동시 생성 시 중복 문제 해결

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -21,6 +21,7 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
     implementation 'org.springframework.boot:spring-boot-starter-validation'
+    implementation 'org.springframework.retry:spring-retry'
 
     implementation 'io.micrometer:micrometer-registry-prometheus'
     implementation 'org.springframework.boot:spring-boot-starter-actuator'

--- a/backend/src/main/java/codezap/global/retry/RetryConfiguration.java
+++ b/backend/src/main/java/codezap/global/retry/RetryConfiguration.java
@@ -1,0 +1,9 @@
+package codezap.global.retry;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.retry.annotation.EnableRetry;
+
+@EnableRetry
+@Configuration
+public class RetryConfiguration {
+}

--- a/backend/src/main/java/codezap/tag/domain/Tag.java
+++ b/backend/src/main/java/codezap/tag/domain/Tag.java
@@ -27,7 +27,7 @@ public class Tag extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false, unique = true)
+    @Column(nullable = false,unique = true, columnDefinition = "VARCHAR(255) COLLATE utf8mb4_bin")
     private String name;
 
     public Tag(String name) {

--- a/backend/src/main/java/codezap/tag/domain/Tag.java
+++ b/backend/src/main/java/codezap/tag/domain/Tag.java
@@ -27,7 +27,7 @@ public class Tag extends BaseTimeEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @Column(nullable = false)
+    @Column(nullable = false, unique = true)
     private String name;
 
     public Tag(String name) {

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -4,7 +4,9 @@ import java.util.List;
 
 import jakarta.annotation.Nullable;
 
+import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -45,6 +47,7 @@ public class TemplateApplicationService {
     private final ThumbnailService thumbnailService;
     private final LikesService likesService;
 
+    @Retryable(retryFor = DataIntegrityViolationException.class, maxAttempts = 3)
     @Transactional
     public Long create(Member member, CreateTemplateRequest createTemplateRequest) {
         Category category = categoryService.fetchById(createTemplateRequest.categoryId());

--- a/backend/src/main/resources/db/migration/V10__add_constraint_unique_tag.sql
+++ b/backend/src/main/resources/db/migration/V10__add_constraint_unique_tag.sql
@@ -1,0 +1,1 @@
+ALTER TABLE tag ADD CONSTRAINT unique (name)

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -110,7 +110,6 @@ class TemplateApplicationServiceTest extends ServiceTest {
             // Then
             List<Tag> tags = tagRepository.findAllByNames(List.of("Spring"));
             assertThat(tags).hasSize(1);
-            System.out.println(templateRepository.findByMemberId(member2.getId()));
         }
 
         private static CreateTemplateRequest createTemplateRequest(Category category) {

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -517,7 +517,7 @@ class TemplateApplicationServiceTest extends ServiceTest {
                     Visibility.PUBLIC);
 
             // when & then
-            assertThatThrownBy(() -> sut.update(otherMember, template.getId(), request))
+            assertThatThrownBy(() -> sut.update(member, template.getId(), request))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("해당 카테고리를 수정 또는 삭제할 권한이 없는 유저입니다.");
         }

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -109,7 +109,11 @@ class TemplateApplicationServiceTest extends ServiceTest {
 
             // Then
             List<Tag> tags = tagRepository.findAllByNames(List.of("Spring"));
-            assertThat(tags).hasSize(1);
+            assertAll(
+                    () -> assertThat(tags).hasSize(1),
+                    () -> assertThat(templateRepository.findByMemberId(member.getId())).isNotEmpty(),
+                    () -> assertThat(templateRepository.findByMemberId(member2.getId())).isNotEmpty()
+            );
         }
 
         private static CreateTemplateRequest createTemplateRequest(Category category) {
@@ -118,7 +122,7 @@ class TemplateApplicationServiceTest extends ServiceTest {
             var sourceCodeRequest = new CreateSourceCodeRequest("filename1", "content1", 1);
             var sourceCodes = List.of(sourceCodeRequest);
             int thumbnailOrdinal = 1;
-            List<String> tags = List.of();
+            List<String> tags = List.of("Spring");
             return new CreateTemplateRequest(
                     title,
                     description,


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #960 

## 📍주요 변경 사항

### 고민해본 방법
1. 유니크 제약 조건
2. MySQL INSERT IGNORE
3. synchronized 키워드

위와 같았어요. 각 이유에 대해 우려되는 점들은 이슈에 작성해놓았습니다!

결론적으로는 유니크 제약 조건과 재시도로 처리하는 게 현재 상황에서 적절하다고 판단했어요!

따라서 재시도를 처리해주는 spring retry 의존성을 추가했습니다.

### 기존 정책에 의한 명시적 제약 조건 추가

JPA에서 제공하는 unique 제약 조건은 대소문자를 구분하지 않아요.
때문에 기존 테스트 코드 중 "대소문자 구분하여 조회하는지"에 대한 테스트가 실패했어요.

<img width="550" alt="image" src="https://github.com/user-attachments/assets/35a930f3-e80d-40ff-ab39-4e67fd2aa9ea" />

우리의 정책은 태그의 대소문자를 구분하기 때문에 columnDefinition 옵션에 제약을 추가했으니 참고 부탁드립니다!

## 🎸 기타

문제 상황을 재연하기 위한 테스트에서 ServiceTest에 @Transactional 어노테이션으로 인해 재연이 불가능해요.

@Disable 처리를 해놓았으니 문제 상황을 확인하고 싶으신 분들은 참고 부탁해요!

## 🍗 PR 첫 리뷰 마감 기한
12/20 13:00
