### PR TITLE
문의하기 글자수 제한 20자 → 10자 변경 및 상태코드 200 → 201로 수정

### DIFF
--- a/backend/src/main/java/codezap/voc/controller/SpringDocVocController.java
+++ b/backend/src/main/java/codezap/voc/controller/SpringDocVocController.java
@@ -20,7 +20,7 @@ public interface SpringDocVocController {
             instance = "/contact",
             errorCases = {
                     @ErrorCase(description = "문의 내용을 입력하지 않은 경우.", exampleMessage = "문의 내용을 입력해주세요."),
-                    @ErrorCase(description = "문의 내용이 20자 미만인 경우.", exampleMessage = "문의 내용을 20자 이상 입력해주세요."),
+                    @ErrorCase(description = "문의 내용이 10자 미만인 경우.", exampleMessage = "문의 내용을 10자 이상 입력해주세요."),
                     @ErrorCase(description = "문의 내용이 10,000 글자를 초과한 경우.", exampleMessage = "문의 내용은 최대 10,000 글자까지 입력할 수 있습니다.")
             }
     )

--- a/backend/src/main/java/codezap/voc/controller/VocController.java
+++ b/backend/src/main/java/codezap/voc/controller/VocController.java
@@ -2,6 +2,7 @@ package codezap.voc.controller;
 
 import jakarta.validation.Valid;
 
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -20,6 +21,6 @@ public class VocController implements SpringDocVocController {
     @PostMapping("/contact")
     public ResponseEntity<Void> create(@Valid @RequestBody VocRequest request) {
         vocService.create(request);
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.CREATED).build();
     }
 }

--- a/backend/src/main/java/codezap/voc/dto/VocRequest.java
+++ b/backend/src/main/java/codezap/voc/dto/VocRequest.java
@@ -12,7 +12,7 @@ public record VocRequest(
 
         @Schema(description = "문의 내용", example = "코드잽 정말 잘 사용하고 있어요. 우테코 6기 코드잽 화이팅!")
         @NotEmpty(message = "문의 내용은 비어있을 수 없습니다.")
-        @Size(min = 20, max = 10_000, message = "문의 내용은 최소 20자, 최대 10,000 자 입력할 수 있습니다.")
+        @Size(min = 10, max = 10_000, message = "문의 내용은 최소 10자, 최대 10,000 자 입력할 수 있습니다.")
         String message,
 
         @Nullable

--- a/backend/src/test/java/codezap/voc/controller/VocControllerTest.java
+++ b/backend/src/test/java/codezap/voc/controller/VocControllerTest.java
@@ -22,7 +22,7 @@ class VocControllerTest extends MockMvcTest {
         mvc.perform(post("/contact")
                         .content(objectMapper.writeValueAsString(request))
                         .contentType(MediaType.APPLICATION_JSON))
-                .andExpect(status().isOk());
+                .andExpect(status().isCreated());
     }
 
     @Test

--- a/backend/src/test/java/codezap/voc/dto/VocRequestTest.java
+++ b/backend/src/test/java/codezap/voc/dto/VocRequestTest.java
@@ -25,7 +25,7 @@ class VocRequestTest {
     private static ValidatorFactory validatorFactory;
     private static Validator validator;
 
-    private static String message = "lorem ipsum dolor sit amet consectetur adipiscing elit fugiat cupiditat";
+    private static String message = "lorem ipsum";
     private static String email = "codezap2024@gmail.com";
     private static Long memberId = 1L;
     private static String name = "만두";
@@ -68,7 +68,7 @@ class VocRequestTest {
 
         @ParameterizedTest
         @MethodSource
-        @DisplayName("성공: 문의 내용 길이 20글자부터 10,000글자")
+        @DisplayName("성공: 문의 내용 길이 10글자부터 10,000글자")
         void message_length_success(String message) {
             sut = new VocRequest(message);
 
@@ -78,14 +78,14 @@ class VocRequestTest {
         }
 
         static Stream<String> message_length_success() {
-            var messageLength20 = RandomStringUtils.randomAlphanumeric(20);
+            var messageLength20 = RandomStringUtils.randomAlphanumeric(10);
             var messageLength10_000 = RandomStringUtils.randomAlphanumeric(10_000);
             return Stream.of(messageLength20, messageLength10_000);
         }
 
         @ParameterizedTest
         @MethodSource
-        @DisplayName("실패: 문의 내용 길이 19자 이하, 10,001글자 이상")
+        @DisplayName("실패: 문의 내용 길이 9자 이하, 10,001글자 이상")
         void message_length_fail(String message) {
             sut = new VocRequest(message);
 
@@ -94,11 +94,11 @@ class VocRequestTest {
             assertThat(constraintViolations).isNotEmpty()
                     .first()
                     .extracting(ConstraintViolation::getMessage)
-                    .isEqualTo("문의 내용은 최소 20자, 최대 10,000 자 입력할 수 있습니다.");
+                    .isEqualTo("문의 내용은 최소 10자, 최대 10,000 자 입력할 수 있습니다.");
         }
 
         static Stream<String> message_length_fail() {
-            var messageLength19 = RandomStringUtils.randomAlphanumeric(19);
+            var messageLength19 = RandomStringUtils.randomAlphanumeric(9);
             var messageLength10_001 = RandomStringUtils.randomAlphanumeric(10_001);
             return Stream.of(messageLength19, messageLength10_001);
         }


### PR DESCRIPTION
## ⚡️ 관련 이슈
#984

## 📍주요 변경 사항
회의 내용에 따라 글자수 제한을 변경해요. 

명세에 따라 문의하기에 성공하면 상태코드 201을 응답하도록 고쳤어요. 


## 🎸기타
관리자 페이지가 생기면 구글 스프레드시트 대신 DB를 사용하는 방식으로 변경돼야 해요. 


## 🍗 PR 첫 리뷰 마감 기한
12/24 21:00
