### PR TITLE
ordinal 컬럼 생성 시 멤버별로 순서대로 ordinal 설정

### DIFF
--- a/backend/src/main/resources/db/migration/V12__add_category_ordinal.sql
+++ b/backend/src/main/resources/db/migration/V12__add_category_ordinal.sql
@@ -1,2 +1,15 @@
 ALTER TABLE category ADD COLUMN ordinal INTEGER NOT NULL;
+
+CREATE TEMPORARY TABLE temp_category AS
+SELECT
+    id,
+    ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY id) - 1 AS new_ordinal
+FROM category;
+
+UPDATE category c
+    JOIN temp_category t ON c.id = t.id
+    SET c.ordinal = t.new_ordinal;
+
+DROP TEMPORARY TABLE temp_category;
+
 ALTER TABLE category ADD CONSTRAINT ordinal_with_member UNIQUE (member_id, ordinal);

--- a/backend/src/main/resources/db/migration/V12__add_category_ordinal.sql
+++ b/backend/src/main/resources/db/migration/V12__add_category_ordinal.sql
@@ -1,3 +1,5 @@
+START TRANSACTION;
+
 ALTER TABLE category ADD COLUMN ordinal INTEGER NOT NULL;
 
 CREATE TEMPORARY TABLE temp_category AS
@@ -13,3 +15,5 @@ UPDATE category c
 DROP TEMPORARY TABLE temp_category;
 
 ALTER TABLE category ADD CONSTRAINT ordinal_with_member UNIQUE (member_id, ordinal);
+
+COMMIT;


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #966

## 📍주요 변경 사항
member id와 ordinal에 복합 유니크 키를 설정할 때 에러가 발생하였습니다.
발생한 이유는 다음과 같습니다.
1. category 테이블에 ordinal 컬럼 생성
2. 모든 ordinal이 0으로 생성됨
3. 복합 유니크 키 설정 시 중복된 값이 있어 에러 발생

이에 따라 ordinal 컬럼을 생성할 때 순차적으로 ordinal이 생성되도록 쿼리를 추가하였습니다.
```sql
CREATE TEMPORARY TABLE temp_category AS
SELECT
    id,
    ROW_NUMBER() OVER (PARTITION BY member_id ORDER BY id) - 1 AS new_ordinal
FROM category;
```
- `PARTITION BY member_id`: `member_id`별로 그룹화.
- `ORDER BY id`: 각 그룹 내에서 `id` 순서대로 정렬.
- `ROW_NUMBER()` 결과는 1부터 시작하므로 -1을 해서 0(`default category`)부터 시작하도록 조정합니다.

```sql
UPDATE category c
    JOIN temp_category t ON c.id = t.id
    SET c.ordinal = t.new_ordinal;
```
- category 테이블에 ordinal 값 업데이트 임시 테이블(`temp_category`)을 이용해 `category` 테이블의 `ordinal` 값을 업데이트합니다.

```sql
DROP TEMPORARY TABLE temp_category;
```
- 임시 테이블 삭제

## 🎸기타
> 개발 서버에서 쿼리를 직접 실행하여 정상동작 확인하였습니다.


## 🍗 PR 첫 리뷰 마감 기한
1/8(수) 23:59
