### PR TITLE
요청 헤더에 Authorization 필드 추가

### DIFF
--- a/frontend/src/api/authentication.ts
+++ b/frontend/src/api/authentication.ts
@@ -4,11 +4,7 @@ import type { LoginRequest, SignupRequest } from '@/types';
 
 export const postSignup = async (signupInfo: SignupRequest) => await apiClient.post(END_POINTS.SIGNUP, signupInfo);
 
-export const postLogin = async (loginInfo: LoginRequest) => {
-  const response = await apiClient.post(END_POINTS.LOGIN, loginInfo);
-
-  return await response.json();
-};
+export const postLogin = async (loginInfo: LoginRequest) => await apiClient.post(END_POINTS.LOGIN, loginInfo);
 
 export const postLogout = async () => await apiClient.post(END_POINTS.LOGOUT, {});
 

--- a/frontend/src/api/config.ts
+++ b/frontend/src/api/config.ts
@@ -4,7 +4,6 @@ export const API_URL = process.env.REACT_APP_API_URL ?? 'https://default-url.com
 
 const httpHeader = {
   'Content-Type': 'application/json',
-};
-const httpCredentials = 'include';
+}
 
-export const apiClient = new ApiClient(API_URL, httpHeader, httpCredentials);
+export const apiClient = new ApiClient(API_URL, httpHeader);

--- a/frontend/src/queries/authentication/useLoginMutation.ts
+++ b/frontend/src/queries/authentication/useLoginMutation.ts
@@ -12,15 +12,19 @@ export const useLoginMutation = () => {
   const { failAlert, successAlert } = useCustomContext(ToastContext);
   const navigate = useCustomNavigate();
 
-  return useMutation<MemberInfo, Error, LoginRequest>({
+  return useMutation<Response, Error, LoginRequest>({
     mutationFn: (loginInfo: LoginRequest) => postLogin(loginInfo),
-    onSuccess: (res) => {
-      const { memberId, name } = res;
+    onSuccess: async (res) => {
+      const authorization = res.headers.get('authorization');
+
+      const response = await res.json() as MemberInfo;
+      const { memberId, name } = response;
 
       if (memberId && name) {
         localStorage.setItem('name', String(name));
         localStorage.setItem('memberId', String(memberId));
-        handleMemberInfo(res);
+        localStorage.setItem('authorization', String(authorization));
+        handleMemberInfo({ memberId, name });
         handleLoginState(true);
         successAlert('로그인 성공!');
         navigate(END_POINTS.memberTemplates(memberId));

--- a/frontend/src/queries/authentication/useLogoutMutation.ts
+++ b/frontend/src/queries/authentication/useLogoutMutation.ts
@@ -14,6 +14,7 @@ export const useLogoutMutation = () => {
     onSuccess: () => {
       localStorage.removeItem('name');
       localStorage.removeItem('memberId');
+      localStorage.removeItem('authorization');
       handleLoginState(false);
       successAlert('로그아웃 성공!');
     },


### PR DESCRIPTION
## ⚡️ 관련 이슈
- #908 

## 📍주요 변경 사항
- 쿠키를 보내기 위해 apiClient 인스턴스 생성 시, credential을 'include'로 하는 설정을 제거했습니다.
- Auth 헤더는 `useLoginMutation` 훅에서 로그인 성공 시, localStorage에 저장합니다.
- 이후 모든 요청에 Auth 헤더를 추가합니다


## 🎸기타
- localStorage에 들어갈 값과 자료구조를 생각해봐야합니다. 만약 현재 name, memberId, auth 토큰 모두 쓴다면 이 셋을 하나의 auth 관련 객체로 하나의 키, 값으로 저장하고자 합니다.
현재는 세가지 값이 각각 하나의 키, 값으로 들어갑니다.

```
// 변경 예시
code-zap_auth : {
  name: ll,
  memberId: 23232,
  authorization: daffa~~
}
```


## 🍗 PR 첫 리뷰 마감 기한
01/15 23:59
