### PR TITLE
테스트 시 혼재된 생성 로직과 픽스처 사용을 픽스처 사용으로 통합

### DIFF
--- a/backend/src/main/java/codezap/category/dto/request/UpdateAllCategoriesRequest.java
+++ b/backend/src/main/java/codezap/category/dto/request/UpdateAllCategoriesRequest.java
@@ -6,10 +6,10 @@ import java.util.stream.Stream;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotNull;
 
-import codezap.category.dto.request.validation.ValidatedDuplicateNameRequest;
 import codezap.category.dto.request.validation.ValidatedDuplicateIdRequest;
-import codezap.global.validation.ValidationGroups.NotNullGroup;
+import codezap.category.dto.request.validation.ValidatedDuplicateNameRequest;
 import codezap.global.validation.ValidatedOrdinalRequest;
+import codezap.global.validation.ValidationGroups.NotNullGroup;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UpdateAllCategoriesRequest(

--- a/backend/src/main/java/codezap/likes/service/LikesService.java
+++ b/backend/src/main/java/codezap/likes/service/LikesService.java
@@ -2,11 +2,9 @@ package codezap.likes.service;
 
 import java.util.List;
 
-import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import codezap.global.pagination.FixedPage;
 import codezap.likes.domain.Likes;
 import codezap.likes.repository.LikesRepository;
 import codezap.member.domain.Member;

--- a/backend/src/main/java/codezap/tag/repository/TagQueryDSLRepository.java
+++ b/backend/src/main/java/codezap/tag/repository/TagQueryDSLRepository.java
@@ -4,16 +4,13 @@ import static codezap.tag.domain.QTag.tag;
 import static codezap.template.domain.QTemplateTag.templateTag;
 
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 
 import org.springframework.stereotype.Repository;
 
 import com.querydsl.jpa.impl.JPAQueryFactory;
 
-import codezap.tag.domain.QTag;
 import codezap.tag.domain.Tag;
-import codezap.template.domain.QTemplateTag;
 import lombok.RequiredArgsConstructor;
 
 @Repository

--- a/backend/src/main/java/codezap/template/domain/Template.java
+++ b/backend/src/main/java/codezap/template/domain/Template.java
@@ -65,10 +65,6 @@ public class Template extends SkipModifiedAtBaseTimeEntity {
     @Enumerated(EnumType.STRING)
     private Visibility visibility;
 
-    public Template(Member member, String title, String description, Category category) {
-        this(member, title, description, category, Visibility.PUBLIC);
-    }
-
     public Template(Member member, String title, String description, Category category, Visibility visibility) {
         this(null, member, title, description, category, null, 0L, visibility);
     }

--- a/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/CreateTemplateRequest.java
@@ -8,10 +8,10 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import codezap.global.validation.ByteLength;
+import codezap.global.validation.ValidatedOrdinalRequest;
 import codezap.global.validation.ValidationGroups.NotNullGroup;
 import codezap.global.validation.ValidationGroups.SizeCheckGroup;
 import codezap.template.domain.Visibility;
-import codezap.global.validation.ValidatedOrdinalRequest;
 import codezap.template.dto.request.validation.ValidatedSourceCodesCountRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 

--- a/backend/src/main/java/codezap/template/dto/request/UpdateTemplateRequest.java
+++ b/backend/src/main/java/codezap/template/dto/request/UpdateTemplateRequest.java
@@ -9,11 +9,11 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 
 import codezap.global.validation.ByteLength;
+import codezap.global.validation.ValidatedOrdinalRequest;
 import codezap.global.validation.ValidationGroups.NotNullGroup;
 import codezap.global.validation.ValidationGroups.SizeCheckGroup;
 import codezap.template.domain.Visibility;
 import codezap.template.dto.request.validation.ValidatedSourceCodesCountRequest;
-import codezap.global.validation.ValidatedOrdinalRequest;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 public record UpdateTemplateRequest(

--- a/backend/src/main/java/codezap/template/repository/ThumbnailRepository.java
+++ b/backend/src/main/java/codezap/template/repository/ThumbnailRepository.java
@@ -1,7 +1,6 @@
 package codezap.template.repository;
 
 import java.util.List;
-import java.util.Optional;
 
 import org.springframework.stereotype.Repository;
 

--- a/backend/src/main/java/codezap/template/service/SourceCodeService.java
+++ b/backend/src/main/java/codezap/template/service/SourceCodeService.java
@@ -9,6 +9,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import codezap.global.exception.CodeZapException;
 import codezap.global.exception.ErrorCode;
+import codezap.global.validation.ValidatedOrdinalRequest;
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
@@ -16,7 +17,6 @@ import codezap.template.dto.request.CreateSourceCodeRequest;
 import codezap.template.dto.request.CreateTemplateRequest;
 import codezap.template.dto.request.UpdateSourceCodeRequest;
 import codezap.template.dto.request.UpdateTemplateRequest;
-import codezap.global.validation.ValidatedOrdinalRequest;
 import codezap.template.dto.request.validation.ValidatedSourceCodesCountRequest;
 import codezap.template.repository.SourceCodeRepository;
 import lombok.RequiredArgsConstructor;

--- a/backend/src/main/java/codezap/template/service/ThumbnailService.java
+++ b/backend/src/main/java/codezap/template/service/ThumbnailService.java
@@ -8,7 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
-import codezap.template.dto.response.ExploreTemplatesResponse;
 import codezap.template.repository.ThumbnailRepository;
 import lombok.RequiredArgsConstructor;
 

--- a/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
+++ b/backend/src/test/java/codezap/category/controller/CategoryControllerTest.java
@@ -27,6 +27,7 @@ import codezap.category.dto.request.UpdateAllCategoriesRequest;
 import codezap.category.dto.request.UpdateCategoryRequest;
 import codezap.category.dto.response.CreateCategoryResponse;
 import codezap.category.dto.response.FindAllCategoriesResponse;
+import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.global.MockMvcTest;
 import codezap.global.exception.CodeZapException;
@@ -102,7 +103,7 @@ class CategoryControllerTest extends MockMvcTest {
     void findAllCategoriesSuccess() throws Exception {
         // given
         Member member = MemberFixture.getFirstMember();
-        List<Category> categories = List.of(new Category("category1", member, 1), new Category("category1", member, 2));
+        List<Category> categories = CategoryFixture.getList(member, 2);
         FindAllCategoriesResponse findAllCategoriesResponse = FindAllCategoriesResponse.from(categories);
 
         when(categoryService.findAllByMemberId(any())).thenReturn(findAllCategoriesResponse);

--- a/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
+++ b/backend/src/test/java/codezap/category/repository/CategoryRepositoryTest.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.junit.jupiter.api.Assertions.assertAll;
 
+import java.util.List;
+
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -33,8 +35,8 @@ public class CategoryRepositoryTest {
         @Test
         @DisplayName("Id로 카테고리 조회 성공")
         void fetchByIdSuccess() {
-            memberRepository.save(MemberFixture.getFirstMember());
-            var category = sut.save(CategoryFixture.getFirstCategory());
+            var member = memberRepository.save(MemberFixture.getFirstMember());
+            var category = sut.save(CategoryFixture.getDefaultCategory(member));
 
             var actual = sut.fetchById(category.getId());
 
@@ -89,10 +91,10 @@ public class CategoryRepositoryTest {
         void existsByNameAndMemberSuccess() {
             var member = new Member("Zappy", "password", "salt");
             memberRepository.save(member);
-            var category1 = new Category("category1", member, 1);
+            var category1 = CategoryFixture.getDefaultCategory(member);
             sut.save(category1);
 
-            var actual = sut.existsByNameAndMember("category1", member);
+            var actual = sut.existsByNameAndMember(category1.getName(), member);
 
             assertThat(actual).isTrue();
         }
@@ -102,7 +104,7 @@ public class CategoryRepositoryTest {
         void existsByNameAndMemberFail() {
             var member = new Member("Zappy", "password", "salt");
             memberRepository.save(member);
-            var category1 = new Category("category1", member, 1);
+            var category1 = CategoryFixture.getDefaultCategory(member);
             sut.save(category1);
 
             var actual = sut.existsByNameAndMember("category2", member);
@@ -118,16 +120,11 @@ public class CategoryRepositoryTest {
         @Test
         @DisplayName("회원으로 카테고리 개수 조회 성공")
         void countByMemberSuccess() {
-            var member1 = new Member("Zappy1", "password", "salt");
-            var member2 = new Member("Zappy2", "password", "salt");
-            memberRepository.save(member1);
-            memberRepository.save(member2);
-            var category1 = new Category("category1", member1, 1);
-            var category2 = new Category("category2", member1, 2);
-            var category3 = new Category("category3", member2, 1);
-            sut.save(category1);
-            sut.save(category2);
-            sut.save(category3);
+            var member1 = memberRepository.save(MemberFixture.getFirstMember());
+            var member2 = memberRepository.save(MemberFixture.getSecondMember());
+            sut.save(new Category("category1", member1, 1));
+            sut.save(new Category("category2", member1, 2));
+            sut.save(new Category("category3", member2, 1));
 
             long actual = sut.countByMember(member1);
 

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -172,7 +172,6 @@ class CategoryServiceTest extends ServiceTest {
         @BeforeEach
         void saveDefaultCategory() {
             member = memberRepository.save(MemberFixture.getFirstMember());
-            defaultCategory = categoryRepository.save(Category.createDefaultCategory(member));
         }
 
         @Test

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -167,7 +167,6 @@ class CategoryServiceTest extends ServiceTest {
     class UpdateCategoryTest {
 
         Member member;
-        Category defaultCategory;
 
         @BeforeEach
         void saveDefaultCategory() {
@@ -179,8 +178,9 @@ class CategoryServiceTest extends ServiceTest {
         void updateCategoriesSuccess() {
             String createCategoryName = "createName";
             String updateCategoryName = "updateName1";
-            Category category1 = categoryRepository.save(new Category("category1", member, 1));
-            Category category2 = categoryRepository.save(new Category("category2", member, 2));
+            Category defaultCategory = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Category category1 = categoryRepository.save(new Category("category1", member, 2));
+            Category category2 = categoryRepository.save(new Category("category2", member, 3));
 
             CreateCategoryRequest createRequest = new CreateCategoryRequest(createCategoryName, 1);
             UpdateCategoryRequest updateRequest = new UpdateCategoryRequest(category1.getId(), updateCategoryName, 2);
@@ -201,9 +201,10 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 성공: 복수의 카테고리 순서 변경")
         void updateCategoriesSuccessWithChangeOdinal() {
-            Category category1 = categoryRepository.save(new Category("category1", member, 1));
-            Category category2 = categoryRepository.save(new Category("category2", member, 2));
-            Category category3 = categoryRepository.save(new Category("category3", member, 3));
+            Category defaultCategory = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Category category1 = categoryRepository.save(new Category("category1", member, 2));
+            Category category2 = categoryRepository.save(new Category("category2", member, 3));
+            Category category3 = categoryRepository.save(new Category("category3", member, 4));
 
             CreateCategoryRequest createRequest = new CreateCategoryRequest("newCategory", 3);
             UpdateCategoryRequest updateRequest1 = new UpdateCategoryRequest(category1.getId(), "category1", 2);
@@ -243,7 +244,7 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 실패: 기본 카테고리 수정")
         void updateCategoriesFailWithDefaultCategory() {
-            categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Category defaultCategory = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
 
             UpdateCategoryRequest request = new UpdateCategoryRequest(defaultCategory.getId(), "updateName", 1);
 
@@ -375,7 +376,7 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 실패: 기본 카테고리 삭제")
         void deleteByIdFailDefaultCategory() {
-            categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Category defaultCategory = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
 
             assertThatThrownBy(
                     () -> sut.updateCategories(member, new UpdateAllCategoriesRequest(
@@ -404,8 +405,9 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 실패: 잘못된 개수의 카테고리")
         void deleteByIdFailWrongCount() {
-            Category category1 = categoryRepository.save(new Category("카테고리 1", member, 1));
-            categoryRepository.save(new Category("카테고리 2", member, 2));
+            Category defaultCategory = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Category category1 = categoryRepository.save(new Category("카테고리 1", member, 2));
+            categoryRepository.save(new Category("카테고리 2", member, 3));
             UpdateCategoryRequest request = new UpdateCategoryRequest(category1.getId(), category1.getName(), 1);
 
             assertThatThrownBy(

--- a/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
+++ b/backend/src/test/java/codezap/category/service/CategoryServiceTest.java
@@ -295,7 +295,7 @@ class CategoryServiceTest extends ServiceTest {
         @DisplayName("카테고리 편집 실패: 중복된 순서")
         void duplicatedCategoryOrdinal() {
             Category category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
-            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member));
+            Category category2 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
 
             CreateCategoryRequest createRequest = new CreateCategoryRequest("category3", category2.getOrdinal());
             UpdateCategoryRequest request1 = new UpdateCategoryRequest(category1.getId(), category1.getName(), 2);
@@ -314,7 +314,7 @@ class CategoryServiceTest extends ServiceTest {
         @DisplayName("카테고리 편집 실패: 연속되지 않는 순서")
         void nonSequentialCategoryOrdinal() {
             Category category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
-            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member));
+            Category category2 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
 
             CreateCategoryRequest createRequest = new CreateCategoryRequest("category3", 4);
             UpdateCategoryRequest request1 = new UpdateCategoryRequest(category1.getId(), category1.getName(), 2);
@@ -332,7 +332,7 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 실패: 삭제 권한 없음")
         void updateCategoriesFailWithUnauthorizedDelete() {
-            categoryRepository.save(CategoryFixture.getCategory(member));
+            categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
             Member otherMember = memberRepository.save(MemberFixture.createFixture("otherMember"));
 
             assertThatThrownBy(
@@ -361,7 +361,7 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 실패: 템플릿이 존재하는 카테고리 삭제")
         void deleteByIdFailExistsTemplate() {
-            Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+            Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
             templateRepository.save(TemplateFixture.get(member, category));
 
             assertThatThrownBy(
@@ -390,7 +390,7 @@ class CategoryServiceTest extends ServiceTest {
         @Test
         @DisplayName("카테고리 편집 실패: 중복된 id 수정 및 삭제")
         void deleteByIdFailDuplicatedId() {
-            Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+            Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
             UpdateCategoryRequest request = new UpdateCategoryRequest(category.getId(), category.getName(), 1);
 
             assertThatThrownBy(

--- a/backend/src/test/java/codezap/fixture/CategoryFixture.java
+++ b/backend/src/test/java/codezap/fixture/CategoryFixture.java
@@ -1,18 +1,25 @@
 package codezap.fixture;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
 import codezap.category.domain.Category;
 import codezap.member.domain.Member;
 
 public class CategoryFixture {
-    public static Category getFirstCategory() {
-        return new Category(1L, MemberFixture.getFirstMember(), "카테고리 없음", true, 1);
+    public static Category getDefaultCategory(Member member) {
+        return new Category(1L, member, "카테고리 없음", true, 1);
     }
 
-    public static Category getSecondCategory() {
-        return new Category(2L, MemberFixture.getSecondMember(), "자바", true, 2);
+    public static Category getCategory(Member member) {
+        return new Category(2L, member, "카테고리", false, 2);
     }
 
-    public static Category get(Member member) {
-        return new Category("카테고리", member, 1);
+    public static List<Category> getList(Member member, int size) {
+        List<Category> categories = new ArrayList<>();
+        categories.add(getDefaultCategory(member));
+        IntStream.range(1, size).forEach(i ->  categories.add(new Category("카테고리" + i, member, i + 1)));
+        return categories;
     }
 }

--- a/backend/src/test/java/codezap/fixture/CategoryFixture.java
+++ b/backend/src/test/java/codezap/fixture/CategoryFixture.java
@@ -12,7 +12,7 @@ public class CategoryFixture {
         return new Category(1L, member, "카테고리 없음", true, 1);
     }
 
-    public static Category getCategory(Member member) {
+    public static Category getAdditionalCategory(Member member) {
         return new Category(2L, member, "카테고리", false, 2);
     }
 

--- a/backend/src/test/java/codezap/fixture/SourceCodeFixture.java
+++ b/backend/src/test/java/codezap/fixture/SourceCodeFixture.java
@@ -1,5 +1,9 @@
 package codezap.fixture;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.IntStream;
+
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 
@@ -12,5 +16,11 @@ public class SourceCodeFixture {
                 "content1",
                 ordinal
         );
+    }
+
+    public static List<SourceCode> getList(Template template, int size) {
+        List<SourceCode> sourceCodes = new ArrayList<>();
+        IntStream.range(0, size).forEach(i -> sourceCodes.add(get(template, i)));
+        return sourceCodes;
     }
 }

--- a/backend/src/test/java/codezap/fixture/TemplateFixture.java
+++ b/backend/src/test/java/codezap/fixture/TemplateFixture.java
@@ -7,7 +7,7 @@ import codezap.template.domain.Visibility;
 
 public class TemplateFixture {
     public static Template get(Member member, Category category) {
-        return new Template(member, "안녕", "Description 1", category);
+        return new Template(member, "안녕", "Description 1", category, Visibility.PUBLIC);
     }
 
     public static Template getPrivate(Member member, Category category) {

--- a/backend/src/test/java/codezap/global/ServiceTest.java
+++ b/backend/src/test/java/codezap/global/ServiceTest.java
@@ -4,11 +4,17 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.transaction.annotation.Transactional;
 
+import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
+import codezap.fixture.CategoryFixture;
+import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
 import codezap.likes.repository.LikesRepository;
+import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
 import codezap.tag.repository.TagRepository;
 import codezap.tag.repository.TemplateTagRepository;
+import codezap.template.domain.Template;
 import codezap.template.repository.SourceCodeRepository;
 import codezap.template.repository.TemplateRepository;
 import codezap.template.repository.ThumbnailRepository;
@@ -41,4 +47,16 @@ public class ServiceTest {
 
     @Autowired
     protected LikesRepository likesRepository;
+
+    protected Template createSavedTemplate() {
+        Member member = memberRepository.save(MemberFixture.getFirstMember());
+        Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+        return templateRepository.save(TemplateFixture.get(member, category));
+    }
+
+    protected Template createSavedSecondTemplate() {
+        Member member = memberRepository.save(MemberFixture.getSecondMember());
+        Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+        return templateRepository.save(TemplateFixture.get(member, category));
+    }
 }

--- a/backend/src/test/java/codezap/global/ServiceTest.java
+++ b/backend/src/test/java/codezap/global/ServiceTest.java
@@ -54,7 +54,7 @@ public class ServiceTest {
         return templateRepository.save(TemplateFixture.get(member, category));
     }
 
-    protected Template createSavedSecondTemplate() {
+    protected Template createAnotherMembersTemplate() {
         Member member = memberRepository.save(MemberFixture.getSecondMember());
         Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
         return templateRepository.save(TemplateFixture.get(member, category));

--- a/backend/src/test/java/codezap/global/ServiceTest.java
+++ b/backend/src/test/java/codezap/global/ServiceTest.java
@@ -56,7 +56,7 @@ public class ServiceTest {
 
     protected Template createSavedSecondTemplate() {
         Member member = memberRepository.save(MemberFixture.getSecondMember());
-        Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+        Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
         return templateRepository.save(TemplateFixture.get(member, category));
     }
 }

--- a/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
+++ b/backend/src/test/java/codezap/likes/service/LikesServiceTest.java
@@ -8,6 +8,7 @@ import java.util.List;
 
 import jakarta.persistence.EntityManager;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -38,10 +39,9 @@ class LikesServiceTest extends ServiceTest {
         @DisplayName("성공: 템플릿 수정 시간은 변경되지 않는다.")
         void success() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Template template = templateRepository.save(TemplateFixture.get(
-                    member,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
+
             LocalDateTime modifiedAtBeforeLike = template.getModifiedAt();
 
             likesService.like(member, template.getId());
@@ -57,10 +57,8 @@ class LikesServiceTest extends ServiceTest {
         @DisplayName("성공: 동일한 사람이 동일한 템플릿에 여러번 좋아요를 해도 Likes 가 한번만 생성된다.")
         void multipleLikes() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Template template = templateRepository.save(TemplateFixture.get(
-                    member,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             likesService.like(member, template.getId());
             likesService.like(member, template.getId());
@@ -77,8 +75,9 @@ class LikesServiceTest extends ServiceTest {
         @DisplayName("성공")
         void success() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
+
             likesService.like(member, template.getId());
             LocalDateTime modifiedAtBeforeLike = template.getModifiedAt();
 
@@ -95,9 +94,10 @@ class LikesServiceTest extends ServiceTest {
         @DisplayName("성공: 본인의 좋아요만 취소 가능")
         void cancelMyLikes() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
+
+            Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
 
             likesService.like(otherMember, template.getId());
             likesService.cancelLike(member, template.getId());
@@ -114,10 +114,8 @@ class LikesServiceTest extends ServiceTest {
         @DisplayName("성공: 좋아요를 했을 때")
         void successWithLike() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Template template = templateRepository.save(TemplateFixture.get(
-                    member,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             likesRepository.save(new Likes(template, member));
 
@@ -128,10 +126,8 @@ class LikesServiceTest extends ServiceTest {
         @DisplayName("성공: 좋아요를 하지 않았을 때")
         void successWithNoLike() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Template template = templateRepository.save(TemplateFixture.get(
-                    member,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             assertThat(likesService.isLiked(member, template)).isFalse();
         }
@@ -146,14 +142,9 @@ class LikesServiceTest extends ServiceTest {
         void deleteAllByTemplateIdSuccess() {
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Template template1 = templateRepository.save(TemplateFixture.get(
-                    member1,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
-            Template template2 = templateRepository.save(TemplateFixture.get(
-                    member1,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            Template template1 = templateRepository.save(TemplateFixture.get(member1, category));
+            Template template2 = templateRepository.save(TemplateFixture.get(member1, category));
             likesRepository.save(new Likes(template1, member1));
             likesRepository.save(new Likes(template1, member2));
             likesRepository.save(new Likes(template2, member1));
@@ -171,14 +162,9 @@ class LikesServiceTest extends ServiceTest {
         void deleteAllByTemplateIdsSuccess() {
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Template template1 = templateRepository.save(TemplateFixture.get(
-                    member1,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
-            Template template2 = templateRepository.save(TemplateFixture.get(
-                    member1,
-                    categoryRepository.save(CategoryFixture.getFirstCategory())
-            ));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            Template template1 = templateRepository.save(TemplateFixture.get(member1, category));
+            Template template2 = templateRepository.save(TemplateFixture.get(member1, category));
             likesRepository.save(new Likes(template1, member1));
             likesRepository.save(new Likes(template1, member2));
             likesRepository.save(new Likes(template2, member1));

--- a/backend/src/test/java/codezap/member/repository/MemberRepositoryTest.java
+++ b/backend/src/test/java/codezap/member/repository/MemberRepositoryTest.java
@@ -12,6 +12,7 @@ import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
 import codezap.global.exception.CodeZapException;
 import codezap.global.repository.RepositoryTest;
 import codezap.member.domain.Member;
@@ -88,8 +89,8 @@ class MemberRepositoryTest {
         @DisplayName("성공 : 템플릿 id로 Member 조회 가능")
         void fetchByTemplateIdSuccess() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            Template template = templateRepository.save(new Template(member, "title", "description", category));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             Member actual = memberRepository.fetchByTemplateId(template.getId());
 

--- a/backend/src/test/java/codezap/member/service/MemberServiceTest.java
+++ b/backend/src/test/java/codezap/member/service/MemberServiceTest.java
@@ -104,7 +104,7 @@ class MemberServiceTest extends ServiceTest {
         @DisplayName("템플릿을 소유한 멤버 조회 성공")
         void getByTemplateId() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             Member actual = memberService.getByTemplateId(template.getId());

--- a/backend/src/test/java/codezap/tag/repository/TagRepositoryTest.java
+++ b/backend/src/test/java/codezap/tag/repository/TagRepositoryTest.java
@@ -126,11 +126,11 @@ class TagRepositoryTest {
         void findMostUsedTagsWithinDateRange() {
             // Given
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
-            Category category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category2 = categoryRepository.save(CategoryFixture.getSecondCategory());
+            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member2));
             Template template2 = templateRepository.save(TemplateFixture.get(member2, category2));
 
             Tag tag1 = tagRepository.save(new Tag("Tag1"));
@@ -152,7 +152,7 @@ class TagRepositoryTest {
         void findMostUsedTagsWithinDateRangeWhen() {
             // Given
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
-            Category category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             Tag tag1 = tagRepository.save(new Tag("Tag1"));
@@ -191,11 +191,11 @@ class TagRepositoryTest {
         void findMostUsedTagsByRecentTemplates() {
             // Given
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
-            Category category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category2 = categoryRepository.save(CategoryFixture.getSecondCategory());
+            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member2));
             Template template2 = templateRepository.save(TemplateFixture.get(member2, category2));
 
             Tag tag1 = tagRepository.save(new Tag("Tag1"));
@@ -217,7 +217,7 @@ class TagRepositoryTest {
         void findMostUsedTagsWithinDateRangeWhenCountSame() {
             // Given
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
-            Category category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             Tag tag1 = tagRepository.save(new Tag("Tag1"));

--- a/backend/src/test/java/codezap/tag/repository/TagRepositoryTest.java
+++ b/backend/src/test/java/codezap/tag/repository/TagRepositoryTest.java
@@ -130,7 +130,7 @@ class TagRepositoryTest {
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member2));
+            Category category2 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member2));
             Template template2 = templateRepository.save(TemplateFixture.get(member2, category2));
 
             Tag tag1 = tagRepository.save(new Tag("Tag1"));
@@ -195,7 +195,7 @@ class TagRepositoryTest {
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member2));
+            Category category2 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member2));
             Template template2 = templateRepository.save(TemplateFixture.get(member2, category2));
 
             Tag tag1 = tagRepository.save(new Tag("Tag1"));

--- a/backend/src/test/java/codezap/tag/repository/TemplateTagRepositoryTest.java
+++ b/backend/src/test/java/codezap/tag/repository/TemplateTagRepositoryTest.java
@@ -17,6 +17,7 @@ import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
 import codezap.global.exception.CodeZapException;
 import codezap.global.repository.RepositoryTest;
 import codezap.member.domain.Member;
@@ -46,15 +47,14 @@ class TemplateTagRepositoryTest {
     @BeforeEach
     void setUp() {
         member = memberRepository.save(MemberFixture.getFirstMember());
-
-        category = categoryRepository.save(CategoryFixture.getFirstCategory());
+        category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
     }
 
     @Test
     @DisplayName("Template 을 이용한 Tag 목록 조회 성공")
     void findAllTagsByTemplateTest() {
         //given
-        Template template = templateRepository.save(createNthTemplate(member, category, 1));
+        Template template = templateRepository.save(TemplateFixture.get(member, category));
 
         Tag tag1 = tagRepository.save(new Tag("tag1"));
         Tag tag2 = tagRepository.save(new Tag("tag2"));
@@ -76,7 +76,7 @@ class TemplateTagRepositoryTest {
     @DisplayName("Template Id 을 이용한 TemplateTag 목록 조회 성공")
     void findAllByTemplateIdTest() {
         //given
-        Template template = templateRepository.save(createNthTemplate(member, category, 1));
+        Template template = templateRepository.save(TemplateFixture.get(member, category));
 
         Tag tag1 = tagRepository.save(new Tag("tag1"));
         Tag tag2 = tagRepository.save(new Tag("tag2"));
@@ -97,8 +97,8 @@ class TemplateTagRepositoryTest {
     @DisplayName("Template Id 목록 중 하나라도 일치하는 TemplateTag 목록 조회 성공")
     void findAllByTemplateIdsInTest() {
         //given
-        Template template1 = templateRepository.save(createNthTemplate(member, category, 1));
-        Template template2 = templateRepository.save(createNthTemplate(member, category, 1));
+        Template template1 = templateRepository.save(TemplateFixture.get(member, category));
+        Template template2 = templateRepository.save(TemplateFixture.get(member, category));
 
         Tag tag1 = tagRepository.save(new Tag("tag1"));
         Tag tag2 = tagRepository.save(new Tag("tag2"));
@@ -127,9 +127,9 @@ class TemplateTagRepositoryTest {
         void testFindDistinctByTemplateIn() {
             // given
             Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            Template template1 = templateRepository.save(createNthTemplate(member, category, 1));
-            Template template2 = templateRepository.save(createNthTemplate(otherMember, category, 2));
-            Template template3 = templateRepository.save(createNthTemplate(member, category, 3));
+            Template template1 = templateRepository.save(TemplateFixture.get(member, category));
+            Template template2 = templateRepository.save(TemplateFixture.get(otherMember, category));
+            Template template3 = templateRepository.save(TemplateFixture.get(member, category));
 
             Tag tag1 = tagRepository.save(new Tag("tag1"));
             Tag tag2 = tagRepository.save(new Tag("tag2"));
@@ -175,8 +175,8 @@ class TemplateTagRepositoryTest {
         @DisplayName("태그 삭제 성공 : 주어진 id 의 템플릿에선 태그가 삭제되고, 나머지 템플릿의 태그에는 영향을 주지 않는다.")
         void successTest() {
             //given
-            Template template1 = templateRepository.save(createNthTemplate(member, category, 1));
-            Template template2 = templateRepository.save(createNthTemplate(member, category, 2));
+            Template template1 = templateRepository.save(TemplateFixture.get(member, category));
+            Template template2 = templateRepository.save(TemplateFixture.get(member, category));
 
             Tag tag1 = tagRepository.save(new Tag("tag1"));
             Tag tag2 = tagRepository.save(new Tag("tag2"));
@@ -201,7 +201,7 @@ class TemplateTagRepositoryTest {
         @DisplayName("태그 삭제 성공 : 존재하지 않는 id 를 사용해도 예외가 발생하지 않고 아무 영향이 없다.")
         void notExistIdTest() {
             //given
-            Template template = templateRepository.save(createNthTemplate(member, category, 1));
+            Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             Tag tag1 = tagRepository.save(new Tag("tag1"));
             Tag tag2 = tagRepository.save(new Tag("tag2"));
@@ -220,9 +220,5 @@ class TemplateTagRepositoryTest {
                             .containsExactly(template1Tag1, template1Tag2)
             );
         }
-    }
-
-    private Template createNthTemplate(Member member, Category category, int n) {
-        return new Template(member, "mockTitle" + n, "mockDescription" + n, category);
     }
 }

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -153,7 +153,7 @@ class TagServiceTest extends ServiceTest {
         void getAllTemplateTagsByTemplates() {
             // given
             Template template = createSavedTemplate();
-            Template secondTemplate = createSecondTemplate();
+            Template secondTemplate = createSavedSecondTemplate();
             Tag tag1 = tagRepository.save(new Tag("tag1"));
             Tag tag2 = tagRepository.save(new Tag("tag2"));
             TemplateTag templateTag1 = templateTagRepository.save(new TemplateTag(template, tag1));
@@ -188,9 +188,9 @@ class TagServiceTest extends ServiceTest {
             var member = memberRepository.save(MemberFixture.getFirstMember());
 
             var category = categoryRepository.save(Category.createDefaultCategory(member));
-            var template1 = templateRepository.save(new Template(member, "title1", "description", category));
-            var template2 = templateRepository.save(new Template(member, "title2", "description", category));
-            var template3 = templateRepository.save(new Template(member, "title3", "description", category));
+            var template1 = templateRepository.save(TemplateFixture.get(member, category));
+            var template2 = templateRepository.save(TemplateFixture.get(member, category));
+            var template3 = templateRepository.save(TemplateFixture.get(member, category));
             var tag1 = tagRepository.save(new Tag("tag1"));
             var tag2 = tagRepository.save(new Tag("tag2"));
             var tag3 = tagRepository.save(new Tag("tag3"));
@@ -221,7 +221,7 @@ class TagServiceTest extends ServiceTest {
             Tag tag2 = tagRepository.save(new Tag("tag2"));
 
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(new Category("자바", member, 1));
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
 
             Template template1 = templateRepository.save(TemplateFixture.get(member, category));
             templateTagRepository.save(new TemplateTag(template1, tag1));
@@ -250,7 +250,7 @@ class TagServiceTest extends ServiceTest {
             templateTagRepository.save(new TemplateTag(template1, tag1));
             templateTagRepository.save(new TemplateTag(template1, tag2));
 
-            Template template2 = createSecondTemplate();
+            Template template2 = createSavedSecondTemplate();
             templateTagRepository.save(new TemplateTag(template2, tag2));
 
             // when & then
@@ -426,17 +426,5 @@ class TagServiceTest extends ServiceTest {
             // then
             assertThat(templateTagRepository.findAllByTemplate(template)).isEmpty();
         }
-    }
-
-    private Template createSavedTemplate() {
-        Member member = memberRepository.save(MemberFixture.getFirstMember());
-        Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-        return templateRepository.save(TemplateFixture.get(member, category));
-    }
-
-    private Template createSecondTemplate() {
-        Member member = memberRepository.save(MemberFixture.getSecondMember());
-        Category category = categoryRepository.save(CategoryFixture.getSecondCategory());
-        return templateRepository.save(TemplateFixture.get(member, category));
     }
 }

--- a/backend/src/test/java/codezap/tag/service/TagServiceTest.java
+++ b/backend/src/test/java/codezap/tag/service/TagServiceTest.java
@@ -153,7 +153,7 @@ class TagServiceTest extends ServiceTest {
         void getAllTemplateTagsByTemplates() {
             // given
             Template template = createSavedTemplate();
-            Template secondTemplate = createSavedSecondTemplate();
+            Template secondTemplate = createAnotherMembersTemplate();
             Tag tag1 = tagRepository.save(new Tag("tag1"));
             Tag tag2 = tagRepository.save(new Tag("tag2"));
             TemplateTag templateTag1 = templateTagRepository.save(new TemplateTag(template, tag1));
@@ -250,7 +250,7 @@ class TagServiceTest extends ServiceTest {
             templateTagRepository.save(new TemplateTag(template1, tag1));
             templateTagRepository.save(new TemplateTag(template1, tag2));
 
-            Template template2 = createSavedSecondTemplate();
+            Template template2 = createAnotherMembersTemplate();
             templateTagRepository.save(new TemplateTag(template2, tag2));
 
             // when & then

--- a/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
+++ b/backend/src/test/java/codezap/template/controller/TemplateControllerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 
+import codezap.category.domain.Category;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
 import codezap.fixture.SourceCodeFixture;
@@ -290,7 +291,9 @@ class TemplateControllerTest extends MockMvcTest {
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse() {
-            Template template = TemplateFixture.get(MemberFixture.getFirstMember(), CategoryFixture.getFirstCategory());
+            Member member = MemberFixture.getFirstMember();
+            Category category = CategoryFixture.getDefaultCategory(member);
+            Template template = TemplateFixture.get(member, category);
             return FindAllTemplateItemResponse.of(
                     template,
                     List.of(new Tag(1L, "tag1")),
@@ -307,7 +310,9 @@ class TemplateControllerTest extends MockMvcTest {
         @DisplayName("템플릿 단건 조회 성공")
         void findOneTemplateSuccess() throws Exception {
             // given
-            Template template = TemplateFixture.get(MemberFixture.getFirstMember(), CategoryFixture.getFirstCategory());
+            Member member = MemberFixture.getFirstMember();
+            Category category = CategoryFixture.getDefaultCategory(member);
+            Template template = TemplateFixture.get(member, category);
             FindTemplateResponse findTemplateResponse = FindTemplateResponse.of(
                     template,
                     List.of(SourceCodeFixture.get(template, 1)),
@@ -327,7 +332,9 @@ class TemplateControllerTest extends MockMvcTest {
         @DisplayName("템플릿 단건 조회 성공: 로그인한 사용자가 없는 경우도 조회 가능")
         void findOneTemplateSuccessWithNoMember() throws Exception {
             // given
-            Template template = TemplateFixture.get(MemberFixture.getFirstMember(), CategoryFixture.getFirstCategory());
+            Member member = MemberFixture.getFirstMember();
+            Category category = CategoryFixture.getDefaultCategory(member);
+            Template template = TemplateFixture.get(member, category);
             FindTemplateResponse findTemplateResponse = FindTemplateResponse.of(
                     template,
                     List.of(SourceCodeFixture.get(template, 1)),
@@ -619,7 +626,7 @@ class TemplateControllerTest extends MockMvcTest {
         }
 
         private FindAllTemplateItemResponse getFindAllTemplateItemResponse(Member member) {
-            Template template = TemplateFixture.get(member, CategoryFixture.getFirstCategory());
+            Template template = TemplateFixture.get(member, CategoryFixture.getDefaultCategory(member));
             return FindAllTemplateItemResponse.of(
                     template,
                     List.of(new Tag(1L, "tag1")),

--- a/backend/src/test/java/codezap/template/domain/SourceCodeTest.java
+++ b/backend/src/test/java/codezap/template/domain/SourceCodeTest.java
@@ -8,6 +8,7 @@ import org.junit.jupiter.api.Test;
 import codezap.category.domain.Category;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
+import codezap.fixture.TemplateFixture;
 import codezap.member.domain.Member;
 
 class SourceCodeTest {
@@ -17,8 +18,8 @@ class SourceCodeTest {
     void getThumbnailContent() {
         // given
         Member member = MemberFixture.getFirstMember();
-        Category category = CategoryFixture.getFirstCategory();
-        Template template = new Template(member, "title", "description", category);
+        Category category = CategoryFixture.getDefaultCategory(member);
+        Template template = TemplateFixture.get(member, category);
         SourceCode sourceCode = new SourceCode(
                 1L,
                 template,

--- a/backend/src/test/java/codezap/template/domain/TemplateTagTest.java
+++ b/backend/src/test/java/codezap/template/domain/TemplateTagTest.java
@@ -42,7 +42,7 @@ class TemplateTagTest {
 
         private Template createTemplateById(Long id) {
             Member member = MemberFixture.getFirstMember();
-            Category category = CategoryFixture.getFirstCategory();
+            Category category = CategoryFixture.getDefaultCategory(member);
             List<SourceCode> sourceCodes = List.of();
             long likesCount = 1L;
             return new Template(

--- a/backend/src/test/java/codezap/template/domain/ThumbnailTest.java
+++ b/backend/src/test/java/codezap/template/domain/ThumbnailTest.java
@@ -47,7 +47,7 @@ class ThumbnailTest {
 
         private Template createTemplateById(Long id) {
             Member member = MemberFixture.getFirstMember();
-            Category category = CategoryFixture.getFirstCategory();
+            Category category = CategoryFixture.getDefaultCategory(member);
             List<SourceCode> sourceCodes = List.of();
             long likesCount = 1L;
             return new Template(

--- a/backend/src/test/java/codezap/template/repository/SourceCodeRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/SourceCodeRepositoryTest.java
@@ -13,11 +13,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import codezap.category.repository.CategoryRepository;
 import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
+import codezap.fixture.SourceCodeFixture;
+import codezap.fixture.TemplateFixture;
 import codezap.global.exception.CodeZapException;
 import codezap.global.repository.RepositoryTest;
 import codezap.member.repository.MemberRepository;
 import codezap.template.domain.SourceCode;
-import codezap.template.domain.Template;
 
 @RepositoryTest
 public class SourceCodeRepositoryTest {
@@ -34,14 +35,15 @@ public class SourceCodeRepositoryTest {
     @Nested
     @DisplayName("ID로 소스코드 조회")
     class FetchById {
+
         @Test
         @DisplayName("성공: 소스코드 ID로 소스코드 조회")
         void fetchByIdSuccess() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var sourceCode1 = sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", 1));
-            var sourceCode2 = sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", 1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var sourceCode1 = sut.save(SourceCodeFixture.get(template1, 1));
+            var sourceCode2 = sut.save(SourceCodeFixture.get(template1, 2));
 
             var result = sut.fetchById(1L);
 
@@ -65,25 +67,24 @@ public class SourceCodeRepositoryTest {
         @DisplayName("성공: 템플릿으로 전체 소스코드 조회")
         void findAllByTemplateSuccess() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
-            var sourceCode1 = sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", 1));
-            var sourceCode2 = sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", 2));
-            var sourceCode3 = sut.save(new SourceCode(template2, "SourceCode 3", "Content 3", 1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var sourceCodes = sut.saveAll(SourceCodeFixture.getList(template1, 2));
+            var sourceCode2 = sut.save(SourceCodeFixture.get(template2, 1));
 
             var result = sut.findAllByTemplate(template1);
 
             assertThat(result).hasSize(2)
-                    .containsExactly(sourceCode1, sourceCode2);
+                    .hasSameElementsAs(sourceCodes);
         }
 
         @Test
         @DisplayName("성공: 소스코드가 없는 템플릿으로 조회하는 경우 빈 리스트가 반환된다.")
         void findAllByTemplateSuccessWithNoSourceCodeTemplate() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
 
             var result = sut.findAllByTemplate(template1);
 
@@ -98,12 +99,12 @@ public class SourceCodeRepositoryTest {
         @DisplayName("성공: 템플릿과 소스코드 순서로 조회")
         void fetchByTemplateAndOrdinalSuccess() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
-            var sourceCode1 = sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", 1));
-            var sourceCode2 = sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", 2));
-            var sourceCode3 = sut.save(new SourceCode(template2, "SourceCode 3", "Content 3", 1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var sourceCode1 = sut.save(SourceCodeFixture.get(template1, 1));
+            var sourceCode2 = sut.save(SourceCodeFixture.get(template1, 2));
+            var sourceCode3 = sut.save(SourceCodeFixture.get(template2, 1));
 
             var result = sut.fetchByTemplateAndOrdinal(template1, 1);
 
@@ -114,9 +115,9 @@ public class SourceCodeRepositoryTest {
         @DisplayName("실패: 잘못된 순서로 조회하는 경우 예외가 발생")
         void fetchByTemplateAndOrdinalFailWithWrongOrdinal() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var sourceCode1 = sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", 1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var sourceCode1 = sut.save(SourceCodeFixture.get(template1, 1));
 
             var ordinal = 100;
             assertThatThrownBy(() -> sut.fetchByTemplateAndOrdinal(template1, ordinal))
@@ -128,40 +129,41 @@ public class SourceCodeRepositoryTest {
     @Nested
     @DisplayName("템플릿과 순서에 해당하는 전체 소스코드 조회")
     class FindAllByTemplateAndOrdinal {
+
         @Test
         @DisplayName("성공: 템플릿과 순서에 해당하는 전체 소스코드 조회")
         void findAllByTemplateAndOrdinalSuccess() {
             var ordinal = 1;
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
-            var sourceCode1 = sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", ordinal));
-            var sourceCode2 = sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", ordinal));
-            var sourceCode3 = sut.save(new SourceCode(template1, "SourceCode 3", "Content 3", 2));
-            var sourceCode4 = sut.save(new SourceCode(template2, "SourceCode 4", "Content 4", ordinal));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var sourceCode1 = sut.save(SourceCodeFixture.get(template1, ordinal));
+            var sourceCode2 = sut.save(SourceCodeFixture.get(template1, ordinal + 1));
+            var sourceCode3 = sut.save(SourceCodeFixture.get(template2, ordinal));
 
             var result = sut.findAllByTemplateAndOrdinal(template1, ordinal);
 
-            assertThat(result).hasSize(2)
-                    .containsExactly(sourceCode1, sourceCode2);
+            assertThat(result).hasSize(1)
+                    .containsExactly(sourceCode1);
         }
     }
 
     @Nested
     @DisplayName("템플릿에 존재하는 소스코드 개수 조회")
     class CountByTemplate {
+
         @Test
         @DisplayName("성공: 템플릿에 존재하는 소스코드 개수 조회")
         void countByTemplateSuccess() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
-            var sourceCode1 = sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", 1));
-            var sourceCode2 = sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", 2));
-            var sourceCode3 = sut.save(new SourceCode(template2, "SourceCode 3", "Content 3", 1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            List<SourceCode> sourceCodes = sut.saveAll(SourceCodeFixture.getList(template1, 2));
+            sut.saveAll(SourceCodeFixture.getList(template2,  1));
 
+            System.out.println(sourceCodes);
             var result = sut.countByTemplate(template1);
 
             assertThat(result).isEqualTo(2);
@@ -175,12 +177,11 @@ public class SourceCodeRepositoryTest {
         @DisplayName("성공: 템플릿 ID로 템플릿에 존재하는 소스코드 삭제")
         void testDeleteByTemplateId() {
             var member1 = memberRepository.save(MemberFixture.getFirstMember());
-            var category1 = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(new Template(member1, "Template 1", "Description 1", category1));
-            var template2 = templateRepository.save(new Template(member1, "Template 2", "Description 2", category1));
-            sut.save(new SourceCode(template1, "SourceCode 1", "Content 1", 1));
-            sut.save(new SourceCode(template1, "SourceCode 2", "Content 2", 2));
-            sut.save(new SourceCode(template2, "SourceCode 3", "Content 3", 1));
+            var category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+            var template1 = templateRepository.save(TemplateFixture.get(member1, category1));
+            var template2 = templateRepository.save(TemplateFixture.get(member1, category1));
+            sut.saveAll(SourceCodeFixture.getList(template1,  2));
+            sut.saveAll(SourceCodeFixture.getList(template2,  1));
 
             sut.deleteAllByTemplateIds(List.of(1L));
             var result = sut.findAllByTemplate(template1);

--- a/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
@@ -42,9 +42,9 @@ class TemplateRepositoryTest {
         // given
         Member member = memberRepository.save(MemberFixture.getFirstMember());
         Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-        Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-        Category otherCategory = categoryRepository.save(CategoryFixture.getSecondCategory());
-        templateRepository.save(new Template(member, "Template 1", "Description 1", category));
+        Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+        Category otherCategory = categoryRepository.save(CategoryFixture.getCategory(member2));
+        templateRepository.save(TemplateFixture.get(member, category));
 
         assertAll(
                 () -> assertThat(templateRepository.existsByCategoryId(category.getId())).isTrue(),
@@ -60,7 +60,7 @@ class TemplateRepositoryTest {
         @DisplayName("템플릿 id로 템플릿 조회 성공")
         void fetchById() {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             Template savedTemplate = templateRepository.save(TemplateFixture.get(member, category));
 
             assertThat(templateRepository.fetchById(savedTemplate.getId())).isEqualTo(savedTemplate);
@@ -87,8 +87,8 @@ class TemplateRepositoryTest {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
             Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
 
-            Category category = categoryRepository.save(CategoryFixture.get(member));
-            Category otherCategory = categoryRepository.save(CategoryFixture.get(otherMember));
+            Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+            Category otherCategory = categoryRepository.save(CategoryFixture.getCategory(otherMember));
 
             Template myPublicTemplate = templateRepository.save(TemplateFixture.get(member, category));
             Template myPrivateTemplate = templateRepository.save(TemplateFixture.getPrivate(member, category));

--- a/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/TemplateRepositoryTest.java
@@ -42,8 +42,8 @@ class TemplateRepositoryTest {
         // given
         Member member = memberRepository.save(MemberFixture.getFirstMember());
         Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-        Category category = categoryRepository.save(CategoryFixture.getCategory(member));
-        Category otherCategory = categoryRepository.save(CategoryFixture.getCategory(member2));
+        Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
+        Category otherCategory = categoryRepository.save(CategoryFixture.getAdditionalCategory(member2));
         templateRepository.save(TemplateFixture.get(member, category));
 
         assertAll(
@@ -87,8 +87,8 @@ class TemplateRepositoryTest {
             Member member = memberRepository.save(MemberFixture.getFirstMember());
             Member otherMember = memberRepository.save(MemberFixture.getSecondMember());
 
-            Category category = categoryRepository.save(CategoryFixture.getCategory(member));
-            Category otherCategory = categoryRepository.save(CategoryFixture.getCategory(otherMember));
+            Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
+            Category otherCategory = categoryRepository.save(CategoryFixture.getAdditionalCategory(otherMember));
 
             Template myPublicTemplate = templateRepository.save(TemplateFixture.get(member, category));
             Template myPrivateTemplate = templateRepository.save(TemplateFixture.getPrivate(member, category));

--- a/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
@@ -51,10 +51,8 @@ public class ThumbnailRepositoryTest {
         @DisplayName("템플릿으로 썸네일 조회 성공")
         void fetchByTemplateSuccess() {
             // given
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(Category.createDefaultCategory(member));
-            var template = templateRepository.save(new Template(member, "Template Title", "Description", category));
-            var sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename", "content", 1));
+            var template = createSavedTemplate();
+            var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
             var thumbnail = sut.save(new Thumbnail(template, sourceCode));
 
             // when
@@ -96,18 +94,6 @@ public class ThumbnailRepositoryTest {
 
             assertThat(sut.findAllByTemplateIn(List.of(template1.getId()))).isEmpty();
         }
-
-        private Template createSavedTemplate() {
-            Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            return templateRepository.save(TemplateFixture.get(member, category));
-        }
-
-        private Template createSecondTemplate() {
-            Member member = memberRepository.save(MemberFixture.getSecondMember());
-            Category category = categoryRepository.save(CategoryFixture.getSecondCategory());
-            return templateRepository.save(TemplateFixture.get(member, category));
-        }
     }
 
     @Nested
@@ -118,10 +104,8 @@ public class ThumbnailRepositoryTest {
         @DisplayName("템플릿 id로 썸네일 삭제 성공")
         void deleteByTemplateIdSuccess() {
             // given
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(Category.createDefaultCategory(member));
-            var template = templateRepository.save(new Template(member, "Template Title", "Description", category));
-            var sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename", "content", 1));
+            var template = createSavedTemplate();
+            var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
             sut.save(new Thumbnail(template, sourceCode));
 
             // when
@@ -139,5 +123,17 @@ public class ThumbnailRepositoryTest {
             assertThatCode(() -> sut.deleteAllByTemplateIds(List.of(100L)))
                     .doesNotThrowAnyException();
         }
+    }
+
+    private Template createSavedTemplate() {
+        Member member = memberRepository.save(MemberFixture.getFirstMember());
+        Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+        return templateRepository.save(TemplateFixture.get(member, category));
+    }
+
+    private Template createSecondTemplate() {
+        Member member = memberRepository.save(MemberFixture.getSecondMember());
+        Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+        return templateRepository.save(TemplateFixture.get(member, category));
     }
 }

--- a/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
@@ -21,7 +21,6 @@ import codezap.global.exception.CodeZapException;
 import codezap.global.repository.RepositoryTest;
 import codezap.member.domain.Member;
 import codezap.member.repository.MemberRepository;
-import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
 
@@ -133,7 +132,7 @@ public class ThumbnailRepositoryTest {
 
     private Template createSecondTemplate() {
         Member member = memberRepository.save(MemberFixture.getSecondMember());
-        Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+        Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
         return templateRepository.save(TemplateFixture.get(member, category));
     }
 }

--- a/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
+++ b/backend/src/test/java/codezap/template/repository/ThumbnailRepositoryTest.java
@@ -74,7 +74,7 @@ public class ThumbnailRepositoryTest {
             var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var thumbnail1 = sut.save(new Thumbnail(template1, sourceCode1));
 
-            var template2 = createSecondTemplate();
+            var template2 = createAnotherMembersTemplate();
             var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var thumbnail2 = sut.save(new Thumbnail(template2, sourceCode2));
 
@@ -130,7 +130,7 @@ public class ThumbnailRepositoryTest {
         return templateRepository.save(TemplateFixture.get(member, category));
     }
 
-    private Template createSecondTemplate() {
+    private Template createAnotherMembersTemplate() {
         Member member = memberRepository.save(MemberFixture.getSecondMember());
         Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
         return templateRepository.save(TemplateFixture.get(member, category));

--- a/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/SourceCodeServiceTest.java
@@ -12,14 +12,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import codezap.category.domain.Category;
-import codezap.fixture.CategoryFixture;
-import codezap.fixture.MemberFixture;
 import codezap.fixture.SourceCodeFixture;
-import codezap.fixture.TemplateFixture;
 import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
-import codezap.member.domain.Member;
 import codezap.template.domain.SourceCode;
 import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
@@ -428,12 +423,6 @@ class SourceCodeServiceTest extends ServiceTest {
 
             assertThat(sourceCodeRepository.findAllByTemplate(template)).isEmpty();
         }
-    }
-
-    private Template createSavedTemplate() {
-        Member member = memberRepository.save(MemberFixture.getFirstMember());
-        Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-        return templateRepository.save(TemplateFixture.get(member, category));
     }
 
     private CreateTemplateRequest createSavedTemplateRequest(List<CreateSourceCodeRequest> requests) {

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -18,7 +18,9 @@ import org.springframework.data.domain.Pageable;
 
 import codezap.category.domain.Category;
 import codezap.category.repository.CategoryRepository;
+import codezap.fixture.CategoryFixture;
 import codezap.fixture.MemberFixture;
+import codezap.fixture.SourceCodeFixture;
 import codezap.fixture.TemplateFixture;
 import codezap.global.DatabaseIsolation;
 import codezap.global.pagination.FixedPage;
@@ -358,8 +360,8 @@ class TemplateSearchServiceTest {
     }
 
     private void saveTwoCategory() {
-        category1 = categoryRepository.save(new Category("Category 1", member1, 1));
-        category2 = categoryRepository.save(new Category("Category 2", member1, 2));
+        category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
+        category2 = categoryRepository.save(CategoryFixture.getCategory(member1));
     }
 
     private void saveTwoTags() {
@@ -373,10 +375,10 @@ class TemplateSearchServiceTest {
         var template3 = templateRepository.save(TemplateFixture.get(member2, category1));
         var template4 = templateRepository.save(TemplateFixture.getPrivate(member2, category2));
 
-        SourceCode sourceCode1 = sourceCodeRepository.save(new SourceCode(template1, "filename1", "content1", 1));
-        SourceCode sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "filename2", "content2", 2));
-        SourceCode sourceCode3 = sourceCodeRepository.save(new SourceCode(template3, "filename1", "content1", 1));
-        SourceCode sourceCode4 = sourceCodeRepository.save(new SourceCode(template4, "filename1", "content1", 1));
+        SourceCode sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
+        SourceCode sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
+        SourceCode sourceCode3 = sourceCodeRepository.save(SourceCodeFixture.get(template3, 1));
+        SourceCode sourceCode4 = sourceCodeRepository.save(SourceCodeFixture.get(template4, 1));
 
         thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
         thumbnailRepository.save(new Thumbnail(template2, sourceCode2));

--- a/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateSearchServiceTest.java
@@ -361,7 +361,7 @@ class TemplateSearchServiceTest {
 
     private void saveTwoCategory() {
         category1 = categoryRepository.save(CategoryFixture.getDefaultCategory(member1));
-        category2 = categoryRepository.save(CategoryFixture.getCategory(member1));
+        category2 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member1));
     }
 
     private void saveTwoTags() {

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -51,7 +51,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 생성 성공")
         void createTemplateSuccess() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var templateRequest = new CreateTemplateRequest(
                     "title",
                     "description",
@@ -86,7 +86,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 단건 조회 성공")
         void getByIdSuccess() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var template = templateRepository.save(TemplateFixture.get(member, category));
 
             var actual = sut.getById(template.getId());
@@ -118,8 +118,9 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("좋아요 순 정렬 테스트")
         void sortByLikesCount() {
             saveMembers10();
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            saveTemplates5(category);
+            Member member = memberRepository.fetchById(1L);
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
+            saveTemplates5(member, category);
             likeTemplate(3L, 10L);
             likeTemplate(5L, 7L);
             likeTemplate(2L, 5L);
@@ -145,14 +146,9 @@ class TemplateServiceTest extends ServiceTest {
             }
         }
 
-        private void saveTemplates5(Category category) {
+        private void saveTemplates5(Member member, Category category) {
             for (int i = 0; i < 5; i++) {
-                templateRepository.save(new Template(
-                        memberRepository.fetchById(1L),
-                        "title" + i,
-                        "description",
-                        category
-                ));
+                templateRepository.save(TemplateFixture.get(member, category));
             }
         }
 
@@ -173,8 +169,8 @@ class TemplateServiceTest extends ServiceTest {
             // given
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category1 = categoryRepository.save(CategoryFixture.get(member1));
-            Category category2 = categoryRepository.save(CategoryFixture.get(member2));
+            Category category1 = categoryRepository.save(CategoryFixture.getCategory(member1));
+            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member2));
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
             Template template2 = templateRepository.save(TemplateFixture.get(member1, category1));
             Template template3 = templateRepository.save(TemplateFixture.get(member2, category2));
@@ -199,7 +195,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 수정 성공")
         void updateTemplateSuccess() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var template = templateRepository.save(TemplateFixture.get(member, category));
             var updateTemplateRequest = new UpdateTemplateRequest(
                     "Update Title",
@@ -224,7 +220,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 수정 성공 : 데이터가 수정됐을 경우 modifiedAt 변경")
         void updateTemplateSuccessChangeModifiedAt() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var template = templateRepository.save(TemplateFixture.get(member, category));
             var beforeModifiedAt = template.getModifiedAt();
             var updateRequest = new UpdateTemplateRequest(
@@ -248,7 +244,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 수정 실패: 해당하는 ID의 템플릿이 존재하지 않는 경우")
         void updateTemplateFailWithWrongID() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var updateTemplateRequest = new UpdateTemplateRequest(
                     "Update Title",
                     "Update Description",
@@ -271,7 +267,7 @@ class TemplateServiceTest extends ServiceTest {
         void updateTemplateFailWithWrongMember() {
             var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
             var otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(ownerMember));
             var template = templateRepository.save(TemplateFixture.get(ownerMember, category));
             var updateTemplateRequest = new UpdateTemplateRequest(
                     "Update Title",
@@ -291,14 +287,14 @@ class TemplateServiceTest extends ServiceTest {
     }
 
     @Nested
-    @DisplayName("템플릿 삭제")
-    class DeleteTemplate {
+    @DisplayName("회원의 템플릿 목록 삭제")
+    class DeleteByMemberAndIds {
 
         @Test
         @DisplayName("템플릿 삭제 성공: 1개 삭제")
         void deleteTemplateSuccessWithOneTemplate() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var template1 = templateRepository.save(TemplateFixture.get(member, category));
             var template2 = templateRepository.save(TemplateFixture.get(member, category));
 
@@ -314,7 +310,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 삭제 성공: 여러개 삭제")
         void deleteTemplateSuccessWithMultipleTemplate() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             var template1 = templateRepository.save(TemplateFixture.get(member, category));
             var template2 = templateRepository.save(TemplateFixture.get(member, category));
             var template3 = templateRepository.save(TemplateFixture.get(member, category));
@@ -332,7 +328,7 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 삭제 실패: 존재하지 않는 템플릿 삭제")
         void deleteTemplateSuccessWithNonExistentTemplate() {
             var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             templateRepository.save(TemplateFixture.get(member, category));
             Long nonExistentID = 100L;
 
@@ -346,7 +342,7 @@ class TemplateServiceTest extends ServiceTest {
         void deleteTemplateFailWithWrongMember() {
             var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
             var otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(ownerMember));
             var template = templateRepository.save(TemplateFixture.get(ownerMember, category));
 
             assertThatThrownBy(() -> sut.deleteByMemberAndIds(otherMember, List.of(template.getId())))
@@ -359,14 +355,12 @@ class TemplateServiceTest extends ServiceTest {
         @DisplayName("템플릿 삭제 실패: 동일한 ID가 2개 들어있는 경우")
         void deleteTemplateFailWithDuplicateID() {
             var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
-            var otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            var category = categoryRepository.save(CategoryFixture.getDefaultCategory(ownerMember));
             var template = templateRepository.save(TemplateFixture.get(ownerMember, category));
 
-            assertThatThrownBy(() -> sut.deleteByMemberAndIds(otherMember, List.of(template.getId(), template.getId())))
+            assertThatThrownBy(() -> sut.deleteByMemberAndIds(ownerMember, List.of(template.getId(), template.getId())))
                     .isInstanceOf(CodeZapException.class)
                     .hasMessage("삭제하고자 하는 템플릿 ID가 중복되었습니다.");
-
         }
     }
 }

--- a/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/TemplateServiceTest.java
@@ -169,8 +169,8 @@ class TemplateServiceTest extends ServiceTest {
             // given
             Member member1 = memberRepository.save(MemberFixture.getFirstMember());
             Member member2 = memberRepository.save(MemberFixture.getSecondMember());
-            Category category1 = categoryRepository.save(CategoryFixture.getCategory(member1));
-            Category category2 = categoryRepository.save(CategoryFixture.getCategory(member2));
+            Category category1 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member1));
+            Category category2 = categoryRepository.save(CategoryFixture.getAdditionalCategory(member2));
             Template template1 = templateRepository.save(TemplateFixture.get(member1, category1));
             Template template2 = templateRepository.save(TemplateFixture.get(member1, category1));
             Template template3 = templateRepository.save(TemplateFixture.get(member2, category2));

--- a/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
@@ -35,10 +35,8 @@ class ThumbnailServiceTest extends ServiceTest {
         @Test
         @DisplayName("썸네일 생성 성공")
         void createThumbnailSuccess() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode = sourceCodeRepository.save(new SourceCode(template, "Filename 1", "Content 1", 1));
+            var template = createSavedTemplate();
+            var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
 
             sut.createThumbnail(template, sourceCode);
             var actual = thumbnailRepository.fetchByTemplate(template);
@@ -58,10 +56,8 @@ class ThumbnailServiceTest extends ServiceTest {
         @Test
         @DisplayName("썸네일 조회 성공")
         void getByTemplateSuccess() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode = sourceCodeRepository.save(new SourceCode(template, "Filename 1", "Content 1", 1));
+            var template = createSavedTemplate();
+            var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
             thumbnailRepository.save(new Thumbnail(template, sourceCode));
 
             var actual = sut.getByTemplate(template);
@@ -76,9 +72,7 @@ class ThumbnailServiceTest extends ServiceTest {
         @Test
         @DisplayName("썸네일 조회 실패: 해당하는 썸네일이 없는 경우")
         void getByTemplateFailWithWrongID() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template = templateRepository.save(TemplateFixture.get(member, category));
+            var template = createSavedTemplate();
 
             assertThatThrownBy(() -> sut.getByTemplate(template))
                     .isInstanceOf(CodeZapException.class)
@@ -97,7 +91,7 @@ class ThumbnailServiceTest extends ServiceTest {
             var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var thumbnail1 = thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
 
-            var template2 = createSecondTemplate();
+            var template2 = createSavedSecondTemplate();
             var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var thumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
@@ -113,18 +107,6 @@ class ThumbnailServiceTest extends ServiceTest {
 
             assertThat(sut.getAllByTemplates(List.of())).isEmpty();
         }
-
-        private Template createSavedTemplate() {
-            Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            return templateRepository.save(TemplateFixture.get(member, category));
-        }
-
-        private Template createSecondTemplate() {
-            Member member = memberRepository.save(MemberFixture.getSecondMember());
-            Category category = categoryRepository.save(CategoryFixture.getSecondCategory());
-            return templateRepository.save(TemplateFixture.get(member, category));
-        }
     }
 
     @Nested
@@ -134,13 +116,12 @@ class ThumbnailServiceTest extends ServiceTest {
         @Test
         @DisplayName("썸네일 삭제 성공: 1개의 썸네일 삭제")
         void deleteByTemplateSuccessWithOneThumbnail() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode1 = sourceCodeRepository.save(new SourceCode(template1, "Filename 1", "Content 1", 1));
+            var template1 = createSavedTemplate();
+            var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var savedThumbnail1 = thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
-            var template2 = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "Filename 2", "Content 2", 1));
+
+            var template2 = createSavedSecondTemplate();
+            var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var savedThumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
             sut.deleteAllByTemplateIds(List.of(template1.getId()));
@@ -154,13 +135,12 @@ class ThumbnailServiceTest extends ServiceTest {
         @Test
         @DisplayName("썸네일 삭제 성공: 2개의 썸네일 삭제")
         void deleteByTemplateSuccessWithTwoThumbnail() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template1 = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode1 = sourceCodeRepository.save(new SourceCode(template1, "Filename 1", "Content 1", 1));
+            var template1 = createSavedTemplate();
+            var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var savedThumbnail1 = thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
-            var template2 = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode2 = sourceCodeRepository.save(new SourceCode(template2, "Filename 2", "Content 2", 1));
+
+            var template2 = createSavedSecondTemplate();
+            var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var savedThumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
             sut.deleteAllByTemplateIds(List.of(template1.getId(), template2.getId()));
@@ -172,10 +152,8 @@ class ThumbnailServiceTest extends ServiceTest {
         @Test
         @DisplayName("썸네일 삭제 성공: 존재하지 않는 경우")
         void deleteByTemplateFailWithWrongID() {
-            var member = memberRepository.save(MemberFixture.getFirstMember());
-            var category = categoryRepository.save(CategoryFixture.getFirstCategory());
-            var template = templateRepository.save(TemplateFixture.get(member, category));
-            var sourceCode = sourceCodeRepository.save(new SourceCode(template, "Filename 1", "Content 1", 1));
+            var template = createSavedTemplate();
+            var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
             var savedThumbnail = thumbnailRepository.save(new Thumbnail(template, sourceCode));
             var nonExistentID = 100L;
 

--- a/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/ThumbnailServiceTest.java
@@ -11,16 +11,9 @@ import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import codezap.category.domain.Category;
-import codezap.fixture.CategoryFixture;
-import codezap.fixture.MemberFixture;
 import codezap.fixture.SourceCodeFixture;
-import codezap.fixture.TemplateFixture;
 import codezap.global.ServiceTest;
 import codezap.global.exception.CodeZapException;
-import codezap.member.domain.Member;
-import codezap.template.domain.SourceCode;
-import codezap.template.domain.Template;
 import codezap.template.domain.Thumbnail;
 
 class ThumbnailServiceTest extends ServiceTest {
@@ -91,7 +84,7 @@ class ThumbnailServiceTest extends ServiceTest {
             var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var thumbnail1 = thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
 
-            var template2 = createSavedSecondTemplate();
+            var template2 = createAnotherMembersTemplate();
             var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var thumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
@@ -120,7 +113,7 @@ class ThumbnailServiceTest extends ServiceTest {
             var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var savedThumbnail1 = thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
 
-            var template2 = createSavedSecondTemplate();
+            var template2 = createAnotherMembersTemplate();
             var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var savedThumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 
@@ -139,7 +132,7 @@ class ThumbnailServiceTest extends ServiceTest {
             var sourceCode1 = sourceCodeRepository.save(SourceCodeFixture.get(template1, 1));
             var savedThumbnail1 = thumbnailRepository.save(new Thumbnail(template1, sourceCode1));
 
-            var template2 = createSavedSecondTemplate();
+            var template2 = createAnotherMembersTemplate();
             var sourceCode2 = sourceCodeRepository.save(SourceCodeFixture.get(template2, 1));
             var savedThumbnail2 = thumbnailRepository.save(new Thumbnail(template2, sourceCode2));
 

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -72,7 +72,7 @@ class TemplateApplicationServiceTest extends ServiceTest {
             // given
             var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
             var otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            var category = categoryRepository.save(CategoryFixture.get(ownerMember));
+            var category = categoryRepository.save(CategoryFixture.getCategory(ownerMember));
             var request = createTemplateRequest(category);
 
             // when & then
@@ -274,8 +274,8 @@ class TemplateApplicationServiceTest extends ServiceTest {
             var member = memberRepository.save(MemberFixture.getFirstMember());
             var category = categoryRepository.save(Category.createDefaultCategory(member));
             for (int i = 0; i < 20; i++) {
-                var template = templateRepository.save(new Template(member, "title" + i, "description" + i, category));
-                var sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename" + i, "content" + i, 1));
+                var template = templateRepository.save(TemplateFixture.get(member, category));
+                var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
                 thumbnailRepository.save(new Thumbnail(template, sourceCode));
             }
         }
@@ -411,8 +411,8 @@ class TemplateApplicationServiceTest extends ServiceTest {
             var member = memberRepository.save(MemberFixture.getFirstMember());
             var category = categoryRepository.save(Category.createDefaultCategory(member));
             for (int i = 0; i < 20; i++) {
-                var template = templateRepository.save(new Template(member, "title" + i, "description" + i, category));
-                var sourceCode = sourceCodeRepository.save(new SourceCode(template, "filename" + i, "content" + i, 1));
+                var template = templateRepository.save(TemplateFixture.get(member, category));
+                var sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
                 thumbnailRepository.save(new Thumbnail(template, sourceCode));
             }
         }
@@ -465,7 +465,7 @@ class TemplateApplicationServiceTest extends ServiceTest {
         void updateSourceCodesChangeModifiedAt() {
             // given
             Member member = memberRepository.save(MemberFixture.getFirstMember());
-            Category category = categoryRepository.save(CategoryFixture.getFirstCategory());
+            Category category = categoryRepository.save(CategoryFixture.getDefaultCategory(member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
             SourceCode sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));
             thumbnailRepository.save(new Thumbnail(template, sourceCode));
@@ -494,10 +494,10 @@ class TemplateApplicationServiceTest extends ServiceTest {
         void updateTemplate_WhenNoAuthorization() {
             // given
             Member otherMember = memberRepository.save(MemberFixture.getFirstMember());
-            Category othersCategory = categoryRepository.save(CategoryFixture.get(otherMember));
+            Category othersCategory = categoryRepository.save(CategoryFixture.getCategory(otherMember));
 
             Member member = memberRepository.save(MemberFixture.getSecondMember());
-            Category category = categoryRepository.save(CategoryFixture.get(member));
+            Category category = categoryRepository.save(CategoryFixture.getCategory(member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             SourceCode sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));

--- a/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
+++ b/backend/src/test/java/codezap/template/service/facade/TemplateApplicationServiceTest.java
@@ -72,7 +72,7 @@ class TemplateApplicationServiceTest extends ServiceTest {
             // given
             var ownerMember = memberRepository.save(MemberFixture.getFirstMember());
             var otherMember = memberRepository.save(MemberFixture.getSecondMember());
-            var category = categoryRepository.save(CategoryFixture.getCategory(ownerMember));
+            var category = categoryRepository.save(CategoryFixture.getAdditionalCategory(ownerMember));
             var request = createTemplateRequest(category);
 
             // when & then
@@ -494,10 +494,10 @@ class TemplateApplicationServiceTest extends ServiceTest {
         void updateTemplate_WhenNoAuthorization() {
             // given
             Member otherMember = memberRepository.save(MemberFixture.getFirstMember());
-            Category othersCategory = categoryRepository.save(CategoryFixture.getCategory(otherMember));
+            Category othersCategory = categoryRepository.save(CategoryFixture.getAdditionalCategory(otherMember));
 
             Member member = memberRepository.save(MemberFixture.getSecondMember());
-            Category category = categoryRepository.save(CategoryFixture.getCategory(member));
+            Category category = categoryRepository.save(CategoryFixture.getAdditionalCategory(member));
             Template template = templateRepository.save(TemplateFixture.get(member, category));
 
             SourceCode sourceCode = sourceCodeRepository.save(SourceCodeFixture.get(template, 1));


### PR DESCRIPTION
## ⚡️ 관련 이슈
close #1043

## 📍주요 변경 사항
현재 테스트에서 픽스처와 엔티티를 생성자로 직접 생성하는 부분이 혼재되어 있습니다.
도메인 설계 부분에서 템플릿 생성자가 변경될텐데, 변경사항이 매~~~우 많이 잡혔어요.

도메인 설계 변경하면서 동시에 작업하면 난장판이 될 것 같아 먼저 부분적으로 통합했습니다.
앞으로는 변경에 유연하도록 가급적 픽스처를 사용해주세요. ~~수작업 힘들었음~~

또 테스트 메서드에서만 사용하는 템플릿의 생성자가 있어서 제거했습니다.

급한 건 템플릿 쪽이라 템플릿과 회원, 소스코드 부분을 일단 통합했습니다. 
참고 부탁드려요~

+) 추가적으로 category, member, template 연달아 저장하는 부분이 많은데 이 부분 중복제거가 필요할 것 같아요.
각 테스트에서 전혀 몰라도 되는 준비 과정은 메서드로 추출해도 될 것 같다고 생각했어요. (좋아요 검증을 해야하는데, 카테고리 같은 부분은 해당 검증에서 꼭 들어나지 않아도 된다고 생각)

중복이 너무 심합니다. 

추가로 테스트 코드에서 공감되는 부분이 있어서 읽어보심 좋을 것 같아요 [인프런 Q&A](https://www.inflearn.com/community/questions/947467/%EC%9D%B4-%EA%B2%BD%EC%9A%B0-beforeeach%EC%97%90-fixture%EB%A5%BC-%EA%B5%AC%EC%84%B1%ED%95%B4%EB%8F%84-%EB%90%A0%EA%B9%8C%EC%9A%94)

> 해당 서비스 로직의 요청/응답에도 드러나지 않지만, 테스트가 정상적으로 동작하기 위해서 이미 생성되어 있어야 하는 fixture들은 setUp() 사용한다.
> - 가정 : 하나의 매장을 해당 테스트 클래스 전체에서 공유해도 문제가 없고, 매장의 상태 변화에 관심을 가질 필요도 없을 때 (매장의 상태가 변하지 않을 때)
> 1. 매장을 생성한다.
> 2. 매장을 운영 상태로 만들기 위한 여러 설정값을 세팅한다. (운영시간 등)
> 
> 여기서 저는 매장의 상태 변화 같은 게 우리의 템플릿의 카테고리 같이 비슷하다고 생각했어요.

## 🍗 PR 첫 리뷰 마감 기한
01/20 21:00
