### PR TITLE
태그 중복 생성 시 재시도 처리의 위치를 변경

### DIFF
--- a/backend/src/main/java/codezap/tag/service/TagService.java
+++ b/backend/src/main/java/codezap/tag/service/TagService.java
@@ -2,6 +2,8 @@ package codezap.tag.service;
 
 import java.util.List;
 
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -22,6 +24,7 @@ public class TagService {
     private final TagRepository tagRepository;
     private final TemplateTagRepository templateTagRepository;
 
+    @Retryable(retryFor = DataIntegrityViolationException.class)
     @Transactional
     public void createTags(Template template, List<String> tagNames) {
         List<Tag> existTags = tagRepository.findAllByNames(tagNames);

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -47,7 +47,6 @@ public class TemplateApplicationService {
     private final ThumbnailService thumbnailService;
     private final LikesService likesService;
 
-    @Retryable(retryFor = DataIntegrityViolationException.class, maxAttempts = 3)
     @Transactional
     public Long create(Member member, CreateTemplateRequest request) {
         Category category = categoryService.fetchById(request.categoryId());

--- a/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
+++ b/backend/src/main/java/codezap/template/service/facade/TemplateApplicationService.java
@@ -4,9 +4,7 @@ import java.util.List;
 
 import jakarta.annotation.Nullable;
 
-import org.springframework.dao.DataIntegrityViolationException;
 import org.springframework.data.domain.Pageable;
-import org.springframework.retry.annotation.Retryable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #960

## 📍주요 변경 사항
전체 템플릿 저장을 재시도하지 않고, 태그 생성 로직만 재시도 처리합니다.
전체를 재시도하는 것보다 더 효율적일 것 같아요.

## 🍗 PR 첫 리뷰 마감 기한
01/03 13:00
