### PR TITLE
Gradle test 작업에 fast-fail 옵션 추가

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -46,4 +46,5 @@ dependencies {
 
 test {
     useJUnitPlatform()
+    failFast = true
 }


### PR DESCRIPTION
## ⚡️ 관련 이슈
#955 

## 📍주요 변경 사항

### AS-IS

현재는 테스트 중에 실패하더라도 작업을 멈추지 않고 모든 테스트를 실행해요. 

아래 스크린캡처 이미지처럼, 시간이 오래 걸려요. 

<img width="640" alt="Screenshot 2024-12-23 at 10 17 37 AM" src="https://github.com/user-attachments/assets/dabbbe69-5b33-4764-a32d-5af200cb68e4" />

### TO-BE
아래의 gradle 옵션을 추가해요. 

```gradle
test {
   failFast = true
}
```

Gradle test 작업 실행 중 테스트가 실패하면 작업을 멈춰요. 

<img width="640" alt="Screenshot 2024-12-23 at 10 19 11 AM" src="https://github.com/user-attachments/assets/2c88bf63-9cca-4a85-9b05-74ad96e830ba" />

이렇게하면 실패하는 CI의 작업 속도를 최대 99%(로컬 기준 48.973s → 358ms) 높일 수 있어요. 

계산식: $\left( \frac{48973 - 358}{48973} \right) \times 100 \approx 99.27\%$

## 🍗 PR 첫 리뷰 마감 기한
12/24 22:30
