### PR TITLE
/login/check API의 응답 형식 변경

### DIFF
--- a/backend/src/main/java/codezap/auth/controller/AuthController.java
+++ b/backend/src/main/java/codezap/auth/controller/AuthController.java
@@ -2,7 +2,6 @@ package codezap.auth.controller;
 
 import java.util.List;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import jakarta.validation.Valid;
 
@@ -16,6 +15,7 @@ import codezap.auth.configuration.AuthenticationPrinciple;
 import codezap.auth.dto.Credential;
 import codezap.auth.dto.LoginMember;
 import codezap.auth.dto.request.LoginRequest;
+import codezap.auth.dto.response.CheckLoginResponse;
 import codezap.auth.dto.response.LoginResponse;
 import codezap.auth.manager.CredentialManager;
 import codezap.auth.provider.CredentialProvider;
@@ -45,14 +45,11 @@ public class AuthController implements SpringDocAuthController {
     }
 
     @GetMapping("/login/check")
-    public ResponseEntity<Void> checkLogin(
-            @AuthenticationPrinciple Member member,
-            HttpServletRequest httpServletRequest
-    ) {
+    public ResponseEntity<CheckLoginResponse> checkLogin(@AuthenticationPrinciple Member member) {
         if (member == null) {
             throw new CodeZapException(ErrorCode.UNAUTHORIZED_USER, "인증 정보가 없습니다. 다시 로그인해 주세요.");
         }
-        return ResponseEntity.ok().build();
+        return ResponseEntity.ok(new CheckLoginResponse(member));
     }
 
     @PostMapping("/logout")

--- a/backend/src/main/java/codezap/auth/controller/SpringDocAuthController.java
+++ b/backend/src/main/java/codezap/auth/controller/SpringDocAuthController.java
@@ -1,12 +1,12 @@
 package codezap.auth.controller;
 
-import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import codezap.auth.dto.request.LoginRequest;
+import codezap.auth.dto.response.CheckLoginResponse;
 import codezap.auth.dto.response.LoginResponse;
 import codezap.global.swagger.error.ApiErrorResponse;
 import codezap.global.swagger.error.ErrorCase;
@@ -42,7 +42,7 @@ public interface SpringDocAuthController {
             @ErrorCase(description = "쿠키 없음", exampleMessage = "쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."),
             @ErrorCase(description = "인증 쿠키 없음", exampleMessage = "인증에 대한 쿠키가 없어서 회원 정보를 찾을 수 없습니다. 다시 로그인해주세요."),
     })
-    ResponseEntity<Void> checkLogin(Member member, HttpServletRequest request);
+    ResponseEntity<CheckLoginResponse> checkLogin(Member member);
 
     @Operation(summary = "로그아웃")
     @ApiResponse(responseCode = "204", description = "인증 성공")

--- a/backend/src/main/java/codezap/auth/dto/response/CheckLoginResponse.java
+++ b/backend/src/main/java/codezap/auth/dto/response/CheckLoginResponse.java
@@ -1,0 +1,9 @@
+package codezap.auth.dto.response;
+
+import codezap.member.domain.Member;
+
+public record CheckLoginResponse(long id, String name) {
+    public CheckLoginResponse(Member member) {
+        this(member.getId(), member.getName());
+    }
+}


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #1038 

### 작업 배경 : 프론트엔드의 요청

>현재 프론트는 한번 로그인하면 name, memberId를  localStorage에 저장하는데 
>1. auth token을 이제 localStorage에 보관해서 로그인 유지하려고 합니다. 이 token을 프론트에서 저장하면 name과 memberId는 이제 저장 안해도 될 것 같아요. 처음 서비스 진입 시 '/login/check' 요청을 하고 이 응답에 name, memberId를 받아오고 이는 localStorage가 아닌 프론트 코드 내부 변수로 갖고 있어도 될듯.
>2. name, memberId가 localStorage에 있느냐로 로그인 여부 판단했기에 땜에 그동안 여러 계정으로 로그인하거나 그럴때 이슈가 많기도 했음,,
## 📍주요 변경 사항

### As-is
응답 본문 없이 상태 코드 200으로만 로그인 여부를 판단

```http
HTTP/1.1 200

```

### To-be
응답 본문에 사용자의 id와 이름을 포함

```http
HTTP/1.1 200

{
  "id": 1,
  "name": "만두"
}
```

### 추가 작업
사용하지 않는 HttpServletRequest 타입의 파라미터도 삭제했어요. 

## 🎸기타
이름, 닉네임, 사용자명... 용어 통일하고 싶군요

## 🍗 PR 첫 리뷰 마감 기한
01/21 18:00
