### PR TITLE
QueryDSL 버전 업그레이드

### DIFF
--- a/backend/build.gradle
+++ b/backend/build.gradle
@@ -34,10 +34,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j:9.0.0'
     implementation 'org.flywaydb:flyway-core'
     implementation 'org.flywaydb:flyway-mysql'
-    implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
-    annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
-    annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
-    annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
+
+    implementation 'io.github.openfeign.querydsl:querydsl-jpa-spring:6.10.1'
+    annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'io.rest-assured:rest-assured:5.5.0'


### PR DESCRIPTION
## ⚡️ 관련 이슈
#1001 

## 📍주요 변경 사항

이슈 참고 바라요 😃

## AS-IS
```gradle
implementation 'com.querydsl:querydsl-jpa:5.0.0:jakarta'
annotationProcessor 'com.querydsl:querydsl-apt:5.0.0:jakarta'
annotationProcessor 'jakarta.persistence:jakarta.persistence-api:3.1.0'
annotationProcessor 'jakarta.annotation:jakarta.annotation-api:2.1.1'
```

## TO-BE
```gradle
implementation 'io.github.openfeign.querydsl:querydsl-jpa-spring:6.10.1'
annotationProcessor 'io.github.openfeign.querydsl:querydsl-apt:6.10.1:jpa'
```

## 🍗 PR 첫 리뷰 마감 기한
01/14 23:59
