### PR TITLE
프론트엔드 github actions CD 스크립트

### DIFF
--- a/.github/workflows/frontend_cd.yml
+++ b/.github/workflows/frontend_cd.yml
@@ -26,10 +26,11 @@ jobs:
         run: |
           if [ "${{ github.ref_name }}" == "main" ]; then
             echo "REACT_APP_API_URL=${{ secrets.REACT_APP_API_URL }}" > ${{ env.frontend-directory }}/.env.production
+            echo "APP_ENV=${{ secrets.APP_ENV_PROD }}" >> ${{ env.frontend-directory }}/.env.production
           else
             echo "REACT_APP_API_URL=${{ secrets.REACT_APP_BETA_API_URL }}" > ${{ env.frontend-directory }}/.env.production
+            echo "APP_ENV=${{ secrets.APP_ENV_DEV }}" >> ${{ env.frontend-directory }}/.env.production
           fi
-          echo "APP_ENV=${{ secrets.APP_ENV }}" >> ${{ env.frontend-directory }}/.env.production
           echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> ${{ env.frontend-directory }}/.env.production
           echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> ${{ env.frontend-directory }}/.env.sentry-build-plugin
           echo "AMPLITUDE_API_KEY=${{ secrets.AMPLITUDE_API_KEY }}" >> ${{ env.frontend-directory }}/.env.production

--- a/.github/workflows/frontend_cd.yml
+++ b/.github/workflows/frontend_cd.yml
@@ -1,0 +1,74 @@
+name: Frontend CD
+
+on:
+  push:
+    branches:
+      - main
+      - dev/fe
+    paths:
+      - "frontend/**"
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    env:
+      frontend-directory: ./frontend
+    steps:
+      - name: 체크아웃
+        uses: actions/checkout@v4
+
+      - name: Node.js 설치
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: 환경 파일 생성
+        run: |
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            echo "REACT_APP_API_URL=${{ secrets.REACT_APP_API_URL }}" > ${{ env.frontend-directory }}/.env.production
+          else
+            echo "REACT_APP_API_URL=${{ secrets.REACT_APP_BETA_API_URL }}" > ${{ env.frontend-directory }}/.env.production
+          fi
+          echo "APP_ENV=${{ secrets.APP_ENV }}" >> ${{ env.frontend-directory }}/.env.production
+          echo "SENTRY_DSN=${{ secrets.SENTRY_DSN }}" >> ${{ env.frontend-directory }}/.env.production
+          echo "SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}" >> ${{ env.frontend-directory }}/.env.sentry-build-plugin
+          echo "AMPLITUDE_API_KEY=${{ secrets.AMPLITUDE_API_KEY }}" >> ${{ env.frontend-directory }}/.env.production
+
+      - name: 환경 파일 권한 설정
+        run: chmod 644 ${{ env.frontend-directory }}/.env.*
+
+      - name: npm install
+        run: npm install
+        working-directory: ${{ env.frontend-directory }}
+
+      - name: npm run build
+        run: npm run build
+        working-directory: ${{ env.frontend-directory }}
+
+      - name: AWS credentials 설정
+        uses: aws-actions/configure-aws-credentials@v3
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ap-northeast-2
+
+      - name: S3 업로드
+        run: |
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }}/prod/ --delete
+          else
+            aws s3 sync ./dist s3://${{ secrets.S3_BUCKET_NAME }}/dev/ --delete
+          fi
+        working-directory: ${{ env.frontend-directory }}
+
+      - name: CloudFront 캐시 무효화
+        run: |
+          if [ "${{ github.ref_name }}" == "main" ]; then
+            aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_PROD }} \
+            --paths "/*"
+          else
+            aws cloudfront create-invalidation \
+            --distribution-id ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }} \
+            --paths "/*"
+          fi


### PR DESCRIPTION
## ⚡️ 관련 이슈
- close #949 

## 📍주요 변경 사항
- 프론트엔드 CD 스크립트 작성
clone 받은 개인 레포지토리 dev/fe 브랜치에서 테스트해보았고 잘 동작합니다.

이전 codePipeline에서 작업하던 CD를 github actions로 마이그레이션합니다.
현재 사용되고 있는 `AWS credentials`에는 S3와 cloudFront Full access 권한이 들어가 있습니다.
IAM 이름은 frontend-dev 입니다
(frontend-prod는 누가 만든건가요?)
<img width="731" alt="스크린샷 2025-01-04 오전 2 16 57" src="https://github.com/user-attachments/assets/9b1bca57-faf1-4fd7-bfbd-41dfbc6eeded" />

각 환경 변수 넣어놓겠습니다.
`AWS_ACCESS_KEY_ID` : 엑세스 키 ID
`AWS_SECRET_ACCESS_KEY` : 엑세스 시크릿 키
`S3_BUCKET_NAME` :  버킷 이름
`CLOUDFRONT_DISTRIBUTION_ID_PROD` : cloudFront의 ID (프로덕션)
`CLOUDFRONT_DISTRIBUTION_ID_DEV` : cloudFront의 ID (개발서버)

## 🎸기타
> 고려해야 하는 내용을 작성해 주세요.


## 🍗 PR 첫 리뷰 마감 기한
01/07 23:59
