### PR TITLE
Default yml에서 was, voc 프로파일 제거

### DIFF
--- a/backend/src/main/resources/application.yml
+++ b/backend/src/main/resources/application.yml
@@ -1,6 +1,6 @@
 spring:
   profiles:
     group:
-      default: local, voc, was
+      default: local
       dev: db, actuator, swagger, cors, voc, was
       prod: db, actuator, swagger, cors, voc, was


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #1008

## 📍주요 변경 사항
default에 was, voc를 제거합니다.

회의 결과에 따라 앞으로 기본 yml인 로컬 yml에서는 내부에서 추가하여 사용합니다~!!


## 🍗 PR 첫 리뷰 마감 기한
01/04 16:00
