### PR TITLE
로그에 헤더 정보 수정 및 컨테이너 정보 추가

### DIFF
--- a/backend/src/main/java/codezap/global/logger/RequestResponseLogger.java
+++ b/backend/src/main/java/codezap/global/logger/RequestResponseLogger.java
@@ -28,6 +28,8 @@ import lombok.extern.slf4j.Slf4j;
 @Order(2)
 public class RequestResponseLogger extends OncePerRequestFilter {
 
+    private static final Set<String> REQUEST_HEADERS = Set.of("origin", "host", "content-type");
+    private static final Set<String> RESPONSE_HEADERS = Set.of("docker-hostname");
     private static final int ERROR_CODE = 500;
     private static final int WARN_CODE = 400;
 
@@ -67,23 +69,19 @@ public class RequestResponseLogger extends OncePerRequestFilter {
     }
 
     private String getHeaderAsJson(ContentCachingRequestWrapper requestWrapper) {
-        Set<String> requiredHeaders = Set.of("origin", "host", "content-type");
-
         Map<String, String> headersMap = new HashMap<>();
         Enumeration<String> headerNames = requestWrapper.getHeaderNames();
         Collections.list(headerNames).stream()
-                .filter(headerName -> requiredHeaders.contains(headerName.toLowerCase()))
+                .filter(headerName -> REQUEST_HEADERS.contains(headerName.toLowerCase()))
                 .forEach(headerName -> headersMap.put(headerName, requestWrapper.getHeader(headerName)));
 
         return convertMapToJson(headersMap);
     }
 
     private String getHeaderAsJson(ContentCachingResponseWrapper responseWrapper) {
-        Set<String> requiredHeaders = Set.of("docker-hostname");
-
         Map<String, String> headersMap = new HashMap<>();
         responseWrapper.getHeaderNames().stream()
-                .filter(headerName -> requiredHeaders.contains(headerName.toLowerCase()))
+                .filter(headerName -> RESPONSE_HEADERS.contains(headerName.toLowerCase()))
                 .forEach(headerName -> headersMap.put(headerName, responseWrapper.getHeader(headerName)));
 
         headersMap.put("docker-hostname", System.getenv("HOSTNAME"));


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #989 

## 📍주요 변경 사항
로그에 헤더가 너무 많아서 필요한 정보만 포함되도록 수정하였습니다.
실행중인 서버의 도커 컨테이너 정보가 response 로그에 포함되도록 수정하였습니다.
<img width="708" alt="image" src="https://github.com/user-attachments/assets/d6ba4f1b-071a-4341-a94a-ae3d662729e6" />
적혀있는 정보는 실행중인 도커의 `컨테이너 ID` 입니다.

> 무중단 배포를 도입하면서 현재 어떤 컨테이너가 실행중인지 파악하기 어렵다는 문제가 있었는데 이 로그를 통해 해결할 수 있을 것 같습니당.

## 🎸기타
> 현재 request 로그에는 origin, host, content-type을 추가하였고, response 로그에는 docker-hostname만 추가되도록 하였습니다.
더 추가되었으면 하는 헤더 정보가 있다면 얘기해주세용.


## 🍗 PR 첫 리뷰 마감 기한
12/26 23:59
