### PR TITLE
Tomcat HTTP gzip 압축 적용

### DIFF
--- a/backend/src/main/resources/application-was.yml
+++ b/backend/src/main/resources/application-was.yml
@@ -1,0 +1,3 @@
+server:
+  compression:
+    enabled: true

--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
     group:
-      default: local, voc
-      dev: db, actuator, swagger, cors, voc
-      prod: db, actuator, swagger, cors, voc
+      default: local, voc, was
+      dev: db, actuator, swagger, cors, voc, was
+      prod: db, actuator, swagger, cors, voc, was


### PR DESCRIPTION
## ⚡️ 관련 이슈
#850 

## 📍주요 변경 사항

아래의 설정을 추가해요. 
```yml
# application-was.yml
server:
  compression:
    enabled: true
```

`mime-types`, `min-response-size` 설정은 기본값을 사용하기 위해 커스텀하지 않았어요. 

기본값은 다음과 같아요. 
- `mime-types`: "text/html", "text/xml", "text/plain", "text/css", "text/javascript", "application/javascript", "application/json", "application/xml"
- `min-response-size`: 2KB

### 개선점

로컬에서 [운영 서버와 동일한 템플릿](https://www.code-zap.com/templates/1112) 하나를 생성하고 조회해봤어요. 

<img width="1194" alt="Screenshot 2024-12-23 at 9 44 37 AM" src="https://github.com/user-attachments/assets/7061c635-174a-4ef4-b270-e5e94302741b" />

그리고 조회하면 다음과 같이 얼마나 압축됐는지 확인할 수 있어요. 

<img width="348" alt="Screenshot 2024-12-23 at 9 46 28 AM" src="https://github.com/user-attachments/assets/2bb1de5d-6211-4d6b-ba42-8ec079c859dc" />

HTTP Body 용량을 67%나 줄였어요~!

계산식: $\left( \frac{9.93 - 3.26}{9.93} \right) \times 100 \approx 67.17\%$

## 🎸기타

본 설정을 적용하기 위해 `application-was.yml` 파일을 만들었어요. 

명명 근거는 다음과 같아요. 

- http compression은 WAS의 설정값이고, 우리가 tomcat을 netty, jetty 등 다른 서블릿 컨테이너로 변경하더라도 동일하게 적용되는 설정이에요. 
- 압축뿐 아니라 SSL, 스레드, 캐시, 세션 등의 설정도 할 수 있어요. 
- 모두 prefix가 `server.`으로 시작하고 모두 WAS의 기능이므로 확장 가능해요. 

## 🍗 PR 첫 리뷰 마감 기한
12/24 22:00
