### PR TITLE
리뷰 요청 알람을 재리뷰 요청시에도 가도록 변경

### DIFF
--- a/.github/workflows/pr_notification.yml
+++ b/.github/workflows/pr_notification.yml
@@ -1,7 +1,7 @@
 name: PR Slack Notification
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [review_requested]
 jobs:
   notify_reviewers:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #998

## 📍주요 변경 사항
리뷰 요청 알람을 PR 오픈 시가 아닌 리뷰 요청시로 변경했어요~!
이제 카톡으로 리뷰 반영 했다고 말 안해도 됨!

깃헙에서 리뷰 재요청 하면 됩니당~

## 🍗 PR 첫 리뷰 마감 기한
12/28 23:59
