### PR TITLE
@Disabled 된 테스트 검토 및 사용하지 않는 메서드 제거

### DIFF
--- a/backend/src/main/java/codezap/category/repository/CategoryRepository.java
+++ b/backend/src/main/java/codezap/category/repository/CategoryRepository.java
@@ -29,10 +29,6 @@ public class CategoryRepository {
         return categoryJpaRepository.findAllByMemberIdOrderById(memberId);
     }
 
-    public List<Category> findAll() {
-        return categoryJpaRepository.findAll();
-    }
-
     public boolean existsByNameAndMember(String categoryName, Member member) {
         return categoryJpaRepository.existsByNameAndMember(categoryName, member);
     }

--- a/backend/src/main/java/codezap/category/service/CategoryService.java
+++ b/backend/src/main/java/codezap/category/service/CategoryService.java
@@ -35,10 +35,6 @@ public class CategoryService {
         return FindAllCategoriesResponse.from(categoryRepository.findAllByMemberIdOrderById(memberId));
     }
 
-    public FindAllCategoriesResponse findAll() {
-        return FindAllCategoriesResponse.from(categoryRepository.findAll());
-    }
-
     public Category fetchById(Long id) {
         return categoryRepository.fetchById(id);
     }

--- a/backend/src/main/java/codezap/tag/service/TagService.java
+++ b/backend/src/main/java/codezap/tag/service/TagService.java
@@ -58,12 +58,6 @@ public class TagService {
         return templateTagRepository.findAllTagsByTemplate(template);
     }
 
-    public List<Tag> findAllByTemplateId(Long templateId) {
-        return templateTagRepository.findAllByTemplateId(templateId).stream()
-                .map(TemplateTag::getTag)
-                .toList();
-    }
-
     public List<TemplateTag> getAllTemplateTagsByTemplates(List<Template> templates) {
         List<Long> templateIds = templates.stream().map(Template::getId).toList();
         return templateTagRepository.findAllByTemplateIdsIn(templateIds);

--- a/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
@@ -11,6 +11,7 @@ import codezap.global.validation.ByteLength;
 import codezap.global.validation.ValidationGroups.NotNullGroup;
 import codezap.global.validation.ValidationGroups.SizeCheckGroup;
 import codezap.template.domain.Visibility;
+import codezap.template.dto.request.validation.ValidatedSourceCodesCountRequest;
 import codezap.template.dto.request.validation.ValidatedSourceCodesOrdinalRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 
@@ -47,12 +48,18 @@ public record CreateTemplateRequest(
         @Schema(description = "템플릿 공개 여부", example = "PUBLIC")
         @NotNull(message = "템플릿 공개 여부가 null 입니다.", groups = NotNullGroup.class)
         Visibility visibility
-) implements ValidatedSourceCodesOrdinalRequest {
+) implements ValidatedSourceCodesOrdinalRequest, ValidatedSourceCodesCountRequest {
 
     @Override
     public List<Integer> extractSourceCodesOrdinal() {
         return sourceCodes.stream()
                 .map(CreateSourceCodeRequest::ordinal)
+                .sorted()
                 .toList();
+    }
+
+    @Override
+    public Integer countSourceCodes() {
+        return sourceCodes.size();
     }
 }

--- a/backend/src/main/java/codezap/template/dto/request/UpdateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/UpdateTemplateRequest.java
@@ -53,12 +53,14 @@ public record UpdateTemplateRequest(
         @NotNull(message = "템플릿 공개 여부가 null 입니다.", groups = NotNullGroup.class)
         Visibility visibility
 ) implements ValidatedSourceCodesOrdinalRequest, ValidatedSourceCodesCountRequest {
+
     @Override
     public List<Integer> extractSourceCodesOrdinal() {
         return Stream.concat(
-                updateSourceCodes.stream().map(UpdateSourceCodeRequest::ordinal),
-                createSourceCodes.stream().map(CreateSourceCodeRequest::ordinal)
-        ).toList();
+                        updateSourceCodes.stream().map(UpdateSourceCodeRequest::ordinal),
+                        createSourceCodes.stream().map(CreateSourceCodeRequest::ordinal)
+                ).sorted()
+                .toList();
     }
 
     @Override

--- a/backend/src/main/java/codezap/template/repository/TemplateRepository.java
+++ b/backend/src/main/java/codezap/template/repository/TemplateRepository.java
@@ -24,10 +24,6 @@ public class TemplateRepository {
                 () -> new CodeZapException(ErrorCode.RESOURCE_NOT_FOUND, "식별자 " + id + "에 해당하는 템플릿이 존재하지 않습니다."));
     }
 
-    public List<Template> findByMemberId(Long id) {
-        return templateJpaRepository.findByMemberId(id);
-    }
-
     public FixedPage<Template> findAll(
             Long memberId, String keyword, Long categoryId, List<Long> tagIds, Visibility visibility, Pageable pageable
     ) {

--- a/backend/src/main/java/codezap/template/service/TemplateService.java
+++ b/backend/src/main/java/codezap/template/service/TemplateService.java
@@ -41,10 +41,6 @@ public class TemplateService {
         return templateRepository.fetchById(id);
     }
 
-    public List<Template> getByMemberId(Long memberId) {
-        return templateRepository.findByMemberId(memberId);
-    }
-
     public FixedPage<Template> findAllBy(
             Long memberId,
             String keyword,

--- a/backend/src/main/java/codezap/template/service/ThumbnailService.java
+++ b/backend/src/main/java/codezap/template/service/ThumbnailService.java
@@ -36,10 +36,6 @@ public class ThumbnailService {
         return thumbnailRepository.findAllByTemplateIn(templateIds);
     }
 
-    public ExploreTemplatesResponse findAll() {
-        return ExploreTemplatesResponse.from(thumbnailRepository.findAll());
-    }
-
     @Transactional
     public void deleteAllByTemplateIds(List<Long> templateIds) {
         thumbnailRepository.deleteAllByTemplateIds(templateIds);

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -51,7 +51,7 @@ public class TemplateApplicationService {
         category.validateAuthorization(member);
         Template template = templateService.create(member, createTemplateRequest, category);
         tagService.createTags(template, createTemplateRequest.tags());
-        sourceCodeService.createSourceCodes(template, createTemplateRequest.sourceCodes());
+        sourceCodeService.createSourceCodes(template, createTemplateRequest);
         SourceCode thumbnail = sourceCodeService.getByTemplateAndOrdinal(
                 template,
                 createTemplateRequest.thumbnailOrdinal());

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -5,7 +5,6 @@ import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -146,7 +145,6 @@ class CategoryServiceTest extends ServiceTest {
 
         @Test
         @DisplayName("카테고리 수정 성공")
-        @Disabled
         void updateCategorySuccess() {
             String updateCategoryName = "updateName";
             Member member = memberRepository.save(MemberFixture.memberFixture());

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -115,32 +115,6 @@ class CategoryServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("카테고리 전체 조회 테스트")
-    class FindAllCategoryTest {
-
-        @Test
-        @DisplayName("성공")
-        void findAllCategoriesSuccess() {
-            Member member = memberRepository.save(MemberFixture.memberFixture());
-
-            categoryRepository.save(new Category("category1", member));
-            categoryRepository.save(new Category("category2", member));
-
-            FindAllCategoriesResponse findAllCategoriesResponse = sut.findAll();
-
-            assertThat(findAllCategoriesResponse.categories()).hasSize(2);
-        }
-
-        @Test
-        @DisplayName("성공 : 카테고리가 존재하지 않으면 빈 리스트를 반환한다.")
-        void findAllCategoriesEmptyList() {
-            FindAllCategoriesResponse findAllCategoriesResponse = sut.findAll();
-
-            assertThat(findAllCategoriesResponse.categories()).isEmpty();
-        }
-    }
-
-    @Nested
     @DisplayName("카테고리 단건 조회 테스트")
     class FetchByIdTest {
 

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -163,55 +163,6 @@ class TagServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("템플릿 Id로 태그 조회")
-    class FindAllByTemplateId {
-
-        @Test
-        @DisplayName("성공: 템플릿 Id에 해당하는 태그 목록 반환")
-        void findAllByTemplate() {
-            // given
-            Template template = createSavedTemplate();
-            Tag tag1 = tagRepository.save(new Tag("tag1"));
-            Tag tag2 = tagRepository.save(new Tag("tag2"));
-            TemplateTag templateTag1 = templateTagRepository.save(new TemplateTag(template, tag1));
-            TemplateTag templateTag2 = templateTagRepository.save(new TemplateTag(template, tag2));
-
-            // when & then
-            assertThat(sut.findAllByTemplateId(template.getId()))
-                    .containsExactly(templateTag1.getTag(), templateTag2.getTag());
-        }
-
-        @Test
-        @DisplayName("성공: 템플릿에 해당하는 태그가 없는 경우 빈 목록 반환")
-        void findAllByTemplate_WhenNotExistTemplateTag() {
-            // given
-            Template template = createSavedTemplate();
-            tagRepository.save(new Tag("tag1"));
-            tagRepository.save(new Tag("tag2"));
-
-            // when & then
-            assertThat(sut.findAllByTemplateId(template.getId())).isEmpty();
-        }
-
-        @Test
-        @Disabled("현재 InvalidDataAccessApiUsageException 발생하므로 조회 직전에 검증 처리가 필요")
-        @DisplayName("실패: 존재하지 않는 템플릿으로 태그 조회")
-        void findAllByTemplate_WhenNotExistTemplate() {
-            // given
-            Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            Template unSavedTemplate = TemplateFixture.get(member, category);
-            tagRepository.save(new Tag("tag1"));
-            tagRepository.save(new Tag("tag2"));
-
-            // when & then
-            assertThatThrownBy(() -> sut.findAllByTemplateId(unSavedTemplate.getId()))
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("템플릿이 존재하지 않아 태그를 조회할 수 없습니다.");
-        }
-    }
-
-    @Nested
     @DisplayName("템플릿 목록으로 템플릿 태그 조회")
     class GetAllTemplateTagsByTemplates {
 

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -1,14 +1,12 @@
 package codezap.tag.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -19,7 +17,6 @@ import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.ServiceTest;
-import codezap.global.exception.CodeZapException;
 import codezap.member.domain.Member;
 import codezap.tag.domain.Tag;
 import codezap.tag.dto.response.FindAllTagsResponse;

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -143,23 +143,6 @@ class TagServiceTest extends ServiceTest {
             // when & then
             assertThat(sut.findAllByTemplate(template)).isEmpty();
         }
-
-        @Test
-        @Disabled("현재 InvalidDataAccessApiUsageException 발생하므로 조회 직전에 검증 처리가 필요")
-        @DisplayName("실패: 존재하지 않는 템플릿으로 태그 조회")
-        void findAllByTemplate_WhenNotExistTemplate() {
-            // given
-            Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            Template unSavedTemplate = TemplateFixture.get(member, category);
-            tagRepository.save(new Tag("tag1"));
-            tagRepository.save(new Tag("tag2"));
-
-            // when & then
-            assertThatThrownBy(() -> sut.findAllByTemplate(unSavedTemplate))
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("템플릿이 존재하지 않아 태그를 조회할 수 없습니다.");
-        }
     }
 
     @Nested

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -233,7 +233,7 @@ class TemplateControllerTest extends MockMvcTest {
 
         @ParameterizedTest
         @DisplayName("템플릿 생성 실패: 잘못된 소스 코드 순서 입력 시 400 반환")
-        @CsvSource({"0, 1", "1, 3", "2, 1"})
+        @CsvSource({"0, 1", "1, 3"})
         void createTemplateFailWithWrongSourceCodeOrdinal(int firstIndex, int secondIndex) throws Exception {
             CreateTemplateRequest templateRequest = new CreateTemplateRequest("title", "description",
                     List.of(new CreateSourceCodeRequest("title", "content", firstIndex),
@@ -545,7 +545,7 @@ class TemplateControllerTest extends MockMvcTest {
 
         @ParameterizedTest
         @DisplayName("템플릿 수정 실패: 잘못된 소스 코드 순서 입력")
-        @CsvSource({"1, 2, 1", "3, 2, 1", "0, 2, 1"})
+        @CsvSource({"1, 2, 1", "1, 3, 4", "0, 2, 1"})
         void updateTemplateFailWithWrongSourceCodeOrdinal(int createOrdinal1, int createOrdinal2, int updateOrdinal)
                 throws Exception {
             // given

--- a/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
@@ -77,28 +77,6 @@ class TemplateRepositoryTest {
     }
 
     @Nested
-    @DisplayName("회원 id로 템플릿 조회")
-    class FindByMemberId {
-
-        @Test
-        @DisplayName("회원 id로 템플릿 조회 성공")
-        void findByMemberId() {
-            Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            Template savedTemplate = templateRepository.save(TemplateFixture.get(member, category));
-
-            assertThat(templateRepository.findByMemberId(member.getId())).containsExactly(savedTemplate);
-        }
-
-        @Test
-        @DisplayName("회원 id로 템플릿 조회 실패: 존재하지 않는 회원")
-        void findByMemberIdWhenNotExistsMember() {
-            Long notSavedId = 1L;
-            assertThat(templateRepository.findByMemberId(notSavedId)).isEmpty();
-        }
-    }
-
-    @Nested
     @DisplayName("회원이 좋아요한 템플릿 조회 테스트")
     class FindAllByMemberId {
 

--- a/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
@@ -26,6 +26,7 @@ import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
 import codezap.template.domain.Visibility;
 import codezap.template.dto.request.CreateSourceCodeRequest;
+import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateSourceCodeRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
 
@@ -47,7 +48,7 @@ class SourceCodeServiceTest extends ServiceTest {
             CreateSourceCodeRequest request2 = new CreateSourceCodeRequest("file2.java", "content2", 2);
 
             // when
-            sourceCodeService.createSourceCodes(template, List.of(request1, request2));
+            sourceCodeService.createSourceCodes(template, createSavedTemplateRequest(List.of(request1, request2)));
 
             // then
             List<SourceCode> sourceCodes = sourceCodeRepository.findAllByTemplate(template);
@@ -61,7 +62,6 @@ class SourceCodeServiceTest extends ServiceTest {
         }
 
         @Test
-        @Disabled("애플리케이션 코드에서 검증 코드 작성 필요")
         @DisplayName("실패: 순서 중복된 코드 존재")
         void createSourceCodes_WhenOrdinalIsDuplicate() {
             // given
@@ -70,17 +70,14 @@ class SourceCodeServiceTest extends ServiceTest {
             CreateSourceCodeRequest request1 = new CreateSourceCodeRequest("file1.java", "content1", sameOrdinal);
             CreateSourceCodeRequest request2 = new CreateSourceCodeRequest("file2.java", "content2", sameOrdinal);
 
-            // when
-            sourceCodeService.createSourceCodes(template, List.of(request1, request2));
-
-            // then
-            assertThatThrownBy(() -> sourceCodeRepository.findAllByTemplate(template))
+            // when & then
+            assertThatThrownBy(() -> sourceCodeService.createSourceCodes(
+                    template, createSavedTemplateRequest(List.of(request1, request2))))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("소스 코드의 순서는 중복될 수 없습니다.");
+                    .hasMessage("소스 코드 순서가 잘못되었습니다.");
         }
 
         @Test
-        @Disabled("애플리케이션 코드에서 검증 코드 작성 필요")
         @DisplayName("실패: 순서가 1부터 시작하지 않는 소스 코드")
         void createSourceCodes_WhenOrdinalIsNotStart1() {
             // given
@@ -88,17 +85,14 @@ class SourceCodeServiceTest extends ServiceTest {
             CreateSourceCodeRequest request1 = new CreateSourceCodeRequest("file1.java", "content1", 0);
             CreateSourceCodeRequest request2 = new CreateSourceCodeRequest("file2.java", "content2", 1);
 
-            // when
-            sourceCodeService.createSourceCodes(template, List.of(request1, request2));
-
-            // then
-            assertThatThrownBy(() -> sourceCodeRepository.findAllByTemplate(template))
+            // when & then
+            assertThatThrownBy(() -> sourceCodeService.createSourceCodes(
+                    template, createSavedTemplateRequest(List.of(request1, request2))))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("소스 코드의 순서는 1부터 시작해야 합니다.");
+                    .hasMessage("소스 코드 순서가 잘못되었습니다.");
         }
 
         @Test
-        @Disabled("애플리케이션 코드에서 검증 코드 작성 필요")
         @DisplayName("실패: 소스 코드의 순서들이 연속적이지 않은 경우")
         void createSourceCodes_WhenOrdinalIsNotSort() {
             // given
@@ -107,9 +101,10 @@ class SourceCodeServiceTest extends ServiceTest {
             CreateSourceCodeRequest request2 = new CreateSourceCodeRequest("file2.java", "content2", 3);
 
             // when & then
-            assertThatThrownBy(() -> sourceCodeService.createSourceCodes(template, List.of(request1, request2)))
+            assertThatThrownBy(() -> sourceCodeService.createSourceCodes(
+                    template, createSavedTemplateRequest(List.of(request1, request2))))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("소스 코드의 순서는 1부터 시작해야 합니다.");
+                    .hasMessage("소스 코드 순서가 잘못되었습니다.");
         }
     }
 
@@ -289,8 +284,8 @@ class SourceCodeServiceTest extends ServiceTest {
             SourceCode sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template, 2));
             Thumbnail thumbnail = thumbnailRepository.save(new Thumbnail(template, sourceCode1));
 
-            UpdateSourceCodeRequest ordinalUpdateRequest = new UpdateSourceCodeRequest(sourceCode1.getId(), "변경된 제목1",
-                    "변경된 내용1", 3);
+            UpdateSourceCodeRequest ordinalUpdateRequest = new UpdateSourceCodeRequest(
+                    sourceCode1.getId(), "변경된 제목1", "변경된 내용1", 3);
             UpdateSourceCodeRequest updateRequest2 = getUpdateSourceCodeRequest(sourceCode2);
             CreateSourceCodeRequest createRequest = new CreateSourceCodeRequest("새로운 제목3", "새로운 내용3",
                     sourceCode1.getOrdinal());
@@ -333,7 +328,8 @@ class SourceCodeServiceTest extends ServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
+            assertThatThrownBy(
+                    () -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("소스 코드는 최소 1개 입력해야 합니다.");
         }
@@ -357,7 +353,8 @@ class SourceCodeServiceTest extends ServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
+            assertThatThrownBy(
+                    () -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("소스 코드의 정보가 정확하지 않습니다.");
         }
@@ -384,7 +381,8 @@ class SourceCodeServiceTest extends ServiceTest {
             );
 
             // when & then
-            assertThatThrownBy(() -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
+            assertThatThrownBy(
+                    () -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("소스 코드의 순서는 중복될 수 없습니다.");
         }
@@ -473,5 +471,17 @@ class SourceCodeServiceTest extends ServiceTest {
         Member member = memberRepository.save(MemberFixture.getFirstMember());
         Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
         return templateRepository.save(TemplateFixture.get(member, category));
+    }
+
+    private CreateTemplateRequest createSavedTemplateRequest(List<CreateSourceCodeRequest> requests) {
+        return new CreateTemplateRequest(
+                "title",
+                "description",
+                requests,
+                1,
+                1L,
+                List.of(),
+                Visibility.PUBLIC
+        );
     }
 }

--- a/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
@@ -7,7 +7,6 @@ import static org.junit.jupiter.api.Assertions.assertAll;
 import java.util.Collections;
 import java.util.List;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -62,7 +61,6 @@ class SourceCodeServiceTest extends ServiceTest {
         }
 
         @Test
-        @Disabled("애플리케이션 코드에서 검증 코드 작성 필요")
         @DisplayName("실패: 순서 중복된 코드 존재")
         void createSourceCodes_WhenOrdinalIsDuplicate() {
             // given

--- a/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
@@ -314,7 +314,6 @@ class SourceCodeServiceTest extends ServiceTest {
         }
 
         @Test
-        @Disabled("현재는 전체 삭제를 막지 않고 thumbnail으로 인해 DataIntegrityViolationException 발생, 애플리케이션 코드에서 로직 변경 필요")
         @DisplayName("실패: 템플릿의 전체 소스 코드 삭제는 불가능함")
         void updateSourceCodes_WhenDeleteAll() {
             // given
@@ -336,7 +335,7 @@ class SourceCodeServiceTest extends ServiceTest {
             // when & then
             assertThatThrownBy(() -> sourceCodeService.updateSourceCodes(updateTemplateRequest, template, thumbnail))
                     .isInstanceOf(CodeZapException.class)
-                    .hasMessage("소스 코드는 최소 1개 이상 존재해야 합니다.");
+                    .hasMessage("소스 코드는 최소 1개 입력해야 합니다.");
         }
 
         @Test

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -111,22 +111,6 @@ class TemplateSearchServiceTest {
         }
 
         @Test
-        @Disabled("Pageable에 대한 null 검증이 필요함")
-        @DisplayName("검색 기능 실패: Pageable을 전달하지 않은 경우")
-        void findAllFailureWithNullPageable() {
-            Long memberId = member1.getId();
-            String keyword = null;
-            Long categoryId = null;
-            List<Long> tagIds = null;
-            Visibility visibility = null;
-            Pageable pageable = null;
-
-            assertThatThrownBy(() -> sut.findAllBy(memberId, keyword, categoryId, tagIds, visibility, pageable))
-                    .isInstanceOf(CodeZapException.class)
-                    .hasMessage("Pageable을 필수로 작성해야 합니다.");
-        }
-
-        @Test
         @DisplayName("검색 기능: 키워드로 템플릿 목록 조회 성공")
         void findAllSuccessByKeyword() {
             Long memberId = null;

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -106,39 +106,6 @@ class TemplateServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("멤버 ID로 템플릿 조회")
-    class GetByMemberId {
-
-        @Test
-        @DisplayName("멤버 id로 템플릿 조회 성공")
-        void getByMemberIdSuccess() {
-            var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var member2 = memberRepository.save(MemberFixture.getSecondMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var category2 = categoryRepository.save(CategoryFixture.getSecondCategory());
-            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
-            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
-            var template3 = templateRepository.save(TemplateFixture.get(member2, category2));
-
-            var actual = sut.getByMemberId(member1.getId());
-
-            assertThat(actual).hasSize(2)
-                    .containsExactly(template1, template2)
-                    .doesNotContain(template3);
-        }
-
-        @Test
-        @DisplayName("멤버 ID로 템플릿 조회 성공: 해당하는 템플릿이 없는 경우 빈 목록 반환")
-        void getByMemberIdSuccessWithEmptyList() {
-            var memberId = 100L;
-
-            var actual = sut.getByMemberId(memberId);
-
-            assertThat(actual).isEmpty();
-        }
-    }
-
-    @Nested
     @DisplayName("정렬 기능 테스트")
     class SortTest {
 

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -9,12 +9,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import java.time.LocalDateTime;
 import java.util.Collections;
 import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
 import java.util.stream.Stream;
 
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -35,7 +31,6 @@ import codezap.global.exception.CodeZapException;
 import codezap.global.exception.ErrorCode;
 import codezap.likes.domain.Likes;
 import codezap.member.domain.Member;
-import codezap.tag.domain.Tag;
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
@@ -84,37 +79,6 @@ class TemplateApplicationServiceTest extends ServiceTest {
             assertThatThrownBy(() -> sut.create(otherMember, request))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("해당 카테고리를 수정 또는 삭제할 권한이 없는 유저입니다.");
-        }
-
-        @Test
-        @Disabled("@Transactional 과 함께 사용 시 처리 불가능")
-        @DisplayName("동시성 테스트 - 태그 중복이 발생하지 않는지 확인")
-        void createTagsConcurrencyTest() throws InterruptedException {
-            // Given
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            CreateTemplateRequest createTemplateRequest = createTemplateRequest(category);
-
-            var member2 = memberRepository.save(MemberFixture.getSecondMember());
-            var category2 = categoryRepository.save(CategoryFixture.getSecondCategory());
-            CreateTemplateRequest createTemplateRequest2 = createTemplateRequest(category2);
-
-            // When
-            ExecutorService executorService = Executors.newFixedThreadPool(2);
-
-            executorService.execute(() -> sut.create(member, createTemplateRequest));
-            executorService.execute(() -> sut.create(member2, createTemplateRequest2));
-
-            executorService.shutdown();
-            executorService.awaitTermination(30, TimeUnit.SECONDS);
-
-            // Then
-            List<Tag> tags = tagRepository.findAllByNames(List.of("Spring"));
-            assertAll(
-                    () -> assertThat(tags).hasSize(1),
-                    () -> assertThat(templateRepository.findByMemberId(member.getId())).isNotEmpty(),
-                    () -> assertThat(templateRepository.findByMemberId(member2.getId())).isNotEmpty()
-            );
         }
 
         private static CreateTemplateRequest createTemplateRequest(Category category) {


### PR DESCRIPTION
## ⚡️ 관련 이슈
#948

## 📍주요 변경 사항
> 주요 변경 사항에 대해 작성해주세요.

- 사용하지 않는 메서드 제거 ( [COMMIT](https://github.com/woowacourse-teams/2024-code-zap/commit/e7ade222ad9d4921c145858114f2f158041a5075) )
- `@Disabled` 테스트 확인 후 수정 혹은 제거
  - 수정 혹은 제거한 이유에 대해서는 이슈에 작성
- 소스코드 순서 검증 시 현재까지는 순서가 뒤죽박죽이면 예외 발생하는 방식을 변경
  - 소스 코드 순서 검증 시 정렬하여 1부터 시작해 빠지는 값이 없다면 예외 발생하지 않게 수정
  - 이유 : 이전 코드는 소스코드 업데이트 시 무조건 업데이트 소스코드가 생성 소스코드보다 앞선 순서여야하기 때문. 추후 소스코드 순서 변경을 고려해서 구현한 코드인 만큼 생성 소스코드가 수정 소스코드보다 클 수 있어야한다고 생각했습니다.

이해를 돕기 위해 코드를 가져오면 소스코드 순서를 확인하기 위해 사용했던 순서를 알아내는 코드는 다음과 같았습니다.

```java
    public List<Integer> extractSourceCodesOrdinal() {
        return Stream.concat(
                        updateSourceCodes.stream().map(UpdateSourceCodeRequest::ordinal),
                        createSourceCodes.stream().map(CreateSourceCodeRequest::ordinal)
                )
                .toList();
    }
```

- @jminkkk 몰리가 태그 동시성 구현하면서 `@Disabled`로 만들었던 테스트를 제거했습니다. 이유는 사용하지 않는 이유로 제가 제거한 메서드인 `templateRepository.findByMemberId`을 사용해서 입니다 ! 혹시 다른 의견이 있거나, 해당 메서드를 사용하지 않고 테스트 코드를 두는 방식이 있다면 알려주세요 ~

- @zeus6768 , @zangsu  제우스가 만든 voc의 `@disabled` 테스트와 짱수가 만든 RandomSaltGeneratorTest의 난수 확인 `@disabled` 테스트의 추후 발전 가능성이 있는지 궁금합니다! 사용하지 않고 발전 가능성이 없다면 지우는 방향은 어떨까요? 동의하신다면 해당 PR에서 제거하고 싶습니다~

## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.

코드를 확인할 때 Commit 단위로 보면 더 편하실 것 같아요 ~
뒤로 갈수록 그렇게 예쁘게 분리하진 못했지만 그래도 그냥 보는 것보다는 편할 듯 싶습니다~

## 🍗 PR 첫 리뷰 마감 기한
12/27 20:00
